### PR TITLE
Update eopf-geozarr dependency and correct AOI bounding box

### DIFF
--- a/operator-tools/submit_stac_items_notebook.ipynb
+++ b/operator-tools/submit_stac_items_notebook.ipynb
@@ -90,7 +90,7 @@
     "# Example 3: France Full\n",
     "# aoi_bbox = [-5.14, 41.33, 9.56, 51.09]\n",
     "# Example 4: Lagoon From Venice to Trieste\n",
-    "aoi_bbox = [12.0, 44.4, 14.0, 45.0]\n",
+    "aoi_bbox = [12.0, 44.4, 14.0, 46.0]\n",
     "\n",
     "# Time range\n",
     "start_date = \"2025-01-01T00:00:00Z\"\n",
@@ -284,6 +284,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -334,7 +341,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity>=8.0.0",
     "morecantile>=5.0.0",
     "cf-xarray>=0.9.0",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@v0.6.0",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@v0.6.1",
     "requests",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -744,7 +744,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "cf-xarray", specifier = ">=0.9.0" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=v0.6.0" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=v0.6.1" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "morecantile", specifier = ">=5.0.0" },
     { name = "pystac", specifier = ">=1.10.0" },
@@ -862,8 +862,8 @@ wheels = [
 
 [[package]]
 name = "eopf-geozarr"
-version = "0.6.0"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=v0.6.0#a5b682f412821b8028809ff3a813a56a613e4ee0" }
+version = "0.6.1"
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=v0.6.1#82310f15bc3406fd72bb40457a04bf070d5370fa" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
Update the eopf-geozarr dependency to version 0.6.1 and fix the AOI bounding box in the notebook. Adjust the Python version in the notebook metadata accordingly.