### PR TITLE
feat: create cli command to change storage tier

### DIFF
--- a/operator-tools/README.md
+++ b/operator-tools/README.md
@@ -85,9 +85,17 @@ uv run operator-tools/manage_item.py info sentinel-2-l2a-staging ITEM_ID --s3-st
 # Debug S3 URL extraction
 uv run operator-tools/manage_item.py info sentinel-2-l2a-staging ITEM_ID --s3-stats --debug
 
-# Sync storage tiers for a single item (dry run)
+# Sync storage tier metadata for a single item (dry run)
 uv run operator-tools/manage_item.py sync-storage-tiers sentinel-2-l2a-staging ITEM_ID \
     --s3-endpoint https://s3.de.io.cloud.ovh.net --dry-run
+
+# Change storage tier for a single item (dry run - safe, no writes)
+uv run operator-tools/manage_item.py change-storage-tier sentinel-2-l2a-staging ITEM_ID \
+    --storage-class STANDARD_IA --s3-endpoint https://s3.de.io.cloud.ovh.net --dry-run
+
+# Change storage tier for a single item (requires confirmation)
+uv run operator-tools/manage_item.py change-storage-tier sentinel-2-l2a-staging ITEM_ID \
+    --storage-class STANDARD_IA --s3-endpoint https://s3.de.io.cloud.ovh.net -y
 
 # Delete single item with S3 cleanup (dry run)
 uv run operator-tools/manage_item.py delete sentinel-2-l2a-staging ITEM_ID --clean-s3 --dry-run
@@ -100,6 +108,7 @@ uv run operator-tools/manage_item.py delete sentinel-2-l2a-staging ITEM_ID --cle
 - Detailed item inspection with S3 statistics
 - Storage tier statistics from STAC metadata
 - Sync storage tiers with S3 (single item)
+- **Change S3 storage tier** for a single item and update STAC metadata
 - Debug mode for S3 URL extraction troubleshooting
 - Delete with automatic S3 validation
 - Dry-run mode for safe testing
@@ -149,9 +158,18 @@ uv run operator-tools/manage_collections.py info sentinel-2-l2a-staging --s3-sta
 # Debug S3 URL extraction
 uv run operator-tools/manage_collections.py info sentinel-2-l2a-staging --s3-stats --debug
 
-# Sync storage tiers for entire collection (dry run)
+# Sync storage tier metadata for entire collection (dry run)
 uv run operator-tools/manage_collections.py sync-storage-tiers sentinel-2-l2a-staging \
     --s3-endpoint https://s3.de.io.cloud.ovh.net --dry-run
+
+# Change storage tier for items in a date range (dry run - safe, no writes)
+uv run operator-tools/manage_collections.py change-storage-tier sentinel-2-l2a-staging \
+    --storage-class STANDARD_IA --start-date 2024-01-01 --end-date 2024-03-31 \
+    --s3-endpoint https://s3.de.io.cloud.ovh.net --dry-run
+
+# Change storage tier for all items in a collection (requires confirmation)
+uv run operator-tools/manage_collections.py change-storage-tier sentinel-2-l2a-staging \
+    --storage-class STANDARD_IA --s3-endpoint https://s3.de.io.cloud.ovh.net -y
 
 # Clean a collection (dry run first!)
 uv run operator-tools/manage_collections.py clean sentinel-2-l2a-staging --dry-run
@@ -173,6 +191,7 @@ uv run operator-tools/manage_collections.py batch-create stac/
 - **Validated S3 cleanup** - Verifies all S3 objects deleted before removing STAC items
 - **Comprehensive S3 support** - Handles individual files, directories, and Zarr stores
 - **Sync storage tiers** - Keep STAC metadata in sync with S3 storage classes
+- **Change storage tier** - Move items to a different storage class, with date filtering
 - **Debug mode** - Detailed S3 URL extraction and validation info
 - **Safety first** - STAC items preserved if S3 cleanup fails
 
@@ -341,6 +360,61 @@ Sampling 5 of 43 items...
     Objects: ~53,621
     Size: ~100.5 GB
 ```
+
+### Change S3 Storage Tier
+
+Move items to a different storage class (STANDARD, STANDARD_IA, EXPRESS_ONEZONE), then automatically update the STAC metadata to reflect the change.
+
+**Debug workflow** — always test a single item first:
+```bash
+ITEM_ID="S2A_MSIL2A_20250831T103701_N0511_R008_T31TFL_20250831T145420"
+
+# 1. Single item dry run (no writes)
+uv run operator-tools/manage_item.py change-storage-tier sentinel-2-l2a-staging $ITEM_ID \
+    --storage-class STANDARD_IA --s3-endpoint https://s3.de.io.cloud.ovh.net --dry-run
+
+# 2. Single item live run (prompts for confirmation)
+uv run operator-tools/manage_item.py change-storage-tier sentinel-2-l2a-staging $ITEM_ID \
+    --storage-class STANDARD_IA --s3-endpoint https://s3.de.io.cloud.ovh.net -y
+
+# 3. Verify: storage tier info should show the new class
+uv run operator-tools/manage_item.py info sentinel-2-l2a-staging $ITEM_ID --s3-stac-info
+```
+
+**Collection-level** — with optional date filtering:
+```bash
+# Dry run for a date range
+uv run operator-tools/manage_collections.py change-storage-tier sentinel-2-l2a-staging \
+    --storage-class STANDARD_IA --start-date 2024-01-01 --end-date 2024-03-31 \
+    --s3-endpoint https://s3.de.io.cloud.ovh.net --dry-run
+
+# Live run (prompts for confirmation showing item count)
+uv run operator-tools/manage_collections.py change-storage-tier sentinel-2-l2a-staging \
+    --storage-class STANDARD_IA --start-date 2024-01-01 --end-date 2024-03-31 \
+    --s3-endpoint https://s3.de.io.cloud.ovh.net -y
+
+# All items (no date filter)
+uv run operator-tools/manage_collections.py change-storage-tier sentinel-2-l2a-staging \
+    --storage-class STANDARD --s3-endpoint https://s3.de.io.cloud.ovh.net -y
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--storage-class` | Target class: `STANDARD`, `STANDARD_IA`, or `EXPRESS_ONEZONE` (required) |
+| `--start-date` | Filter items on or after this date (`YYYY-MM-DD`) |
+| `--end-date` | Filter items on or before this date (`YYYY-MM-DD`) |
+| `--s3-endpoint` | S3 endpoint URL (falls back to `AWS_ENDPOINT_URL`) |
+| `--include-pattern` | fnmatch pattern for objects to include (repeatable) |
+| `--exclude-pattern` | fnmatch pattern for objects to exclude (repeatable) |
+| `--dry-run` | Show what would change without writing anything |
+| `-y` / `--yes` | Skip confirmation prompt |
+
+**Safety guarantees:**
+- S3 storage class is changed first; STAC metadata is only updated if S3 succeeds
+- Items with S3 failures are tracked and reported in the final summary — STAC is not touched
+- `--dry-run` propagates to S3 operations; nothing is written in either system
 
 ### Clean S3 Data (with Validation)
 

--- a/operator-tools/manage_collections.py
+++ b/operator-tools/manage_collections.py
@@ -1213,5 +1213,217 @@ def sync_storage_tiers(
         raise click.Abort() from e
 
 
+@cli.command()
+@click.argument("collection_id")
+@click.option(
+    "--storage-class",
+    required=True,
+    type=click.Choice(["STANDARD", "STANDARD_IA", "EXPRESS_ONEZONE"]),
+    help="Target S3 storage class",
+)
+@click.option(
+    "--start-date",
+    help="Start date filter, inclusive (YYYY-MM-DD)",
+)
+@click.option(
+    "--end-date",
+    help="End date filter, inclusive (YYYY-MM-DD)",
+)
+@click.option(
+    "--s3-endpoint",
+    help="S3 endpoint URL (required, uses AWS_ENDPOINT_URL env var if not specified)",
+)
+@click.option(
+    "--include-pattern",
+    "include_patterns",
+    multiple=True,
+    help="fnmatch pattern for objects to include (repeatable)",
+)
+@click.option(
+    "--exclude-pattern",
+    "exclude_patterns",
+    multiple=True,
+    help="fnmatch pattern for objects to exclude (repeatable)",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be changed without actually changing",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+@click.pass_context
+def change_storage_tier(
+    ctx: click.Context,
+    collection_id: str,
+    storage_class: str,
+    start_date: str | None,
+    end_date: str | None,
+    s3_endpoint: str | None,
+    include_patterns: tuple[str, ...],
+    exclude_patterns: tuple[str, ...],
+    dry_run: bool,
+    yes: bool,
+) -> None:
+    """
+    Change S3 storage tier for items in a collection, optionally filtered by date.
+
+    This command changes the S3 storage class for all objects in each item's
+    Zarr store, then updates STAC item metadata to reflect the new storage class.
+
+    Example:
+        manage_collections.py change-storage-tier sentinel-2-l2a-staging --storage-class STANDARD_IA --s3-endpoint https://s3.de.io.cloud.ovh.net --dry-run
+        manage_collections.py change-storage-tier sentinel-2-l2a-staging --storage-class STANDARD_IA --start-date 2024-01-01 --end-date 2024-03-31 --s3-endpoint https://s3.de.io.cloud.ovh.net -y
+    """
+    manager: STACCollectionManager = ctx.obj["manager"]
+    api_url: str = ctx.obj["api_url"]
+
+    # Get S3 endpoint
+    if not s3_endpoint:
+        s3_endpoint = os.getenv("AWS_ENDPOINT_URL")
+        if not s3_endpoint:
+            click.echo(
+                "❌ S3 endpoint required. Use --s3-endpoint or set AWS_ENDPOINT_URL", err=True
+            )
+            raise click.Abort()
+
+    # Validate date format early
+    from datetime import datetime
+
+    def _parse_date(date_str: str, param_name: str) -> None:
+        try:
+            datetime.strptime(date_str, "%Y-%m-%d")
+        except ValueError:
+            click.echo(f"❌ Invalid {param_name} format: '{date_str}'. Use YYYY-MM-DD.", err=True)
+            raise click.Abort() from None
+
+    if start_date:
+        _parse_date(start_date, "--start-date")
+    if end_date:
+        _parse_date(end_date, "--end-date")
+
+    try:
+        # Search items with optional date filter
+        catalog = Client.open(api_url)
+        if start_date or end_date:
+            start_str = f"{start_date}T00:00:00Z" if start_date else "1900-01-01T00:00:00Z"
+            end_str = f"{end_date}T23:59:59Z" if end_date else "2100-12-31T23:59:59Z"
+            search = catalog.search(
+                collections=[collection_id],
+                filter={"op": "between", "args": [{"property": "datetime"}, start_str, end_str]},
+                filter_lang="cql2-json",
+                limit=100,
+                max_items=None,
+            )
+        else:
+            search = catalog.search(collections=[collection_id], max_items=None)
+
+        items = list(search.items())
+
+        if not items:
+            click.echo("✅ No items matched the specified criteria.")
+            return
+
+        # Build date range message for confirmation
+        date_range_msg = ""
+        if start_date or end_date:
+            date_range_msg = f" ({start_date or 'any'} → {end_date or 'any'})"
+
+        # Confirmation prompt
+        if not dry_run and not yes:
+            click.confirm(
+                f"⚠️  This will change storage class for {len(items)} item(s) in '{collection_id}'"
+                f"{date_range_msg} to {storage_class}.\n\nContinue?",
+                abort=True,
+            )
+
+        click.echo(
+            f"\n{'DRY RUN: ' if dry_run else ''}Changing storage tier for {len(items)} item(s)"
+        )
+        click.echo(f"Collection: {collection_id}")
+        if date_range_msg:
+            click.echo(f"Date range: {date_range_msg.strip()}")
+        click.echo(f"Target storage class: {storage_class}")
+
+        from change_storage_tier import process_stac_item  # noqa: E402
+        from update_stac_storage_tier import update_item_storage_tiers  # noqa: E402
+
+        items_changed = 0
+        items_failed = 0
+        failed_item_ids: list[str] = []
+
+        with click.progressbar(
+            items, label="Processing items", show_pos=True, show_percent=True
+        ) as bar:
+            for item in bar:
+                item_id = item.id
+                stac_item_url = f"{manager.api_url}/collections/{collection_id}/items/{item_id}"
+
+                stats = process_stac_item(
+                    stac_item_url,
+                    storage_class,
+                    dry_run,
+                    s3_endpoint,
+                    list(include_patterns) or None,
+                    list(exclude_patterns) or None,
+                )
+
+                if stats["failed"] > 0:
+                    items_failed += 1
+                    failed_item_ids.append(item_id)
+                elif stats["processed"] > 0:
+                    if not dry_run:
+                        # Re-fetch and update STAC metadata
+                        item_dict = manager.item_manager.get_item(collection_id, item_id)
+                        if item_dict:
+                            pystac_item = Item.from_dict(item_dict)
+                            update_item_storage_tiers(pystac_item, s3_endpoint)
+
+                            # Use DELETE then POST (pgstac doesn't support PUT)
+                            delete_url = (
+                                f"{manager.api_url}" f"/collections/{collection_id}/items/{item_id}"
+                            )
+                            manager.session.delete(delete_url, timeout=30)
+                            create_url = f"{manager.api_url}" f"/collections/{collection_id}/items"
+                            manager.session.post(
+                                create_url,
+                                json=pystac_item.to_dict(),
+                                headers={"Content-Type": "application/json"},
+                                timeout=30,
+                            )
+                        else:
+                            items_failed += 1
+                            failed_item_ids.append(item_id)
+                            continue
+                    items_changed += 1
+
+        # Summary
+        click.echo("\n" + "=" * 60)
+        click.echo("CHANGE SUMMARY")
+        click.echo("=" * 60)
+        click.echo(f"Items processed: {len(items)}")
+        click.echo(f"✅ Items changed: {items_changed}")
+        if items_failed > 0:
+            click.echo(f"❌ Items failed: {items_failed}")
+            click.echo("\nFailed items:")
+            for fid in failed_item_ids:
+                click.echo(f"  - {fid}")
+
+        if dry_run:
+            click.echo(f"\n{'─'*60}")
+            click.echo("DRY RUN - No changes were made")
+            click.echo(f"{'─'*60}")
+
+        click.echo("=" * 60)
+
+    except Exception as e:
+        click.echo(f"❌ Operation failed: {e}", err=True)
+        raise click.Abort() from e
+
+
 if __name__ == "__main__":
     cli()

--- a/operator-tools/manage_item.py
+++ b/operator-tools/manage_item.py
@@ -1152,5 +1152,147 @@ def sync_storage_tiers(
         raise click.Abort() from e
 
 
+@cli.command()
+@click.argument("collection_id")
+@click.argument("item_id")
+@click.option(
+    "--storage-class",
+    required=True,
+    type=click.Choice(["STANDARD", "STANDARD_IA", "EXPRESS_ONEZONE"]),
+    help="Target S3 storage class",
+)
+@click.option(
+    "--s3-endpoint",
+    help="S3 endpoint URL (required, uses AWS_ENDPOINT_URL env var if not specified)",
+)
+@click.option(
+    "--include-pattern",
+    "include_patterns",
+    multiple=True,
+    help="fnmatch pattern for objects to include (repeatable)",
+)
+@click.option(
+    "--exclude-pattern",
+    "exclude_patterns",
+    multiple=True,
+    help="fnmatch pattern for objects to exclude (repeatable)",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be changed without actually changing",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+@click.pass_context
+def change_storage_tier(
+    ctx: click.Context,
+    collection_id: str,
+    item_id: str,
+    storage_class: str,
+    s3_endpoint: str | None,
+    include_patterns: tuple[str, ...],
+    exclude_patterns: tuple[str, ...],
+    dry_run: bool,
+    yes: bool,
+) -> None:
+    """
+    Change S3 storage tier for a single STAC item and update STAC metadata.
+
+    This command changes the S3 storage class for all objects in the item's
+    Zarr store, then updates the STAC item metadata to reflect the new storage class.
+
+    Example:
+        manage_item.py change-storage-tier sentinel-2-l2a-staging ITEM_ID --storage-class STANDARD_IA --s3-endpoint https://s3.de.io.cloud.ovh.net --dry-run
+        manage_item.py change-storage-tier sentinel-2-l2a-staging ITEM_ID --storage-class STANDARD_IA --s3-endpoint https://s3.de.io.cloud.ovh.net -y
+    """
+    manager: STACItemManager = ctx.obj["manager"]
+
+    # Get S3 endpoint
+    if not s3_endpoint:
+        s3_endpoint = os.getenv("AWS_ENDPOINT_URL")
+        if not s3_endpoint:
+            click.echo(
+                "❌ S3 endpoint required. Use --s3-endpoint or set AWS_ENDPOINT_URL", err=True
+            )
+            raise click.Abort()
+
+    # Confirmation prompt
+    if not dry_run and not yes:
+        click.confirm(
+            f"⚠️  This will change storage class for item '{item_id}' to {storage_class}.\n\nContinue?",
+            abort=True,
+        )
+
+    try:
+        stac_item_url = f"{manager.api_url}/collections/{collection_id}/items/{item_id}"
+        click.echo(f"\n{'DRY RUN: ' if dry_run else ''}Changing storage tier for item: {item_id}")
+        click.echo(f"Collection: {collection_id}")
+        click.echo(f"Target storage class: {storage_class}")
+
+        # Change S3 storage class
+        from change_storage_tier import process_stac_item  # noqa: E402
+
+        stats = process_stac_item(
+            stac_item_url,
+            storage_class,
+            dry_run,
+            s3_endpoint,
+            list(include_patterns) or None,
+            list(exclude_patterns) or None,
+        )
+
+        click.echo(f"\n{'─'*60}")
+        click.echo("S3 CHANGE SUMMARY")
+        click.echo(f"{'─'*60}")
+        click.echo(f"Objects processed: {stats['processed']}")
+        click.echo(f"✅ Objects changed: {stats['succeeded']}")
+        if stats["failed"] > 0:
+            click.echo(f"❌ Objects failed: {stats['failed']}")
+
+        # Update STAC metadata if S3 succeeded and not dry-run
+        if stats["failed"] == 0 and not dry_run and stats["processed"] > 0:
+            from update_stac_storage_tier import update_item_storage_tiers  # noqa: E402
+
+            # Re-fetch item after S3 change and update storage metadata
+            item_dict = manager.get_item(collection_id, item_id)
+            if not item_dict:
+                raise click.Abort()
+            item = Item.from_dict(item_dict)
+            update_item_storage_tiers(item, s3_endpoint)
+
+            try:
+                # Use DELETE then POST (pgstac doesn't support PUT)
+                delete_url = f"{manager.api_url}/collections/{collection_id}/items/{item_id}"
+                manager.session.delete(delete_url, timeout=30)
+                create_url = f"{manager.api_url}/collections/{collection_id}/items"
+                manager.session.post(
+                    create_url,
+                    json=item.to_dict(),
+                    headers={"Content-Type": "application/json"},
+                    timeout=30,
+                )
+                click.echo(f"\n✅ Updated STAC metadata for item {item_id}")
+            except Exception as e:
+                click.echo(f"\n❌ Failed to update STAC item: {e}", err=True)
+                raise click.Abort() from e
+        elif dry_run:
+            click.echo(f"\n{'─'*60}")
+            click.echo("DRY RUN - No changes were made")
+            click.echo(f"{'─'*60}")
+        elif stats["failed"] > 0:
+            click.echo("\n⚠️  Skipping STAC metadata update due to S3 failures")
+
+        click.echo(f"{'='*60}\n")
+
+    except Exception as e:
+        click.echo(f"❌ Operation failed: {e}", err=True)
+        raise click.Abort() from e
+
+
 if __name__ == "__main__":
     cli()

--- a/tests/unit/test_change_storage_tier_commands.py
+++ b/tests/unit/test_change_storage_tier_commands.py
@@ -1,0 +1,491 @@
+"""Unit tests for the change-storage-tier CLI commands.
+
+Covers manage_item.py and manage_collections.py change-storage-tier subcommands.
+All external calls (S3, STAC API, pystac_client) are mocked.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+# ---------------------------------------------------------------------------
+# Module loading
+# operator-tools uses a hyphen in the directory name so we cannot use a
+# standard import statement; use importlib to load by file path instead.
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).parent.parent.parent
+OPERATOR_TOOLS = REPO_ROOT / "operator-tools"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+for _p in (str(SCRIPTS_DIR), str(OPERATOR_TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _load(module_name: str, file_path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Load manage_item first (manage_collections imports from it)
+manage_item_module = _load("manage_item", OPERATOR_TOOLS / "manage_item.py")
+manage_collections_module = _load("manage_collections", OPERATOR_TOOLS / "manage_collections.py")
+
+item_cli = manage_item_module.cli
+collection_cli = manage_collections_module.cli
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+API_URL = "https://api.example.com/stac"
+S3_ENDPOINT = "https://s3.example.com"
+COLLECTION_ID = "sentinel-2-l2a-staging"
+ITEM_ID = "test-item-001"
+
+FAKE_ITEM_DICT = {
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "stac_extensions": [],
+    "id": ITEM_ID,
+    "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
+    "bbox": [0.0, 0.0, 0.0, 0.0],
+    "properties": {"datetime": "2024-01-15T00:00:00Z"},
+    "assets": {},
+    "links": [],
+    "collection": COLLECTION_ID,
+}
+
+S3_SUCCESS_STATS = {"processed": 100, "succeeded": 100, "failed": 0}
+S3_FAILURE_STATS = {"processed": 100, "succeeded": 90, "failed": 10}
+S3_ZERO_STATS = {"processed": 0, "succeeded": 0, "failed": 0}
+
+BASE_ARGS = ["--api-url", API_URL, "change-storage-tier"]
+ITEM_BASE_ARGS = BASE_ARGS + [COLLECTION_ID, ITEM_ID]
+COLL_BASE_ARGS = BASE_ARGS + [COLLECTION_ID]
+
+
+def _fake_pystac_item(item_id: str) -> MagicMock:
+    mock = MagicMock()
+    mock.id = item_id
+    return mock
+
+
+def _mock_catalog(items: list) -> MagicMock:
+    mock_search = MagicMock()
+    mock_search.items.return_value = items
+    mock_catalog = MagicMock()
+    mock_catalog.search.return_value = mock_search
+    return mock_catalog
+
+
+# ---------------------------------------------------------------------------
+# manage_item.py: change-storage-tier
+# ---------------------------------------------------------------------------
+class TestManageItemChangeStorageTier:
+    def test_help_output(self):
+        runner = CliRunner()
+        result = runner.invoke(item_cli, BASE_ARGS + ["--help"])
+        assert result.exit_code == 0
+        for flag in (
+            "--storage-class",
+            "--s3-endpoint",
+            "--include-pattern",
+            "--exclude-pattern",
+            "--dry-run",
+        ):
+            assert flag in result.output
+
+    def test_missing_storage_class(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            item_cli,
+            ITEM_BASE_ARGS + ["--s3-endpoint", S3_ENDPOINT],
+        )
+        assert result.exit_code != 0
+
+    def test_invalid_storage_class(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            item_cli,
+            ITEM_BASE_ARGS + ["--storage-class", "GLACIER", "--s3-endpoint", S3_ENDPOINT],
+        )
+        assert result.exit_code != 0
+
+    def test_missing_s3_endpoint(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            item_cli,
+            ITEM_BASE_ARGS + ["--storage-class", "STANDARD_IA"],
+            env={"AWS_ENDPOINT_URL": ""},
+        )
+        assert "S3 endpoint required" in result.output
+
+    def test_s3_endpoint_from_env(self):
+        runner = CliRunner()
+        with patch("change_storage_tier.process_stac_item", return_value=S3_ZERO_STATS):
+            result = runner.invoke(
+                item_cli,
+                ITEM_BASE_ARGS + ["--storage-class", "STANDARD_IA", "--dry-run"],
+                env={"AWS_ENDPOINT_URL": S3_ENDPOINT},
+            )
+        assert result.exit_code == 0
+
+    def test_dry_run_skips_confirmation(self):
+        """With --dry-run, no confirmation prompt is shown (no input needed)."""
+        runner = CliRunner()
+        with patch("change_storage_tier.process_stac_item", return_value=S3_ZERO_STATS):
+            result = runner.invoke(
+                item_cli,
+                ITEM_BASE_ARGS
+                + ["--storage-class", "STANDARD_IA", "--s3-endpoint", S3_ENDPOINT, "--dry-run"],
+            )
+        assert result.exit_code == 0
+        assert "Continue?" not in result.output
+
+    def test_confirmation_prompt_shown(self):
+        """Without --dry-run or -y, a confirmation prompt must appear."""
+        runner = CliRunner()
+        with patch("change_storage_tier.process_stac_item", return_value=S3_ZERO_STATS):
+            result = runner.invoke(
+                item_cli,
+                ITEM_BASE_ARGS + ["--storage-class", "STANDARD_IA", "--s3-endpoint", S3_ENDPOINT],
+                input="n\n",
+            )
+        assert "Continue?" in result.output
+
+    def test_dry_run_calls_process_stac_item(self):
+        runner = CliRunner()
+        with patch("change_storage_tier.process_stac_item", return_value=S3_ZERO_STATS) as mock_psi:
+            runner.invoke(
+                item_cli,
+                ITEM_BASE_ARGS
+                + ["--storage-class", "STANDARD_IA", "--s3-endpoint", S3_ENDPOINT, "--dry-run"],
+            )
+        mock_psi.assert_called_once()
+        assert mock_psi.call_args.args[2] is True  # dry_run positional argument
+
+    def test_dry_run_skips_stac_update(self):
+        """In dry-run mode, STAC DELETE+POST must not be called."""
+        runner = CliRunner()
+        with (
+            patch("change_storage_tier.process_stac_item", return_value=S3_SUCCESS_STATS),
+            patch("update_stac_storage_tier.update_item_storage_tiers") as mock_update,
+            patch("requests.Session.delete") as mock_delete,
+            patch("requests.Session.post") as mock_post,
+        ):
+            runner.invoke(
+                item_cli,
+                ITEM_BASE_ARGS
+                + [
+                    "--storage-class",
+                    "STANDARD_IA",
+                    "--s3-endpoint",
+                    S3_ENDPOINT,
+                    "--dry-run",
+                ],
+            )
+        mock_update.assert_not_called()
+        mock_delete.assert_not_called()
+        mock_post.assert_not_called()
+
+    def test_success_calls_update_stac_metadata(self):
+        """When S3 succeeds (failed=0), update_item_storage_tiers must be called."""
+        runner = CliRunner()
+        with (
+            patch("change_storage_tier.process_stac_item", return_value=S3_SUCCESS_STATS),
+            patch("manage_item.STACItemManager.get_item", return_value=FAKE_ITEM_DICT),
+            patch("update_stac_storage_tier.update_item_storage_tiers") as mock_update,
+            patch("requests.Session.delete", return_value=MagicMock(status_code=200)),
+            patch("requests.Session.post", return_value=MagicMock(status_code=201)),
+        ):
+            result = runner.invoke(
+                item_cli,
+                ITEM_BASE_ARGS
+                + [
+                    "--storage-class",
+                    "STANDARD_IA",
+                    "--s3-endpoint",
+                    S3_ENDPOINT,
+                    "-y",
+                ],
+            )
+        mock_update.assert_called_once()
+        assert result.exit_code == 0
+
+    def test_s3_failure_skips_stac_update(self):
+        """When S3 has failures (failed>0), update_item_storage_tiers must NOT be called."""
+        runner = CliRunner()
+        with (
+            patch("change_storage_tier.process_stac_item", return_value=S3_FAILURE_STATS),
+            patch("update_stac_storage_tier.update_item_storage_tiers") as mock_update,
+        ):
+            runner.invoke(
+                item_cli,
+                ITEM_BASE_ARGS
+                + ["--storage-class", "STANDARD_IA", "--s3-endpoint", S3_ENDPOINT, "-y"],
+            )
+        mock_update.assert_not_called()
+
+    def test_include_exclude_patterns_passed(self):
+        """--include-pattern and --exclude-pattern are forwarded to process_stac_item."""
+        runner = CliRunner()
+        with patch("change_storage_tier.process_stac_item", return_value=S3_ZERO_STATS) as mock_psi:
+            runner.invoke(
+                item_cli,
+                ITEM_BASE_ARGS
+                + [
+                    "--storage-class",
+                    "STANDARD_IA",
+                    "--s3-endpoint",
+                    S3_ENDPOINT,
+                    "--dry-run",
+                    "--include-pattern",
+                    "*.zarr",
+                    "--exclude-pattern",
+                    "*.metadata",
+                ],
+            )
+        mock_psi.assert_called_once()
+        call_args = mock_psi.call_args.args
+        assert call_args[4] == ["*.zarr"]  # include_patterns
+        assert call_args[5] == ["*.metadata"]  # exclude_patterns
+
+
+# ---------------------------------------------------------------------------
+# manage_collections.py: change-storage-tier
+# ---------------------------------------------------------------------------
+class TestManageCollectionsChangeStorageTier:
+    def test_help_output(self):
+        runner = CliRunner()
+        result = runner.invoke(collection_cli, BASE_ARGS + ["--help"])
+        assert result.exit_code == 0
+        for flag in ("--storage-class", "--start-date", "--end-date", "--s3-endpoint", "--dry-run"):
+            assert flag in result.output
+
+    def test_missing_storage_class(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            collection_cli,
+            COLL_BASE_ARGS + ["--s3-endpoint", S3_ENDPOINT],
+        )
+        assert result.exit_code != 0
+
+    def test_invalid_date_format(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            collection_cli,
+            COLL_BASE_ARGS
+            + [
+                "--storage-class",
+                "STANDARD_IA",
+                "--s3-endpoint",
+                S3_ENDPOINT,
+                "--start-date",
+                "01-2024-01",
+            ],
+        )
+        assert "Invalid" in result.output or result.exit_code != 0
+
+    def test_no_date_filter_fetches_all(self):
+        """Without dates, catalog.search() is called without a CQL2 filter."""
+        runner = CliRunner()
+        mock_catalog = _mock_catalog([_fake_pystac_item("item-001")])
+        with (
+            patch("pystac_client.Client.open", return_value=mock_catalog),
+            patch("change_storage_tier.process_stac_item", return_value=S3_ZERO_STATS),
+        ):
+            runner.invoke(
+                collection_cli,
+                COLL_BASE_ARGS
+                + [
+                    "--storage-class",
+                    "STANDARD_IA",
+                    "--s3-endpoint",
+                    S3_ENDPOINT,
+                    "--dry-run",
+                    "-y",
+                ],
+            )
+        call_kwargs = mock_catalog.search.call_args.kwargs
+        assert "filter" not in call_kwargs
+
+    def test_date_filter_builds_cql2_between(self):
+        """With start+end dates, catalog.search() receives the correct CQL2 between filter."""
+        runner = CliRunner()
+        mock_catalog = _mock_catalog([_fake_pystac_item("item-001")])
+        with (
+            patch("pystac_client.Client.open", return_value=mock_catalog),
+            patch("change_storage_tier.process_stac_item", return_value=S3_ZERO_STATS),
+        ):
+            runner.invoke(
+                collection_cli,
+                COLL_BASE_ARGS
+                + [
+                    "--storage-class",
+                    "STANDARD_IA",
+                    "--s3-endpoint",
+                    S3_ENDPOINT,
+                    "--start-date",
+                    "2024-01-01",
+                    "--end-date",
+                    "2024-03-31",
+                    "--dry-run",
+                    "-y",
+                ],
+            )
+        call_kwargs = mock_catalog.search.call_args.kwargs
+        filter_arg = call_kwargs["filter"]
+        assert filter_arg["op"] == "between"
+        args_list = str(filter_arg)
+        assert "2024-01-01T00:00:00Z" in args_list
+        assert "2024-03-31T23:59:59Z" in args_list
+
+    def test_start_date_only(self):
+        """Only --start-date: range goes from start to far future."""
+        runner = CliRunner()
+        mock_catalog = _mock_catalog([_fake_pystac_item("item-001")])
+        with (
+            patch("pystac_client.Client.open", return_value=mock_catalog),
+            patch("change_storage_tier.process_stac_item", return_value=S3_ZERO_STATS),
+        ):
+            runner.invoke(
+                collection_cli,
+                COLL_BASE_ARGS
+                + [
+                    "--storage-class",
+                    "STANDARD_IA",
+                    "--s3-endpoint",
+                    S3_ENDPOINT,
+                    "--start-date",
+                    "2024-01-01",
+                    "--dry-run",
+                    "-y",
+                ],
+            )
+        filter_arg = mock_catalog.search.call_args.kwargs["filter"]
+        args_str = str(filter_arg)
+        assert "2024-01-01T00:00:00Z" in args_str
+        assert "2100-12-31T23:59:59Z" in args_str
+
+    def test_end_date_only(self):
+        """Only --end-date: range goes from far past to end."""
+        runner = CliRunner()
+        mock_catalog = _mock_catalog([_fake_pystac_item("item-001")])
+        with (
+            patch("pystac_client.Client.open", return_value=mock_catalog),
+            patch("change_storage_tier.process_stac_item", return_value=S3_ZERO_STATS),
+        ):
+            runner.invoke(
+                collection_cli,
+                COLL_BASE_ARGS
+                + [
+                    "--storage-class",
+                    "STANDARD_IA",
+                    "--s3-endpoint",
+                    S3_ENDPOINT,
+                    "--end-date",
+                    "2024-03-31",
+                    "--dry-run",
+                    "-y",
+                ],
+            )
+        filter_arg = mock_catalog.search.call_args.kwargs["filter"]
+        args_str = str(filter_arg)
+        assert "1900-01-01T00:00:00Z" in args_str
+        assert "2024-03-31T23:59:59Z" in args_str
+
+    def test_dry_run_no_stac_update(self):
+        """In dry-run mode, STAC DELETE+POST must not be called for any item."""
+        runner = CliRunner()
+        items = [_fake_pystac_item(f"item-{i:03d}") for i in range(3)]
+        mock_catalog = _mock_catalog(items)
+        with (
+            patch("pystac_client.Client.open", return_value=mock_catalog),
+            patch("change_storage_tier.process_stac_item", return_value=S3_SUCCESS_STATS),
+            patch("update_stac_storage_tier.update_item_storage_tiers") as mock_update,
+            patch("requests.Session.delete") as mock_delete,
+            patch("requests.Session.post") as mock_post,
+        ):
+            runner.invoke(
+                collection_cli,
+                COLL_BASE_ARGS
+                + [
+                    "--storage-class",
+                    "STANDARD_IA",
+                    "--s3-endpoint",
+                    S3_ENDPOINT,
+                    "--dry-run",
+                    "-y",
+                ],
+            )
+        mock_update.assert_not_called()
+        mock_delete.assert_not_called()
+        mock_post.assert_not_called()
+
+    def test_per_item_failure_tracking(self):
+        """One item fails S3 change; summary reports correct counts and failed item ID."""
+        runner = CliRunner()
+        items = [_fake_pystac_item(f"item-{i:03d}") for i in range(3)]
+        mock_catalog = _mock_catalog(items)
+
+        def _psi_side_effect(url, *args, **kwargs):
+            return S3_FAILURE_STATS if "item-000" in url else S3_SUCCESS_STATS
+
+        with (
+            patch("pystac_client.Client.open", return_value=mock_catalog),
+            patch("change_storage_tier.process_stac_item", side_effect=_psi_side_effect),
+            patch("manage_item.STACItemManager.get_item", return_value=FAKE_ITEM_DICT),
+            patch("update_stac_storage_tier.update_item_storage_tiers"),
+            patch("requests.Session.delete", return_value=MagicMock()),
+            patch("requests.Session.post", return_value=MagicMock()),
+        ):
+            result = runner.invoke(
+                collection_cli,
+                COLL_BASE_ARGS
+                + [
+                    "--storage-class",
+                    "STANDARD_IA",
+                    "--s3-endpoint",
+                    S3_ENDPOINT,
+                    "-y",
+                ],
+            )
+        assert "Items failed: 1" in result.output
+        assert "item-000" in result.output
+        assert "Items changed: 2" in result.output
+
+    def test_confirmation_with_item_count(self):
+        """Confirmation prompt includes the number of matched items."""
+        runner = CliRunner()
+        items = [_fake_pystac_item(f"item-{i:03d}") for i in range(5)]
+        mock_catalog = _mock_catalog(items)
+        with patch("pystac_client.Client.open", return_value=mock_catalog):
+            result = runner.invoke(
+                collection_cli,
+                COLL_BASE_ARGS + ["--storage-class", "STANDARD_IA", "--s3-endpoint", S3_ENDPOINT],
+                input="n\n",
+            )
+        assert "5" in result.output
+        assert "Continue?" in result.output
+
+    def test_empty_search_results(self):
+        """When no items match, exit gracefully with a message."""
+        runner = CliRunner()
+        mock_catalog = _mock_catalog([])
+        with patch("pystac_client.Client.open", return_value=mock_catalog):
+            result = runner.invoke(
+                collection_cli,
+                COLL_BASE_ARGS
+                + ["--storage-class", "STANDARD_IA", "--s3-endpoint", S3_ENDPOINT, "-y"],
+            )
+        assert result.exit_code == 0
+        assert "No items matched" in result.output


### PR DESCRIPTION
## Summary

- **Add `change-storage-tier` CLI commands** to both `manage_item.py` (single item) and `manage_collections.py` (collection-level with optional date filtering) in `operator-tools/`. These commands change S3 object storage classes (STANDARD, STANDARD_IA, EXPRESS_ONEZONE) and update STAC metadata to reflect the new tier.
- **Remove `fix_zarr_asset_media_types()`** from both `register_v0.py` and `register_v1.py` — the upstream source now provides correct media types, so runtime patching is no longer needed. The test fixture was updated accordingly.
- **Remove `aggregate_items.py`** script and its documentation/tests — this aggregation functionality is no longer used.
- **Fix URL encoding** in S2 visualization/thumbnail query strings (`%20` → `+`) in both registration scripts.

## Details

### New `change-storage-tier` commands

**Single item** (`manage_item.py change-storage-tier`):
- Changes S3 storage class for all objects in a STAC item's Zarr store
- Updates STAC item metadata only if all S3 operations succeed (zero failures)
- Supports `--include-pattern` / `--exclude-pattern` for filtering objects
- Safety: requires confirmation prompt unless `--dry-run` or `-y` is passed

**Collection-level** (`manage_collections.py change-storage-tier`):
- Operates across all items in a collection
- Optional `--start-date` / `--end-date` filtering via CQL2 `between` query
- Progress bar and per-item failure tracking with summary report

### Cleanup
- Removed `aggregate_items.py`, its README, and 348 lines of tests
- Removed `fix_zarr_asset_media_types()` and its 106-line test file
- Fixed test fixture media types to match upstream corrections

## Test plan

- [x] Added 21 unit tests for the new CLI commands (`test_change_storage_tier_commands.py`)
- [x] Verify `uv run pytest` passes
- [x] Manual dry-run test of `change-storage-tier` against staging collection
