### PR TITLE
feat: add s3 object cleanup while cleaning a STAC collection

### DIFF
--- a/operator-tools/example_usage.py
+++ b/operator-tools/example_usage.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Example: Using the Refactored STAC Management Tools Programmatically
+
+This script demonstrates how to use manage_item.py and manage_collections.py
+as Python modules in your own code.
+"""
+
+import os
+
+import boto3
+from manage_collections import STACCollectionManager
+from manage_item import STACItemManager, count_s3_objects_for_item, extract_s3_urls_from_item
+
+# Configuration
+API_URL = "https://api.explorer.eopf.copernicus.eu/stac"
+COLLECTION_ID = "sentinel-2-l2a-staging"
+
+# Initialize managers
+item_manager = STACItemManager(API_URL)
+collection_manager = STACCollectionManager(API_URL)
+
+# Initialize S3 client (if needed)
+
+endpoint = os.getenv("AWS_ENDPOINT_URL")
+if endpoint is not None:
+    s3_client = boto3.client("s3", endpoint_url=endpoint)
+else:
+    s3_client = boto3.client("s3")
+
+
+def example_1_inspect_single_item() -> None:
+    """Example: Inspect a single item and its S3 data."""
+    print("\n" + "=" * 60)
+    print("Example 1: Inspecting a Single Item")
+    print("=" * 60)
+
+    item_id = "S2A_MSIL2A_20210917T115221_N0500_R123_T28RBS_20230110T165456"
+
+    # Fetch the item
+    item = item_manager.get_item(COLLECTION_ID, item_id)
+
+    if item:
+        print(f"✓ Found item: {item['id']}")
+        print(f"  Collection: {item['collection']}")
+        print(f"  Assets: {len(item.get('assets', {}))}")
+
+        # Extract S3 URLs
+        s3_urls = extract_s3_urls_from_item(item)
+        print(f"  S3 URLs: {len(s3_urls)}")
+
+        if s3_urls:
+            # Count S3 objects
+            obj_count = count_s3_objects_for_item(s3_client, s3_urls)
+            print(f"  S3 Objects: {obj_count:,}")
+
+            # Get detailed stats
+            obj_count, size, urls = item_manager.get_item_s3_stats(item, s3_client)
+            print(f"  Total Size: {size / (1024**3):.2f} GB")
+
+
+def example_2_delete_single_item() -> None:
+    """Example: Delete a single item with S3 cleanup."""
+    print("\n" + "=" * 60)
+    print("Example 2: Deleting a Single Item (DRY RUN)")
+    print("=" * 60)
+
+    item_id = "SOME_ITEM_ID"
+
+    # First, fetch the item to see what we're working with
+    item = item_manager.get_item(COLLECTION_ID, item_id)
+
+    if not item:
+        print(f"✗ Item {item_id} not found")
+        return
+
+    # Preview S3 data
+    s3_urls = extract_s3_urls_from_item(item)
+    if s3_urls:
+        obj_count = count_s3_objects_for_item(s3_client, s3_urls)
+        print(f"Would delete {obj_count:,} S3 objects")
+
+    # Uncomment to actually delete (with validation):
+    # success, s3_deleted, s3_failed = item_manager.delete_item(
+    #     collection_id=COLLECTION_ID,
+    #     item_id=item_id,
+    #     clean_s3=True,
+    #     s3_client=s3_client,
+    #     item_dict=item,
+    #     validate_s3=True,
+    # )
+    #
+    # if success:
+    #     print(f"✓ Deleted item and {s3_deleted:,} S3 objects")
+    # else:
+    #     print(f"✗ Deletion failed (S3 issues: {s3_failed})")
+
+
+def example_3_process_collection_items() -> None:
+    """Example: Process all items in a collection."""
+    print("\n" + "=" * 60)
+    print("Example 3: Processing Collection Items")
+    print("=" * 60)
+
+    # Get all items
+    items = collection_manager.get_collection_items(COLLECTION_ID)
+    print(f"Found {len(items)} items in collection")
+
+    # Process each item
+    items_with_s3 = 0
+    total_objects = 0
+
+    for item in items[:5]:  # Sample first 5 items
+        s3_urls = extract_s3_urls_from_item(item)
+
+        if s3_urls:
+            items_with_s3 += 1
+            obj_count = count_s3_objects_for_item(s3_client, s3_urls)
+            total_objects += obj_count
+            print(f"  {item['id']}: {obj_count:,} S3 objects")
+
+    print("\nSummary:")
+    print(f"  Items with S3 data: {items_with_s3}/{len(items[:5])}")
+    print(f"  Total S3 objects: {total_objects:,}")
+
+
+def example_4_clean_collection_with_filtering() -> None:
+    """Example: Clean collection with custom filtering logic."""
+    print("\n" + "=" * 60)
+    print("Example 4: Selective Collection Cleaning")
+    print("=" * 60)
+
+    # Get all items
+    items = collection_manager.get_collection_items(COLLECTION_ID)
+
+    # Filter items based on custom criteria
+    # Example: Only delete items older than a certain date
+    from typing import Any
+
+    items_to_delete: list[Any] = []
+    for _item in items:
+        # Add your filtering logic here
+        # e.g., if item['properties']['datetime'] < some_date:
+        pass
+
+    print(f"Would delete {len(items_to_delete)} of {len(items)} items")
+
+    # Delete filtered items (uncomment to execute)
+    # deleted = 0
+    # failed = 0
+    # for item in items_to_delete:
+    #     success, _, _ = item_manager.delete_item(
+    #         collection_id=COLLECTION_ID,
+    #         item_id=item['id'],
+    #         clean_s3=True,
+    #         s3_client=s3_client,
+    #         item_dict=item,
+    #         validate_s3=True,
+    #     )
+    #     if success:
+    #         deleted += 1
+    #     else:
+    #         failed += 1
+    #
+    # print(f"✓ Deleted: {deleted}")
+    # print(f"✗ Failed: {failed}")
+
+
+def example_5_batch_s3_stats() -> None:
+    """Example: Get S3 statistics for multiple items."""
+    print("\n" + "=" * 60)
+    print("Example 5: Batch S3 Statistics")
+    print("=" * 60)
+
+    items = collection_manager.get_collection_items(COLLECTION_ID)
+
+    # Get stats for each item
+    stats = []
+    for item in items[:10]:  # Sample first 10
+        obj_count, size, urls = item_manager.get_item_s3_stats(item, s3_client)
+        stats.append(
+            {
+                "item_id": item["id"],
+                "objects": obj_count,
+                "size_gb": size / (1024**3),
+                "url_count": len(urls),
+            }
+        )
+
+    # Sort by size
+    stats.sort(key=lambda x: x["size_gb"], reverse=True)
+
+    print("\nTop items by size:")
+    for stat in stats[:5]:
+        print(f"  {stat['item_id']}")
+        print(f"    Objects: {stat['objects']:,}")
+        print(f"    Size: {stat['size_gb']:.2f} GB")
+
+
+def example_6_error_handling() -> None:
+    """Example: Proper error handling."""
+    print("\n" + "=" * 60)
+    print("Example 6: Error Handling")
+    print("=" * 60)
+
+    item_id = "NON_EXISTENT_ITEM"
+
+    try:
+        # This will return None for non-existent items
+        item = item_manager.get_item(COLLECTION_ID, item_id)
+
+        if item is None:
+            print(f"✗ Item {item_id} not found")
+            # Handle missing item case
+            return
+
+        # If we get here, item exists
+        print(f"✓ Item found: {item['id']}")
+
+        # Try S3 operations with error handling
+        try:
+            s3_urls = extract_s3_urls_from_item(item)
+            if not s3_urls:
+                print("⚠ No S3 URLs found in item")
+                return
+
+            obj_count = count_s3_objects_for_item(s3_client, s3_urls)
+            print(f"✓ Found {obj_count:,} S3 objects")
+
+        except Exception as e:
+            print(f"✗ S3 operation failed: {e}")
+            # Handle S3 errors
+
+    except Exception as e:
+        print(f"✗ Unexpected error: {e}")
+        # Handle other errors
+
+
+def example_7_integration_with_existing_code() -> None:
+    """Example: Integration pattern with existing code."""
+    print("\n" + "=" * 60)
+    print("Example 7: Integration Pattern")
+    print("=" * 60)
+
+    from typing import Any
+
+    def my_custom_processing_function(item: Any) -> bool:
+        """Your existing item processing logic."""
+        # Do something with the item
+        print(f"Processing: {item['id']}")
+        return True
+
+    # Integrate with STAC management
+    items = collection_manager.get_collection_items(COLLECTION_ID)
+
+    for item in items[:3]:
+        # Run your custom processing
+        if my_custom_processing_function(item):
+            print("  ✓ Processed successfully")
+
+            # Optionally check S3 data
+            s3_urls = extract_s3_urls_from_item(item)
+            if s3_urls:
+                obj_count = count_s3_objects_for_item(s3_client, s3_urls)
+                print(f"    S3 objects: {obj_count:,}")
+
+
+def main() -> None:
+    """Run all examples."""
+    print("\n" + "=" * 60)
+    print("STAC Management Tools - Usage Examples")
+    print("=" * 60)
+    print("\nNOTE: Most examples are in DRY RUN mode")
+    print("Uncomment deletion code to actually execute")
+
+    try:
+        # Run examples
+        example_1_inspect_single_item()
+        # example_2_delete_single_item()  # Commented - requires valid item ID
+        example_3_process_collection_items()
+        # example_4_clean_collection_with_filtering()  # Commented - modifies data
+        example_5_batch_s3_stats()
+        example_6_error_handling()
+        example_7_integration_with_existing_code()
+
+    except Exception as e:
+        print(f"\n✗ Error running examples: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+    print("\n" + "=" * 60)
+    print("Examples completed")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/operator-tools/manage_collections.py
+++ b/operator-tools/manage_collections.py
@@ -9,18 +9,25 @@ Supports:
 - Creating/updating collections from templates
 - Deleting collections
 - Viewing S3 storage statistics
+
+This tool uses manage_item.py for all item-level operations.
 """
 
 import json
 import os
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 import boto3
 import click
 import requests
-from botocore.exceptions import ClientError
+
+# Import item management functionality
+from manage_item import (
+    STACItemManager,
+    count_s3_objects_for_item,
+    extract_s3_urls_from_item,
+)
 from pystac import Collection
 from pystac_client import Client
 
@@ -38,6 +45,7 @@ class STACCollectionManager:
         self.api_url = api_url.rstrip("/")
         self.session = requests.Session()
         self.session.headers.update({"Content-Type": "application/json"})
+        self.item_manager = STACItemManager(api_url)
 
     def get_collection_items(self, collection_id: str) -> list[dict[str, Any]]:
         """
@@ -65,33 +73,6 @@ class STACCollectionManager:
         except Exception as e:
             click.echo(f"❌ Error fetching items: {e}", err=True)
             raise
-
-    def delete_item(self, collection_id: str, item_id: str) -> bool:
-        """
-        Delete a single item from a collection using Transaction API.
-
-        Args:
-            collection_id: ID of the collection
-            item_id: ID of the item to delete
-
-        Returns:
-            True if successful, False otherwise
-        """
-        url = f"{self.api_url}/collections/{collection_id}/items/{item_id}"
-
-        try:
-            response = self.session.delete(url)
-            response.raise_for_status()
-            return True
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 404:
-                click.echo(f"⚠️  Item {item_id} not found (already deleted?)", err=True)
-                return True  # Consider it success if already gone
-            click.echo(f"❌ Failed to delete item {item_id}: {e}", err=True)
-            return False
-        except Exception as e:
-            click.echo(f"❌ Error deleting item {item_id}: {e}", err=True)
-            return False
 
     def clean_collection(
         self,
@@ -176,8 +157,8 @@ class STACCollectionManager:
 
             return 0, 0, 0
 
+        # Actual deletion
         items_deleted = 0
-        items_failed = 0
         items_skipped = 0
         s3_objects_deleted = 0
         s3_objects_failed = 0
@@ -198,41 +179,23 @@ class STACCollectionManager:
             for item in bar:
                 item_id = item["id"]
 
-                # Delete S3 data first if requested
-                s3_deletion_successful = True
-                if clean_s3 and s3_client:
-                    s3_urls = extract_s3_urls_from_item(item)
+                # Use item manager's delete_item method
+                success, s3_deleted, s3_failed = self.item_manager.delete_item(
+                    collection_id=collection_id,
+                    item_id=item_id,
+                    clean_s3=clean_s3,
+                    s3_client=s3_client,
+                    item_dict=item,
+                    validate_s3=True,
+                )
 
-                    if s3_urls:
-                        # Delete all S3 objects for this item
-                        deleted, failed = delete_s3_objects_for_item(s3_client, s3_urls)
-                        s3_objects_deleted += deleted
-                        s3_objects_failed += failed
-
-                        # Validation: verify all S3 objects were deleted
-                        if failed > 0:
-                            click.echo(f"\n⚠️  Item {item_id}: Failed to delete {failed} S3 objects")
-                            s3_deletion_successful = False
-                        else:
-                            # Double-check: verify no objects remain
-                            remaining = count_s3_objects_for_item(s3_client, s3_urls)
-                            if remaining > 0:
-                                click.echo(
-                                    f"\n⚠️  Item {item_id}: Validation failed - {remaining} S3 objects still exist"
-                                )
-                                s3_deletion_successful = False
-
-                # Only delete STAC item if S3 cleanup succeeded (or wasn't requested)
-                if s3_deletion_successful:
-                    if self.delete_item(collection_id, item_id):
-                        items_deleted += 1
-                    else:
-                        items_failed += 1
+                if success:
+                    items_deleted += 1
                 else:
-                    click.echo(
-                        f"\n⚠️  Skipping STAC item deletion for {item_id} due to S3 cleanup failures"
-                    )
                     items_skipped += 1
+
+                s3_objects_deleted += s3_deleted
+                s3_objects_failed += s3_failed
 
         # Summary
         click.echo("\n" + "=" * 60)
@@ -240,8 +203,6 @@ class STACCollectionManager:
         click.echo("=" * 60)
         click.echo(f"Total items processed: {len(items)}")
         click.echo(f"✅ STAC items deleted: {items_deleted}")
-        if items_failed > 0:
-            click.echo(f"❌ STAC items failed: {items_failed}")
         if items_skipped > 0:
             click.echo(f"⏭️  STAC items skipped: {items_skipped} (due to S3 failures)")
 
@@ -375,274 +336,7 @@ class STACCollectionManager:
             return None
 
 
-# === S3 Helper Functions ===
-
-
-def extract_s3_urls_from_item(item_dict: dict) -> set[str]:
-    """Extract all S3 URLs from a STAC item's assets.
-
-    Tries multiple locations in order:
-    1. alternate.s3.href (preferred, new format)
-    2. main href if it's an s3:// URL
-    """
-    s3_urls = set()
-
-    for _asset_key, asset in item_dict.get("assets", {}).items():
-        # Skip thumbnails
-        if "thumbnail" in asset.get("roles", []):
-            continue
-
-        # Try alternate.s3.href first (preferred location)
-        alternate = asset.get("alternate", {})
-        if isinstance(alternate, dict):
-            s3_info = alternate.get("s3", {})
-            if isinstance(s3_info, dict):
-                href = s3_info.get("href", "")
-                if href.startswith("s3://"):
-                    s3_urls.add(href)
-                    continue
-
-        # Fallback: check if main href is an S3 URL
-        href = asset.get("href", "")
-        if href.startswith("s3://"):
-            s3_urls.add(href)
-
-    return s3_urls
-
-
-def get_zarr_root_from_urls(s3_urls: set[str]) -> str | None:
-    """Extract the root Zarr store URL from S3 URLs.
-
-    Returns the first Zarr root found, or None if no Zarr URLs present.
-    """
-    for url in s3_urls:
-        if ".zarr/" in url:
-            return url.split(".zarr/")[0] + ".zarr"
-    return None
-
-
-def delete_s3_zarr_store(
-    s3_client: Any,
-    zarr_root: str,
-    dry_run: bool = False,
-) -> tuple[int, int]:
-    """Delete all objects in a Zarr store.
-
-    Args:
-        s3_client: Boto3 S3 client
-        zarr_root: Root Zarr URL (e.g., s3://bucket/path/file.zarr)
-        dry_run: If True, only show what would be deleted
-
-    Returns:
-        Tuple of (deleted_count, failed_count)
-    """
-    parsed = urlparse(zarr_root)
-    bucket = parsed.netloc
-    prefix = parsed.path.lstrip("/") + "/"
-
-    deleted = 0
-    failed = 0
-
-    try:
-        paginator = s3_client.get_paginator("list_objects_v2")
-
-        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-            objects = page.get("Contents", [])
-
-            if not objects:
-                continue
-
-            for obj in objects:
-                key = obj["Key"]
-
-                if dry_run:
-                    deleted += 1
-                else:
-                    try:
-                        s3_client.delete_object(Bucket=bucket, Key=key)
-                        deleted += 1
-                    except ClientError as e:
-                        click.echo(f"      ❌ Failed to delete s3://{bucket}/{key}: {e}", err=True)
-                        failed += 1
-
-        return deleted, failed
-
-    except ClientError as e:
-        click.echo(f"    ❌ Error listing/deleting S3 objects: {e}", err=True)
-        return 0, 1
-
-
-def delete_s3_objects_for_item(
-    s3_client: Any,
-    s3_urls: set[str],
-) -> tuple[int, int]:
-    """Delete all S3 objects referenced by a STAC item's assets.
-
-    Handles both individual files and prefixes (directories/Zarr stores).
-
-    Args:
-        s3_client: Boto3 S3 client
-        s3_urls: Set of S3 URLs from the item's assets
-
-    Returns:
-        Tuple of (deleted_count, failed_count)
-    """
-    deleted = 0
-    failed = 0
-
-    # Group URLs by bucket for efficiency
-    urls_by_bucket: dict[str, list[str]] = {}
-    for url in s3_urls:
-        parsed = urlparse(url)
-        bucket = parsed.netloc
-        if bucket not in urls_by_bucket:
-            urls_by_bucket[bucket] = []
-        urls_by_bucket[bucket].append(url)
-
-    for bucket, urls in urls_by_bucket.items():
-        # Determine if we need to handle prefixes
-        prefixes_to_delete = set()
-        individual_keys = set()
-
-        for url in urls:
-            parsed = urlparse(url)
-            key = parsed.path.lstrip("/")
-
-            # Check if this is a prefix (directory or Zarr store)
-            if ".zarr/" in key:
-                # Extract the Zarr root prefix
-                zarr_root = key.split(".zarr/")[0] + ".zarr/"
-                prefixes_to_delete.add(zarr_root)
-            elif key.endswith("/"):
-                # It's a directory prefix
-                prefixes_to_delete.add(key)
-            else:
-                # It's an individual file
-                individual_keys.add(key)
-
-        # Delete objects under prefixes
-        for prefix in prefixes_to_delete:
-            try:
-                paginator = s3_client.get_paginator("list_objects_v2")
-                for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-                    objects = page.get("Contents", [])
-                    for obj in objects:
-                        try:
-                            s3_client.delete_object(Bucket=bucket, Key=obj["Key"])
-                            deleted += 1
-                        except ClientError:
-                            failed += 1
-            except ClientError:
-                failed += 1
-
-        # Delete individual files
-        for key in individual_keys:
-            try:
-                s3_client.delete_object(Bucket=bucket, Key=key)
-                deleted += 1
-            except ClientError as e:
-                # Handle 404 as success (already deleted)
-                if e.response.get("Error", {}).get("Code") == "NoSuchKey":
-                    deleted += 1
-                else:
-                    failed += 1
-
-    return deleted, failed
-
-
-def count_s3_objects_for_item(
-    s3_client: Any,
-    s3_urls: set[str],
-) -> int:
-    """Count how many S3 objects exist for a STAC item's assets.
-
-    Handles both individual files and prefixes (directories/Zarr stores).
-
-    Args:
-        s3_client: Boto3 S3 client
-        s3_urls: Set of S3 URLs from the item's assets
-
-    Returns:
-        Total count of S3 objects
-    """
-    count = 0
-
-    # Group URLs by bucket for efficiency
-    urls_by_bucket: dict[str, list[str]] = {}
-    for url in s3_urls:
-        parsed = urlparse(url)
-        bucket = parsed.netloc
-        if bucket not in urls_by_bucket:
-            urls_by_bucket[bucket] = []
-        urls_by_bucket[bucket].append(url)
-
-    for bucket, urls in urls_by_bucket.items():
-        # Determine if we need to handle prefixes
-        prefixes_to_check = set()
-        individual_keys = set()
-
-        for url in urls:
-            parsed = urlparse(url)
-            key = parsed.path.lstrip("/")
-
-            # Check if this is a prefix (directory or Zarr store)
-            if ".zarr/" in key:
-                # Extract the Zarr root prefix
-                zarr_root = key.split(".zarr/")[0] + ".zarr/"
-                prefixes_to_check.add(zarr_root)
-            elif key.endswith("/"):
-                # It's a directory prefix
-                prefixes_to_check.add(key)
-            else:
-                # It's an individual file
-                individual_keys.add(key)
-
-        # Count objects under prefixes
-        for prefix in prefixes_to_check:
-            try:
-                paginator = s3_client.get_paginator("list_objects_v2")
-                for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-                    count += len(page.get("Contents", []))
-            except ClientError:
-                pass
-
-        # Count individual files
-        for key in individual_keys:
-            try:
-                s3_client.head_object(Bucket=bucket, Key=key)
-                count += 1
-            except ClientError:
-                pass
-
-    return count
-
-
-def get_s3_storage_info(s3_client, zarr_root: str) -> tuple[int, int]:  # type: ignore
-    """Get object count and total size for a Zarr store.
-
-    Returns:
-        Tuple of (object_count, total_size_bytes)
-    """
-    parsed = urlparse(zarr_root)
-    bucket = parsed.netloc
-    prefix = parsed.path.lstrip("/") + "/"
-
-    count = 0
-    total_size = 0
-
-    try:
-        paginator = s3_client.get_paginator("list_objects_v2")
-
-        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-            for obj in page.get("Contents", []):
-                count += 1
-                total_size += obj.get("Size", 0)
-
-        return count, total_size
-
-    except ClientError as e:
-        click.echo(f"    ⚠️  Error accessing S3: {e}", err=True)
-        return 0, 0
+# === CLI Commands ===
 
 
 @click.group()
@@ -715,17 +409,21 @@ def clean(
         # Initialize S3 client if needed
         s3_client = None
         if clean_s3:
-            endpoint_url: str | None = None
-            if s3_endpoint is not None:
-                endpoint_url = s3_endpoint
-            elif os.getenv("AWS_ENDPOINT_URL") is not None:
-                endpoint_url = os.getenv("AWS_ENDPOINT_URL")
-            if endpoint_url:
-                s3_client = boto3.client("s3", endpoint_url=endpoint_url)
-                click.echo(f"📦 S3 client initialized (endpoint: {endpoint_url})")
+            s3_config = {}
+            if s3_endpoint:
+                s3_config["endpoint_url"] = s3_endpoint
+            elif os.getenv("AWS_ENDPOINT_URL"):
+                endpoint = os.getenv("AWS_ENDPOINT_URL")
+                if endpoint is not None:
+                    s3_config["endpoint_url"] = endpoint
+
+            if "endpoint_url" in s3_config:
+                s3_client = boto3.client("s3", endpoint_url=s3_config["endpoint_url"])
             else:
                 s3_client = boto3.client("s3")
-                click.echo("📦 S3 client initialized (endpoint: default)")
+            click.echo(
+                f"📦 S3 client initialized (endpoint: {s3_config.get('endpoint_url', 'default')})"
+            )
 
         manager.clean_collection(
             collection_id, dry_run=dry_run, clean_s3=clean_s3, s3_client=s3_client
@@ -769,9 +467,10 @@ def create(ctx: click.Context, template_path: Path, update: bool) -> None:
     click.echo(f"Title: {collection_data.get('title', 'N/A')}")
     click.echo(f"Action: {action}")
 
-    if not click.confirm(f"\nProceed to {action} collection?"):
-        click.echo("Aborted.")
-        return
+    if not update:
+        click.confirm("\nCreate this collection?", abort=True)
+    else:
+        click.confirm("\nUpdate this collection?", abort=True)
 
     success = manager.create_or_update_collection(collection_data, update=update)
 
@@ -786,59 +485,53 @@ def create(ctx: click.Context, template_path: Path, update: bool) -> None:
     is_flag=True,
     help="Update existing collections instead of creating new",
 )
-@click.option(
-    "--pattern",
-    default="*.json",
-    help="File pattern to match",
-    show_default=True,
-)
 @click.pass_context
-def batch_create(ctx: click.Context, directory: Path, update: bool, pattern: str) -> None:
+def batch_create(ctx: click.Context, directory: Path, update: bool) -> None:
     """
-    Create or update multiple collections from template files in a directory.
+    Create or update multiple collections from a directory of templates.
 
-    Example:
+    DIRECTORY should contain JSON files with STAC Collections.
+
+    Examples:
         manage_collections.py batch-create stac/
         manage_collections.py batch-create stac/ --update
     """
     manager: STACCollectionManager = ctx.obj["manager"]
 
-    template_files = list(directory.glob(pattern))
+    # Find all JSON files
+    json_files = list(directory.glob("*.json"))
 
-    if not template_files:
-        click.echo(f"❌ No template files found matching '{pattern}' in {directory}")
-        return
+    if not json_files:
+        click.echo(f"❌ No JSON files found in {directory}", err=True)
+        raise click.Abort()
 
-    click.echo(f"Found {len(template_files)} template files:")
-    for template_file in template_files:
-        click.echo(f"  - {template_file.name}")
-
-    action = "update" if update else "create"
-    if not click.confirm(f"\nProceed to {action} {len(template_files)} collections?"):
-        click.echo("Aborted.")
-        return
+    click.echo(f"Found {len(json_files)} JSON files in {directory}")
+    click.confirm("\nProcess all files?", abort=True)
 
     success_count = 0
-    failed_count = 0
+    fail_count = 0
 
-    for template_file in template_files:
+    for json_file in json_files:
         click.echo(f"\n{'='*60}")
-        click.echo(f"Processing: {template_file.name}")
+        click.echo(f"Processing: {json_file.name}")
 
-        collection_data = manager.load_collection_from_template(template_file)
+        collection_data = manager.load_collection_from_template(json_file)
         if not collection_data:
-            failed_count += 1
+            fail_count += 1
             continue
+
+        collection_id = collection_data["id"]
+        click.echo(f"Collection ID: {collection_id}")
 
         if manager.create_or_update_collection(collection_data, update=update):
             success_count += 1
         else:
-            failed_count += 1
+            fail_count += 1
 
     click.echo(f"\n{'='*60}")
-    click.echo(f"✅ Successfully processed: {success_count}")
-    if failed_count > 0:
-        click.echo(f"❌ Failed: {failed_count}")
+    click.echo(f"✅ Success: {success_count}")
+    if fail_count > 0:
+        click.echo(f"❌ Failed: {fail_count}")
 
 
 @cli.command()
@@ -846,36 +539,28 @@ def batch_create(ctx: click.Context, directory: Path, update: bool, pattern: str
 @click.option(
     "--clean-first",
     is_flag=True,
-    help="Remove all items from the collection before deleting it",
-)
-@click.option(
-    "--yes",
-    "-y",
-    is_flag=True,
-    help="Skip confirmation prompt",
+    help="Clean all items from collection before deleting it",
 )
 @click.pass_context
-def delete(ctx: click.Context, collection_id: str, clean_first: bool, yes: bool) -> None:
+def delete(ctx: click.Context, collection_id: str, clean_first: bool) -> None:
     """
     Delete a collection.
 
-    Note: Some STAC servers require the collection to be empty before deletion.
-    Use --clean-first to automatically remove all items first.
-
-    Examples:
+    Example:
         manage_collections.py delete sentinel-2-l2a-staging
         manage_collections.py delete sentinel-2-l2a-staging --clean-first
-        manage_collections.py delete sentinel-2-l2a-staging --clean-first --yes
     """
     manager: STACCollectionManager = ctx.obj["manager"]
 
-    if not yes:
-        click.confirm(
-            f"⚠️  This will permanently delete collection '{collection_id}'. Continue?",
-            abort=True,
-        )
-
     try:
+        # Confirmation prompt
+        warning = f"⚠️  This will DELETE collection '{collection_id}'."
+        if clean_first:
+            warning += "\n⚠️  This will first remove all items from the collection."
+        warning += "\n⚠️  This action CANNOT be undone!"
+
+        click.confirm(f"{warning}\n\nContinue?", abort=True)
+
         # Clean collection first if requested
         if clean_first:
             click.echo("\n📋 Cleaning collection before deletion...")
@@ -953,17 +638,17 @@ def info(
             click.echo("S3 Storage Statistics:")
 
             # Initialize S3 client
-            endpoint_url: str | None = None
-            if s3_endpoint is not None:
-                endpoint_url = s3_endpoint
-            elif os.getenv("AWS_ENDPOINT_URL") is not None:
-                env_url = os.getenv("AWS_ENDPOINT_URL")
-                if env_url is not None:
-                    endpoint_url = env_url
+            s3_config = {}
+            if s3_endpoint:
+                s3_config["endpoint_url"] = s3_endpoint
+            elif os.getenv("AWS_ENDPOINT_URL"):
+                endpoint = os.getenv("AWS_ENDPOINT_URL")
+                if endpoint is not None:
+                    s3_config["endpoint_url"] = endpoint
 
             try:
-                if endpoint_url:
-                    s3_client = boto3.client("s3", endpoint_url=endpoint_url)
+                if "endpoint_url" in s3_config:
+                    s3_client = boto3.client("s3", endpoint_url=s3_config["endpoint_url"])
                 else:
                     s3_client = boto3.client("s3")
 
@@ -980,63 +665,18 @@ def info(
                 click.echo(f"Sampling {sample_size} of {len(items)} items...")
 
                 for item in sample_items:
-                    s3_urls = extract_s3_urls_from_item(item)
+                    # Use item manager's method to get S3 stats
+                    obj_count, size, urls = manager.item_manager.get_item_s3_stats(
+                        item, s3_client, debug=debug
+                    )
 
-                    if debug:
-                        click.echo(f"\n  📄 Item: {item['id']}")
-                        click.echo(f"     Found {len(s3_urls)} S3 URLs")
-                        for url in list(s3_urls)[:3]:
-                            click.echo(f"       • {url}")
-                        if len(s3_urls) > 3:
-                            click.echo(f"       ... and {len(s3_urls) - 3} more")
-
-                    if s3_urls:
+                    if obj_count > 0:
                         items_with_s3 += 1
-                        sample_urls.extend(list(s3_urls)[:2])  # Keep a few sample URLs
-
-                        # Count objects for this item (handles both files and prefixes)
-                        obj_count = count_s3_objects_for_item(s3_client, s3_urls)
                         total_objects += obj_count
-
-                        # Calculate size by checking actual objects
-                        # Group URLs by bucket/prefix for efficiency
-                        for url in s3_urls:
-                            parsed = urlparse(url)
-                            bucket = parsed.netloc
-                            key = parsed.path.lstrip("/")
-
-                            # Check if this is a prefix or individual file
-                            if ".zarr/" in key:
-                                zarr_root = key.split(".zarr/")[0] + ".zarr/"
-                                prefix = zarr_root
-                            elif key.endswith("/"):
-                                prefix = key
-                            else:
-                                # Individual file
-                                try:
-                                    response = s3_client.head_object(Bucket=bucket, Key=key)
-                                    total_size += response.get("ContentLength", 0)
-                                except ClientError:
-                                    pass
-                                continue
-
-                            # For prefixes, sum up all object sizes
-                            try:
-                                paginator = s3_client.get_paginator("list_objects_v2")
-                                for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-                                    for obj in page.get("Contents", []):
-                                        total_size += obj.get("Size", 0)
-                            except ClientError:
-                                pass
-
-                        if debug:
-                            click.echo(
-                                f"     Objects: {obj_count}, Size: {total_size / (1024**3):.2f} GB (cumulative)"
-                            )
+                        total_size += size
+                        sample_urls.extend(urls[:2])  # Keep a few sample URLs
                     else:
                         items_without_s3 += 1
-                        if debug:
-                            click.echo("     ⚠️  No S3 URLs found")
 
                 if debug:
                     click.echo("\n  Summary of sampled items:")

--- a/operator-tools/manage_item.py
+++ b/operator-tools/manage_item.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python3
+"""
+STAC Item Management Tool
+
+Manage individual STAC items in the EOPF STAC catalog.
+Supports:
+- Viewing item information with S3 statistics
+- Deleting items with optional S3 data cleanup
+- S3 operations validation and debugging
+"""
+
+import os
+from typing import Any
+from urllib.parse import urlparse
+
+import boto3
+import click
+import requests
+from botocore.exceptions import ClientError
+
+
+class STACItemManager:
+    """Manager for STAC item operations."""
+
+    def __init__(self, api_url: str):
+        """
+        Initialize the STAC Item Manager.
+
+        Args:
+            api_url: Base URL of the STAC API (e.g., https://api.explorer.eopf.copernicus.eu/stac)
+        """
+        self.api_url = api_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({"Content-Type": "application/json"})
+
+    def get_item(self, collection_id: str, item_id: str) -> dict[str, Any] | None:
+        """
+        Get a single item from a collection.
+
+        Args:
+            collection_id: ID of the collection
+            item_id: ID of the item
+
+        Returns:
+            Item dictionary or None if not found
+        """
+        url = f"{self.api_url}/collections/{collection_id}/items/{item_id}"
+
+        try:
+            response = self.session.get(url)
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                click.echo(f"❌ Item {item_id} not found in collection {collection_id}", err=True)
+                return None
+            click.echo(f"❌ Error fetching item: {e}", err=True)
+            return None
+        except Exception as e:
+            click.echo(f"❌ Error fetching item: {e}", err=True)
+            return None
+
+    def delete_item(
+        self,
+        collection_id: str,
+        item_id: str,
+        clean_s3: bool = False,
+        s3_client: Any = None,
+        item_dict: dict[str, Any] | None = None,
+        validate_s3: bool = True,
+    ) -> tuple[bool, int, int]:
+        """
+        Delete a single item from a collection, optionally cleaning S3 data.
+
+        Args:
+            collection_id: ID of the collection
+            item_id: ID of the item to delete
+            clean_s3: If True, also delete S3 data
+            s3_client: Boto3 S3 client (required if clean_s3=True)
+            item_dict: Optional pre-fetched item dictionary (to avoid re-fetching)
+            validate_s3: If True, validate S3 deletion before removing STAC item
+
+        Returns:
+            Tuple of (success: bool, s3_deleted: int, s3_failed: int)
+        """
+        # Fetch item if not provided
+        if item_dict is None and clean_s3:
+            item_dict = self.get_item(collection_id, item_id)
+            if item_dict is None:
+                return False, 0, 0
+
+        s3_deleted = 0
+        s3_failed = 0
+        s3_deletion_successful = True
+
+        # Delete S3 data first if requested
+        if clean_s3 and s3_client and item_dict:
+            s3_urls = extract_s3_urls_from_item(item_dict)
+
+            if s3_urls:
+                click.echo(f"  Deleting S3 data for {item_id}...")
+                s3_deleted, s3_failed = delete_s3_objects_for_item(s3_client, s3_urls)
+
+                # Validate deletion if requested
+                if validate_s3:
+                    if s3_failed > 0:
+                        click.echo(f"    ⚠️  Failed to delete {s3_failed} S3 objects")
+                        s3_deletion_successful = False
+                    else:
+                        # Double-check: verify no objects remain
+                        remaining = count_s3_objects_for_item(s3_client, s3_urls)
+                        if remaining > 0:
+                            click.echo(
+                                f"    ⚠️  Validation failed - {remaining} S3 objects still exist"
+                            )
+                            s3_deletion_successful = False
+                        else:
+                            click.echo(f"    ✅ Deleted {s3_deleted} S3 objects")
+
+        # Only delete STAC item if S3 cleanup succeeded (or wasn't requested)
+        if not s3_deletion_successful:
+            click.echo("  ⚠️  Skipping STAC item deletion due to S3 cleanup failures")
+            return False, s3_deleted, s3_failed
+
+        # Delete the STAC item
+        url = f"{self.api_url}/collections/{collection_id}/items/{item_id}"
+
+        try:
+            response = self.session.delete(url)
+            response.raise_for_status()
+            click.echo(f"  ✅ Deleted STAC item {item_id}")
+            return True, s3_deleted, s3_failed
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                click.echo(f"  ⚠️  Item {item_id} not found (already deleted?)")
+                return True, s3_deleted, s3_failed  # Consider it success if already gone
+            click.echo(f"  ❌ Failed to delete item {item_id}: {e}", err=True)
+            return False, s3_deleted, s3_failed
+        except Exception as e:
+            click.echo(f"  ❌ Error deleting item {item_id}: {e}", err=True)
+            return False, s3_deleted, s3_failed
+
+    def get_item_s3_stats(
+        self,
+        item_dict: dict[str, Any],
+        s3_client: Any,
+        debug: bool = False,
+    ) -> tuple[int, int, list[str]]:
+        """
+        Get S3 storage statistics for a single item.
+
+        Args:
+            item_dict: Item dictionary
+            s3_client: Boto3 S3 client
+            debug: If True, show detailed debug information
+
+        Returns:
+            Tuple of (object_count, total_size_bytes, s3_urls)
+        """
+        s3_urls = extract_s3_urls_from_item(item_dict)
+
+        if debug:
+            click.echo(f"\n  📄 Item: {item_dict['id']}")
+            click.echo(f"     Found {len(s3_urls)} S3 URLs")
+            for url in list(s3_urls)[:3]:
+                click.echo(f"       • {url}")
+            if len(s3_urls) > 3:
+                click.echo(f"       ... and {len(s3_urls) - 3} more")
+
+        if not s3_urls:
+            if debug:
+                click.echo("     ⚠️  No S3 URLs found")
+            return 0, 0, []
+
+        # Count objects
+        obj_count = count_s3_objects_for_item(s3_client, s3_urls)
+
+        # Calculate total size
+        total_size = 0
+        for url in s3_urls:
+            parsed = urlparse(url)
+            bucket = parsed.netloc
+            key = parsed.path.lstrip("/")
+
+            # Check if this is a prefix or individual file
+            if ".zarr/" in key:
+                zarr_root = key.split(".zarr/")[0] + ".zarr/"
+                prefix = zarr_root
+            elif key.endswith("/"):
+                prefix = key
+            else:
+                # Individual file
+                try:
+                    response = s3_client.head_object(Bucket=bucket, Key=key)
+                    total_size += response.get("ContentLength", 0)
+                except ClientError:
+                    pass
+                continue
+
+            # For prefixes, sum up all object sizes
+            try:
+                paginator = s3_client.get_paginator("list_objects_v2")
+                for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+                    for obj in page.get("Contents", []):
+                        total_size += obj.get("Size", 0)
+            except ClientError:
+                pass
+
+        if debug:
+            click.echo(f"     Objects: {obj_count}, Size: {total_size / (1024**3):.2f} GB")
+
+        return obj_count, total_size, list(s3_urls)
+
+
+# === S3 Helper Functions ===
+
+
+def extract_s3_urls_from_item(item_dict: dict) -> set[str]:
+    """Extract all S3 URLs from a STAC item's assets.
+
+    Tries multiple locations in order:
+    1. alternate.s3.href (preferred, new format)
+    2. main href if it's an s3:// URL
+    """
+    s3_urls = set()
+
+    for _asset_key, asset in item_dict.get("assets", {}).items():
+        # Skip thumbnails
+        if "thumbnail" in asset.get("roles", []):
+            continue
+
+        # Try alternate.s3.href first (preferred location)
+        alternate = asset.get("alternate", {})
+        if isinstance(alternate, dict):
+            s3_info = alternate.get("s3", {})
+            if isinstance(s3_info, dict):
+                href = s3_info.get("href", "")
+                if href.startswith("s3://"):
+                    s3_urls.add(href)
+                    continue
+
+        # Fallback: check if main href is an S3 URL
+        href = asset.get("href", "")
+        if href.startswith("s3://"):
+            s3_urls.add(href)
+
+    return s3_urls
+
+
+def delete_s3_objects_for_item(
+    s3_client: Any,
+    s3_urls: set[str],
+) -> tuple[int, int]:
+    """Delete all S3 objects referenced by a STAC item's assets.
+
+    Handles both individual files and prefixes (directories/Zarr stores).
+
+    Args:
+        s3_client: Boto3 S3 client
+        s3_urls: Set of S3 URLs from the item's assets
+
+    Returns:
+        Tuple of (deleted_count, failed_count)
+    """
+    deleted = 0
+    failed = 0
+
+    # Group URLs by bucket for efficiency
+    urls_by_bucket: dict[str, list[str]] = {}
+    for url in s3_urls:
+        parsed = urlparse(url)
+        bucket = parsed.netloc
+        if bucket not in urls_by_bucket:
+            urls_by_bucket[bucket] = []
+        urls_by_bucket[bucket].append(url)
+
+    import click
+
+    # First, gather all keys to delete for progress bar
+    all_keys = []
+    for bucket, urls in urls_by_bucket.items():
+        prefixes_to_delete = set()
+        individual_keys = set()
+        for url in urls:
+            parsed = urlparse(url)
+            key = parsed.path.lstrip("/")
+            if ".zarr/" in key:
+                zarr_root = key.split(".zarr/")[0] + ".zarr/"
+                prefixes_to_delete.add(zarr_root)
+            elif key.endswith("/"):
+                prefixes_to_delete.add(key)
+            else:
+                individual_keys.add(key)
+        # Collect all keys under prefixes
+        for prefix in prefixes_to_delete:
+            try:
+                paginator = s3_client.get_paginator("list_objects_v2")
+                for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+                    objects = page.get("Contents", [])
+                    all_keys.extend([(bucket, obj["Key"]) for obj in objects])
+            except ClientError:
+                pass
+        # Add individual files
+        for key in individual_keys:
+            all_keys.append((bucket, key))
+
+    # Now, delete with progress bar
+    # Group all_keys by bucket for batch deletion
+    from collections import defaultdict
+
+    bucket_to_keys = defaultdict(list)
+    for bucket, key in all_keys:
+        bucket_to_keys[bucket].append(key)
+
+    total = len(all_keys)
+    BATCH_SIZE = 200
+    with click.progressbar(
+        length=total, label="Deleting S3 objects", show_pos=True, show_percent=True
+    ) as bar:
+        for bucket, keys in bucket_to_keys.items():
+            for i in range(0, len(keys), BATCH_SIZE):
+                batch = keys[i : i + BATCH_SIZE]
+                if not batch:
+                    continue
+                try:
+                    resp = s3_client.delete_objects(
+                        Bucket=bucket, Delete={"Objects": [{"Key": k} for k in batch]}
+                    )
+                    deleted += len(resp.get("Deleted", []))
+                    for err in resp.get("Errors", []):
+                        if err.get("Code") == "NoSuchKey":
+                            deleted += 1
+                        else:
+                            failed += 1
+                except ClientError:
+                    failed += len(batch)
+                bar.update(len(batch))
+
+    return deleted, failed
+
+
+def count_s3_objects_for_item(
+    s3_client: Any,
+    s3_urls: set[str],
+) -> int:
+    """Count how many S3 objects exist for a STAC item's assets.
+
+    Handles both individual files and prefixes (directories/Zarr stores).
+
+    Args:
+        s3_client: Boto3 S3 client
+        s3_urls: Set of S3 URLs from the item's assets
+
+    Returns:
+        Total count of S3 objects
+    """
+    count = 0
+
+    # Group URLs by bucket for efficiency
+    urls_by_bucket: dict[str, list[str]] = {}
+    for url in s3_urls:
+        parsed = urlparse(url)
+        bucket = parsed.netloc
+        if bucket not in urls_by_bucket:
+            urls_by_bucket[bucket] = []
+        urls_by_bucket[bucket].append(url)
+
+    for bucket, urls in urls_by_bucket.items():
+        # Determine if we need to handle prefixes
+        prefixes_to_check = set()
+        individual_keys = set()
+
+        for url in urls:
+            parsed = urlparse(url)
+            key = parsed.path.lstrip("/")
+
+            # Check if this is a prefix (directory or Zarr store)
+            if ".zarr/" in key:
+                # Extract the Zarr root prefix
+                zarr_root = key.split(".zarr/")[0] + ".zarr/"
+                prefixes_to_check.add(zarr_root)
+            elif key.endswith("/"):
+                # It's a directory prefix
+                prefixes_to_check.add(key)
+            else:
+                # It's an individual file
+                individual_keys.add(key)
+
+        # Count objects under prefixes
+        for prefix in prefixes_to_check:
+            try:
+                paginator = s3_client.get_paginator("list_objects_v2")
+                for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+                    count += len(page.get("Contents", []))
+            except ClientError:
+                pass
+
+        # Count individual files
+        for key in individual_keys:
+            try:
+                s3_client.head_object(Bucket=bucket, Key=key)
+                count += 1
+            except ClientError:
+                pass
+
+    return count
+
+
+# === CLI Commands ===
+
+
+@click.group()
+@click.option(
+    "--api-url",
+    default="https://api.explorer.eopf.copernicus.eu/stac",
+    help="STAC API URL",
+    show_default=True,
+)
+@click.pass_context
+def cli(ctx: click.Context, api_url: str) -> None:
+    """STAC Item Management Tool for EOPF Explorer."""
+    ctx.ensure_object(dict)
+    ctx.obj["manager"] = STACItemManager(api_url)
+    ctx.obj["api_url"] = api_url
+
+
+@cli.command()
+@click.argument("collection_id")
+@click.argument("item_id")
+@click.option(
+    "--s3-stats",
+    is_flag=True,
+    help="Include S3 storage statistics",
+)
+@click.option(
+    "--s3-endpoint",
+    help="S3 endpoint URL (optional, uses AWS_ENDPOINT_URL env var if not specified)",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    help="Show detailed debug information about S3 URL extraction",
+)
+@click.pass_context
+def info(
+    ctx: click.Context,
+    collection_id: str,
+    item_id: str,
+    s3_stats: bool,
+    s3_endpoint: str | None,
+    debug: bool,
+) -> None:
+    """
+    Show information about a specific STAC item.
+
+    Example:
+        manage_item.py info sentinel-2-l2a-staging S2A_MSIL2A_20210917T115221_N0500_R123_T28RBS_20230110T165456
+        manage_item.py info sentinel-2-l2a-staging S2A_MSIL2A_20210917T115221_N0500_R123_T28RBS_20230110T165456 --s3-stats
+        manage_item.py info sentinel-2-l2a-staging S2A_MSIL2A_20210917T115221_N0500_R123_T28RBS_20230110T165456 --s3-stats --debug
+    """
+    manager: STACItemManager = ctx.obj["manager"]
+
+    try:
+        item = manager.get_item(collection_id, item_id)
+        if not item:
+            raise click.Abort()
+
+        click.echo(f"\n{'='*60}")
+        click.echo(f"Item: {item['id']}")
+        click.echo(f"Collection: {item['collection']}")
+
+        if "properties" in item:
+            props = item["properties"]
+            if "datetime" in props:
+                click.echo(f"Datetime: {props['datetime']}")
+            if "platform" in props:
+                click.echo(f"Platform: {props['platform']}")
+            if "instruments" in props:
+                click.echo(f"Instruments: {', '.join(props['instruments'])}")
+
+        if "geometry" in item:
+            click.echo(f"Geometry: {item['geometry']['type']}")
+
+        # Show assets
+        assets = item.get("assets", {})
+        click.echo(f"Assets: {len(assets)}")
+        for asset_key in list(assets.keys())[:5]:
+            asset = assets[asset_key]
+            click.echo(f"  - {asset_key}: {asset.get('type', 'N/A')}")
+        if len(assets) > 5:
+            click.echo(f"  ... and {len(assets) - 5} more")
+
+        # S3 storage statistics
+        if s3_stats:
+            click.echo(f"\n{'─'*60}")
+            click.echo("S3 Storage Statistics:")
+
+            # Initialize S3 client
+            s3_config = {}
+            if s3_endpoint:
+                s3_config["endpoint_url"] = s3_endpoint
+            elif os.getenv("AWS_ENDPOINT_URL"):
+                endpoint = os.getenv("AWS_ENDPOINT_URL")
+                if endpoint is not None:
+                    s3_config["endpoint_url"] = endpoint
+
+            try:
+                if "endpoint_url" in s3_config:
+                    s3_client = boto3.client("s3", endpoint_url=s3_config["endpoint_url"])
+                else:
+                    s3_client = boto3.client("s3")
+
+                obj_count, total_size, s3_urls = manager.get_item_s3_stats(
+                    item, s3_client, debug=debug
+                )
+
+                if obj_count > 0:
+                    click.echo(f"\n  S3 URLs ({len(s3_urls)}):")
+                    for url in s3_urls[:5]:
+                        click.echo(f"    • {url}")
+                    if len(s3_urls) > 5:
+                        click.echo(f"    ... and {len(s3_urls) - 5} more")
+
+                    click.echo("\n  Statistics:")
+                    click.echo(f"    Objects: {obj_count:,}")
+                    click.echo(f"    Total size: {total_size / (1024**3):.2f} GB")
+                else:
+                    click.echo("  ⚠️  No S3 data found")
+                    if debug:
+                        click.echo("\n  Troubleshooting tips:")
+                        click.echo("    • Check if item has 'alternate.s3.href' in assets")
+                        click.echo("    • Verify that main asset 'href' fields contain s3:// URLs")
+
+            except Exception as e:
+                click.echo(f"  ⚠️  Could not fetch S3 statistics: {e}", err=True)
+
+        click.echo(f"{'='*60}\n")
+
+    except Exception as e:
+        click.echo(f"❌ Error fetching item info: {e}", err=True)
+        raise click.Abort() from e
+
+
+@cli.command()
+@click.argument("collection_id")
+@click.argument("item_id")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be deleted without actually deleting",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+@click.option(
+    "--clean-s3",
+    is_flag=True,
+    help="Also delete S3 data (Zarr stores) referenced by item",
+)
+@click.option(
+    "--s3-endpoint",
+    help="S3 endpoint URL (optional, uses AWS_ENDPOINT_URL env var if not specified)",
+)
+@click.pass_context
+def delete(
+    ctx: click.Context,
+    collection_id: str,
+    item_id: str,
+    dry_run: bool,
+    yes: bool,
+    clean_s3: bool,
+    s3_endpoint: str | None,
+) -> None:
+    """
+    Delete a single STAC item, optionally cleaning S3 data.
+
+    Example:
+        manage_item.py delete sentinel-2-l2a-staging S2A_MSIL2A_20210917T115221_N0500_R123_T28RBS_20230110T165456 --dry-run
+        manage_item.py delete sentinel-2-l2a-staging S2A_MSIL2A_20210917T115221_N0500_R123_T28RBS_20230110T165456
+        manage_item.py delete sentinel-2-l2a-staging S2A_MSIL2A_20210917T115221_N0500_R123_T28RBS_20230110T165456 --clean-s3 -y
+    """
+    manager: STACItemManager = ctx.obj["manager"]
+
+    # Fetch item first
+    item = manager.get_item(collection_id, item_id)
+    if not item:
+        raise click.Abort()
+
+    # Initialize S3 client if needed
+    s3_client = None
+    if clean_s3:
+        s3_config = {}
+        if s3_endpoint:
+            s3_config["endpoint_url"] = s3_endpoint
+        elif os.getenv("AWS_ENDPOINT_URL"):
+            endpoint = os.getenv("AWS_ENDPOINT_URL")
+            if endpoint is not None:
+                s3_config["endpoint_url"] = endpoint
+
+        if "endpoint_url" in s3_config:
+            s3_client = boto3.client("s3", endpoint_url=s3_config["endpoint_url"])
+        else:
+            s3_client = boto3.client("s3")
+
+    # Dry run preview
+    if dry_run:
+        click.echo(f"\n{'='*60}")
+        click.echo(f"DRY RUN: Would delete item {item_id}")
+        click.echo(f"Collection: {collection_id}")
+
+        if clean_s3 and s3_client:
+            s3_urls = extract_s3_urls_from_item(item)
+            if s3_urls:
+                click.echo("\nS3 data that would be deleted:")
+                obj_count = count_s3_objects_for_item(s3_client, s3_urls)
+                click.echo(f"  S3 objects: {obj_count:,}")
+                click.echo(f"  Asset URLs ({len(s3_urls)}):")
+                for url in list(s3_urls)[:5]:
+                    click.echo(f"    • {url}")
+                if len(s3_urls) > 5:
+                    click.echo(f"    ... and {len(s3_urls) - 5} more")
+            else:
+                click.echo("\n  ⚠️  No S3 data found")
+
+        click.echo(f"{'='*60}\n")
+        return
+
+    # Confirmation prompt
+    if not yes:
+        warning = f"⚠️  This will delete item '{item_id}' from collection '{collection_id}'."
+        if clean_s3:
+            warning += "\n⚠️  This will also DELETE ALL S3 DATA referenced by this item!"
+            warning += "\n⚠️  This action CANNOT be undone!"
+        click.confirm(f"{warning}\n\nContinue?", abort=True)
+
+    try:
+        click.echo(f"\n{'='*60}")
+        click.echo(f"Deleting item: {item_id}")
+
+        success, s3_deleted, s3_failed = manager.delete_item(
+            collection_id=collection_id,
+            item_id=item_id,
+            clean_s3=clean_s3,
+            s3_client=s3_client,
+            item_dict=item,
+            validate_s3=True,
+        )
+
+        click.echo(f"{'='*60}")
+        click.echo("\nDELETION SUMMARY:")
+        click.echo(f"{'='*60}")
+
+        if success:
+            click.echo("✅ STAC item deleted successfully")
+        else:
+            click.echo("❌ STAC item deletion failed or skipped")
+
+        if clean_s3:
+            click.echo(f"✅ S3 objects deleted: {s3_deleted:,}")
+            if s3_failed > 0:
+                click.echo(f"❌ S3 objects failed: {s3_failed:,}")
+
+        click.echo(f"{'='*60}\n")
+
+    except Exception as e:
+        click.echo(f"❌ Operation failed: {e}", err=True)
+        raise click.Abort() from e
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
**Key improvements**

- S3 cleanup and statistics: Tools now support validated S3 data deletion and storage stats for items and collections, with dry-run and safety checks.
- AWS credentials: Clear setup instructions and warnings for S3 features.
- Debugging workflow: Recommends starting with single-item operations (`manage_item.py`) before batch actions (`manage_collections.py`).
- Expanded examples: More usage examples and detailed tool descriptions.
- Troubleshooting & best practices: New sections for common S3 issues, dry-run usage, and safe cleanup.

**Test**
I ran it on sentinel-2-l2a-staging and could see that the number of objects decrease in ovh bucket as it should:

Before deletion:
<img width="252" height="137" alt="Screenshot 2026-01-21 at 12 22 33" src="https://github.com/user-attachments/assets/f15a2ef3-090b-4d50-b588-20c385aeb854" />

After deletion:
<img width="215" height="128" alt="Screenshot 2026-01-21 at 12 30 35" src="https://github.com/user-attachments/assets/1e6e2116-f371-48a5-9c09-0601b2342b13" />


