### PR TITLE
feat: align register.py with ADR-111 STAC item standards

### DIFF
--- a/scripts/register.py
+++ b/scripts/register.py
@@ -231,7 +231,9 @@ def remove_xarray_integration(item: Item) -> None:
                 removed_count += 1
 
             # Remove alternate xarray configurations
-            if "alternate" in asset.extra_fields and isinstance(asset.extra_fields["alternate"], dict):
+            if "alternate" in asset.extra_fields and isinstance(
+                asset.extra_fields["alternate"], dict
+            ):
                 if asset.extra_fields["alternate"].pop("xarray", None):
                     removed_count += 1
                 # Remove empty alternate section


### PR DESCRIPTION
Adds three missing features from update_stac_item.py to improve STAC item metadata and compliance:

**Changes**

- Thumbnail assets: Mission-aware preview images for Sentinel-1/2 in STAC browsers
- Data lineage: derived_from link to track source STAC items
- ADR-111 compliance: Remove XArray-specific fields from assets

**Benefits**

- Better STAC browser experience with visual previews
- Improved data provenance and traceability
- Cleaner metadata without XArray dependencies
