### PR TITLE
fix: skip registry login on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
       actions: write # Persist Docker layer cache for docker/build-push-action (type=gha).
       security-events: write # Upload Trivy SARIF to GitHub Advanced Security / Security tab.
 
+    env:
+      PUSH_IMAGE: ${{ github.repository == 'EOPF-Explorer/data-pipeline' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_call') }}
+
     steps:
     - name: Checkout code (release tag from Release Please)
       if: inputs.release_tag != ''
@@ -84,7 +87,7 @@ jobs:
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Log in to OVH Container Registry
-      if: github.actor != 'dependabot[bot]'
+      if: env.PUSH_IMAGE == 'true'
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ${{ secrets.OVH_HARBOR_REGISTRY }}
@@ -149,7 +152,7 @@ jobs:
 
 
     - name: Push Docker image
-      if: github.actor != 'dependabot[bot]'
+      if: env.PUSH_IMAGE == 'true'
       uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       security-events: write # Upload Trivy SARIF to GitHub Advanced Security / Security tab.
 
     env:
-      PUSH_IMAGE: ${{ github.repository == 'EOPF-Explorer/data-pipeline' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_call') }}
+      PUSH_IMAGE: ${{ github.repository == 'EOPF-Explorer/data-pipeline' && (github.event_name == 'workflow_call' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) }}
 
     steps:
     - name: Checkout code (release tag from Release Please)


### PR DESCRIPTION
Fork builds were failing (e.g. https://github.com/EOPF-Explorer/data-pipeline/actions/runs/20130612190), because OVH registry secrets aren’t available. This change gates login/push behind `PUSH_IMAGE` and adds a fallback registry, so forks/PRs still build while only upstream main/tags push images. Result: no secret-related failures; publish behavior preserved for trusted refs.
