### PR TITLE
fix(stac): reflectance media type version=2 -> version=3

### DIFF
--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -594,7 +594,7 @@ def consolidate_reflectance_assets(item: Item, geozarr_url: str) -> None:
 
     reflectance_asset = Asset(
         href=reflectance_href,
-        media_type="application/vnd+zarr; version=2; profile=multiscales",
+        media_type="application/vnd+zarr; version=3; profile=multiscales",
         title="Surface Reflectance",
         roles=["data", "reflectance"],
         extra_fields={

--- a/stac/S2A_MSIL2A_20250831T103701_N0511_R008_T31TFL_20250831T145420.json
+++ b/stac/S2A_MSIL2A_20250831T103701_N0511_R008_T31TFL_20250831T145420.json
@@ -117,7 +117,7 @@
     "reflectance": {
       "gsd": 10,
       "href": "https://esa-zarr-sentinel-explorer-fra.s3.de.io.cloud.ovh.net/tests-output/sentinel-2-l2a-staging/S2A_MSIL2A_20250831T103701_N0511_R008_T31TFL_20250831T145420.zarr/measurements/reflectance",
-      "type": "application/vnd+zarr; version=2; profile=multiscales",
+      "type": "application/vnd+zarr; version=3; profile=multiscales",
       "bands": [
         {
           "gsd": 20,

--- a/stac/S2A_MSIL2A_20250831T103701_N0511_R008_T31TFL_20250831T145420_new_gateway.json
+++ b/stac/S2A_MSIL2A_20250831T103701_N0511_R008_T31TFL_20250831T145420_new_gateway.json
@@ -203,7 +203,7 @@
     "reflectance": {
       "gsd": 10,
       "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a-staging/S2A_MSIL2A_20250831T103701_N0511_R008_T31TFL_20250831T145420.zarr/measurements/reflectance",
-      "type": "application/vnd+zarr; version=2; profile=multiscales",
+      "type": "application/vnd+zarr; version=3; profile=multiscales",
       "bands": [
         {
           "gsd": 20,

--- a/stac/S2A_MSIL2A_20250831T103701_N0511_R008_T31TFL_20250831T145420_with_alternate.json
+++ b/stac/S2A_MSIL2A_20250831T103701_N0511_R008_T31TFL_20250831T145420_with_alternate.json
@@ -203,7 +203,7 @@
     "reflectance": {
       "gsd": 10,
       "href": "https://esa-zarr-sentinel-explorer-fra.s3.de.io.cloud.ovh.net/tests-output/sentinel-2-l2a-staging/S2A_MSIL2A_20250831T103701_N0511_R008_T31TFL_20250831T145420.zarr/measurements/reflectance",
-      "type": "application/vnd+zarr; version=2; profile=multiscales",
+      "type": "application/vnd+zarr; version=3; profile=multiscales",
       "bands": [
         {
           "gsd": 20,

--- a/tests/test_consolidate_reflectance.py
+++ b/tests/test_consolidate_reflectance.py
@@ -160,7 +160,7 @@ class TestConsolidateReflectanceAssets:
 
         reflectance = stac_item.assets["reflectance"]
         assert (
-            reflectance.media_type == "application/vnd+zarr; version=2; profile=multiscales"
+            reflectance.media_type == "application/vnd+zarr; version=3; profile=multiscales"
         ), "Should have correct zarr media type"
 
     def test_reflectance_asset_href_structure(self, stac_item):


### PR DESCRIPTION
`data-model` writes Zarr v3 (`zarr.json` with `zarr_format: 3`, sharding codec), but the reflectance asset in the STAC registration hardcoded `version=2`:

```python
# register_v1.py:597
media_type="application/vnd+zarr; version=2; profile=multiscales"
```

Verified against a live item (`S2A_MSIL2A_20260216T142251_N0512_R096_T25WET_20260216T202508`):

```
curl .../reflectance/r10m/b04/zarr.json | jq .zarr_format
3
```

Clients that branch on this parameter would attempt a v2 parse and fail.

Note: the store link TODO at line 319 (`application/vnd.zarr; version=3`) is a separate issue - left as-is.
