### PR TITLE
feat: add aggregation tool for daily and monthly item counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,11 @@ scripts/
 ├── register_v0.py             # Basic STAC registration (V0 pipeline)
 ├── register_v1.py             # Enhanced STAC registration (V1 pipeline)
 ├── change_storage_tier.py     # S3 storage tier optimization (V1 pipeline step 3)
+├── aggregate_items.py         # Pre-compute daily/monthly item aggregations for timeline UI
 ├── test_complete_workflow.py  # Workflow testing script
 ├── test_gateway_format.py     # Gateway format testing
-└── README_storage_tier.md     # Storage tier management documentation
+├── README_change_storage_tier.md  # Storage tier management documentation
+└── README_aggregate_items.md      # Item aggregation documentation
 
 operator-tools/
 ├── manage_collections.py           # STAC collection management (create/clean/update)
@@ -269,7 +271,8 @@ For infrastructure issues, see platform-deploy troubleshooting: [staging](https:
 ## Documentation
 
 - **Operator Tools:** [operator-tools/README.md](operator-tools/README.md) - Workflow submission and collection management
-- **Storage Management:** [scripts/README_storage_tier.md](scripts/README_storage_tier.md) - S3 storage tier optimization
+- **Storage Management:** [scripts/README_change_storage_tier.md](scripts/README_change_storage_tier.md) - S3 storage tier optimization
+- **Item Aggregations:** [scripts/README_aggregate_items.md](scripts/README_aggregate_items.md) - Pre-computed timeline aggregations
 - **Tests:** `tests/` - pytest unit and integration tests
 - **Deployment:** [platform-deploy/workspaces/devseed-staging/data-pipeline](https://github.com/EOPF-Explorer/platform-deploy/tree/main/workspaces/devseed-staging/data-pipeline)
 

--- a/scripts/README_aggregate_items.md
+++ b/scripts/README_aggregate_items.md
@@ -1,0 +1,250 @@
+# Pre-compute STAC Item Aggregations
+
+## Overview
+
+The `aggregate_items.py` script pre-computes daily and monthly item counts for a STAC collection and stores them as static JSON files on S3. This enables the EOPF Explorer timeline UI to quickly show when satellite data is available, without querying potentially hundreds of thousands of items at runtime.
+
+The script also adds discoverable `rel: "pre-aggregation"` links to the STAC collection, so the Explorer UI can find the aggregation files automatically.
+
+**Why pre-compute?** pgSTAC doesn't support the [STAC Aggregation Extension](https://github.com/stac-api-extensions/aggregation) ([pgstac#257](https://github.com/stac-utils/pgstac/issues/257)), and collections like `sentinel-2-l2a` have >500 items/day, making client-side counting unsustainable.
+
+## Requirements
+
+The script requires the following Python packages:
+- `pystac-client` - STAC API client (item querying)
+- `boto3` - AWS SDK for Python (S3 upload)
+- `httpx` - HTTP client (collection update via Transaction API)
+- `uv` - Python package installer and runner
+
+All dependencies are managed via `uv` and will be automatically installed when running the script.
+
+## Environment Setup
+
+### Credentials for OVH Cloud Storage
+
+Configure your credentials to access OVH cloud storage using one of these methods:
+
+```bash
+# Option 1: Environment variables
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+
+# Option 2: AWS CLI configuration
+aws configure
+```
+
+### S3 Endpoint (Optional)
+
+If using a custom S3-compatible service:
+
+```bash
+export AWS_ENDPOINT_URL="https://s3.de.io.cloud.ovh.net"
+```
+
+Or specify via command line:
+
+```bash
+uv run python scripts/aggregate_items.py \
+    --s3-endpoint https://s3.de.io.cloud.ovh.net \
+    ...
+```
+
+## Usage
+
+### CLI Arguments
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--collection` | Yes | — | Collection ID (e.g. `sentinel-2-l2a`) |
+| `--stac-api-url` | Yes | — | STAC API base URL |
+| `--s3-bucket` | Yes | — | S3 bucket for output files |
+| `--s3-prefix` | No | `aggregations` | S3 key prefix |
+| `--s3-endpoint` | No | `AWS_ENDPOINT_URL` env var | S3 endpoint URL |
+| `--s3-gateway-url` | No | `https://s3.explorer.eopf.copernicus.eu` | Public HTTPS gateway for S3 |
+| `--dry-run` | No | `false` | Generate JSON to stdout, skip upload and collection update |
+
+### Dry Run
+
+Preview the aggregation output without uploading to S3 or modifying the collection:
+
+```bash
+uv run python scripts/aggregate_items.py \
+    --collection sentinel-2-l2a \
+    --stac-api-url https://api.explorer.eopf.copernicus.eu/stac \
+    --s3-bucket esa-zarr-sentinel-explorer-fra \
+    --dry-run
+```
+
+Output example:
+```
+2026-03-03 10:00:01 - __main__ - INFO - Querying items for collection: sentinel-2-l2a
+2026-03-03 10:00:03 - __main__ - INFO - Processed 1000 items so far...
+2026-03-03 10:00:05 - __main__ - INFO - Processed 2000 items so far...
+...
+2026-03-03 10:01:15 - __main__ - INFO - Total items counted: 45230
+2026-03-03 10:01:15 - __main__ - INFO - Daily buckets: 312
+2026-03-03 10:01:15 - __main__ - INFO - Monthly buckets: 14
+2026-03-03 10:01:15 - __main__ - INFO - Dry run - printing daily aggregation to stdout
+{
+  "type": "AggregationCollection",
+  "aggregations": [
+    {
+      "key": "datetime_daily",
+      "buckets": [
+        {"key": "2024-11-15T00:00:00.000Z", "value": 127},
+        {"key": "2024-11-16T00:00:00.000Z", "value": 543},
+        ...
+      ],
+      "interval": "daily"
+    }
+  ]
+}
+```
+
+### Full Run (Upload to S3 + Update Collection)
+
+```bash
+uv run python scripts/aggregate_items.py \
+    --collection sentinel-2-l2a \
+    --stac-api-url https://api.explorer.eopf.copernicus.eu/stac \
+    --s3-bucket esa-zarr-sentinel-explorer-fra \
+    --s3-prefix aggregations \
+    --s3-endpoint https://s3.de.io.cloud.ovh.net
+```
+
+Output example:
+```
+2026-03-03 10:00:01 - __main__ - INFO - Querying items for collection: sentinel-2-l2a
+...
+2026-03-03 10:01:15 - __main__ - INFO - Total items counted: 45230
+2026-03-03 10:01:15 - __main__ - INFO - Daily buckets: 312
+2026-03-03 10:01:15 - __main__ - INFO - Monthly buckets: 14
+2026-03-03 10:01:16 - __main__ - INFO - Uploaded s3://esa-zarr-sentinel-explorer-fra/aggregations/sentinel-2-l2a/daily.json (28.4 KB)
+2026-03-03 10:01:16 - __main__ - INFO - Uploaded s3://esa-zarr-sentinel-explorer-fra/aggregations/sentinel-2-l2a/monthly.json (1.2 KB)
+2026-03-03 10:01:17 - __main__ - INFO - Updated collection sentinel-2-l2a with pre-aggregation links
+2026-03-03 10:01:17 - __main__ - INFO - Aggregation complete
+```
+
+## How It Works
+
+1. **Query all items** using `pystac_client.Client.search()` with the `fields` extension (only fetches `datetime`), paginating with a page size of 1000 for efficiency
+2. **Count by day** using `collections.Counter` keyed by `YYYY-MM-DD`
+3. **Build daily JSON** — sorted chronologically, formatted as `AggregationCollection`
+4. **Build monthly JSON** — derived from daily counts by summing per `YYYY-MM`
+5. **Upload to S3** — `s3://{bucket}/{prefix}/{collection}/daily.json` and `monthly.json`
+6. **Update collection links** — fetches collection via `GET`, removes existing `pre-aggregation` links, adds new ones, `PUT`s back
+
+The script is **idempotent**: running it twice produces the same result (overwrites S3 files, replaces links).
+
+## JSON Output Format
+
+Both daily and monthly files follow the [STAC Aggregation Extension](https://github.com/stac-api-extensions/aggregation) bucket format:
+
+```json
+{
+  "type": "AggregationCollection",
+  "aggregations": [
+    {
+      "key": "datetime_daily",
+      "buckets": [
+        {"key": "2026-01-01T00:00:00.000Z", "value": 523},
+        {"key": "2026-01-02T00:00:00.000Z", "value": 487}
+      ],
+      "interval": "daily"
+    }
+  ]
+}
+```
+
+- `key`: ISO 8601 timestamp for the bucket start
+- `value`: integer count of items in that bucket
+
+## Collection Links
+
+After a full run, the collection will have two `rel: "pre-aggregation"` links:
+
+```json
+{
+  "rel": "pre-aggregation",
+  "href": "https://s3.explorer.eopf.copernicus.eu/{bucket}/aggregations/{collection}/daily.json",
+  "type": "application/json",
+  "title": "Daily Item Aggregation",
+  "aggregation:interval": "daily"
+}
+```
+
+```json
+{
+  "rel": "pre-aggregation",
+  "href": "https://s3.explorer.eopf.copernicus.eu/{bucket}/aggregations/{collection}/monthly.json",
+  "type": "application/json",
+  "title": "Monthly Item Aggregation",
+  "aggregation:interval": "monthly"
+}
+```
+
+**Note:** We use `rel: "pre-aggregation"` (not `rel: "aggregate"`) to avoid conflicting with the official STAC Aggregation Extension, which uses `rel: "aggregate"` for dynamic API endpoints. Our static files are semantically different.
+
+## Verification
+
+After running the script, verify the results:
+
+```bash
+# Check the JSON files are accessible
+curl -s https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/aggregations/sentinel-2-l2a/daily.json | python -m json.tool | head -10
+
+# Check the collection has pre-aggregation links
+curl -s https://api.explorer.eopf.copernicus.eu/stac/collections/sentinel-2-l2a | python -m json.tool | grep -A4 pre-aggregation
+```
+
+## Error Handling
+
+The script handles various error conditions:
+- Empty collections (returns exit code 0, no files uploaded)
+- Items without a `datetime` field (skipped with a warning)
+- S3 upload failures
+- STAC API connectivity issues
+
+The script returns:
+- Exit code `0` - Success
+- Exit code `1` - Failure
+
+## Logging
+
+The script provides detailed logging at different levels:
+- `INFO` - Progress, item counts, upload confirmations
+- `DEBUG` - Individual item processing details
+- `WARNING` - Skipped items (missing datetime)
+- `ERROR` - Failures
+
+Set the `LOG_LEVEL` environment variable to control verbosity:
+
+```bash
+LOG_LEVEL=DEBUG uv run python scripts/aggregate_items.py \
+    --collection sentinel-2-l2a \
+    --stac-api-url https://api.explorer.eopf.copernicus.eu/stac \
+    --s3-bucket esa-zarr-sentinel-explorer-fra \
+    --dry-run
+```
+
+## Integration in Workflow
+
+This script can be run periodically (e.g. daily via cron or CI) to keep aggregations up to date:
+
+```bash
+# Update aggregations for sentinel-2-l2a
+uv run python scripts/aggregate_items.py \
+    --collection sentinel-2-l2a \
+    --stac-api-url https://api.explorer.eopf.copernicus.eu/stac \
+    --s3-bucket esa-zarr-sentinel-explorer-fra \
+    --s3-prefix aggregations \
+    --s3-endpoint https://s3.de.io.cloud.ovh.net
+
+# Update aggregations for sentinel-1-grd
+uv run python scripts/aggregate_items.py \
+    --collection sentinel-1-grd \
+    --stac-api-url https://api.explorer.eopf.copernicus.eu/stac \
+    --s3-bucket esa-zarr-sentinel-explorer-fra \
+    --s3-prefix aggregations \
+    --s3-endpoint https://s3.de.io.cloud.ovh.net
+```

--- a/scripts/aggregate_items.py
+++ b/scripts/aggregate_items.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Pre-compute STAC item aggregations (daily/monthly counts) for timeline UI.
+
+Queries all items in a STAC collection, counts them by date, and produces
+static JSON files following the STAC Aggregation Extension format. Uploads
+the results to S3 and adds discoverable links to the STAC collection.
+
+Usage:
+    python scripts/aggregate_items.py \
+        --collection sentinel-2-l2a \
+        --stac-api-url https://api.explorer.eopf.copernicus.eu/stac \
+        --s3-bucket esa-zarr-sentinel-explorer-fra \
+        --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import logging
+import os
+import sys
+
+import boto3
+import httpx
+from pystac_client import Client
+
+# Configure logging (set LOG_LEVEL=DEBUG for verbose output)
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Suppress verbose library logging
+for _lib in ["botocore", "s3fs", "aiobotocore", "urllib3", "httpx", "httpcore"]:
+    logging.getLogger(_lib).setLevel(logging.WARNING)
+
+
+def count_items_by_datetime(stac_api_url: str, collection_id: str) -> collections.Counter[str]:
+    """Query all items and count them by date (YYYY-MM-DD).
+
+    Uses the STAC ``fields`` extension to fetch only ``datetime``, keeping
+    payloads minimal for large collections.
+    """
+    catalog = Client.open(stac_api_url)
+    search = catalog.search(
+        collections=[collection_id],
+        fields={"includes": ["datetime", "properties.datetime"], "excludes": []},
+        limit=1000,
+    )
+
+    counts: collections.Counter[str] = collections.Counter()
+    total = 0
+
+    for page in search.pages():
+        page_items = list(page.items)
+        for item in page_items:
+            dt = item.datetime
+            if dt is None:
+                # Fallback: try properties.datetime string
+                dt_str = item.properties.get("datetime")
+                if dt_str:
+                    day = dt_str[:10]  # YYYY-MM-DD
+                    counts[day] += 1
+                    total += 1
+                    continue
+                logger.warning(f"Skipping item {item.id}: no datetime")
+                continue
+            counts[dt.strftime("%Y-%m-%d")] += 1
+            total += 1
+
+        if total > 0 and total % 1000 < len(page_items):
+            logger.info(f"Processed {total} items so far...")
+
+    logger.info(f"Total items counted: {total}")
+    return counts
+
+
+def build_daily_aggregation(daily_counts: collections.Counter[str]) -> dict:
+    """Build daily AggregationCollection from per-day counts."""
+    buckets = [
+        {"key": f"{day}T00:00:00.000Z", "value": count}
+        for day, count in sorted(daily_counts.items())
+    ]
+    return {
+        "type": "AggregationCollection",
+        "aggregations": [
+            {
+                "key": "datetime_daily",
+                "buckets": buckets,
+                "interval": "daily",
+            }
+        ],
+    }
+
+
+def build_monthly_aggregation(daily_counts: collections.Counter[str]) -> dict:
+    """Build monthly AggregationCollection by summing daily counts per month."""
+    monthly: collections.Counter[str] = collections.Counter()
+    for day, count in daily_counts.items():
+        month = day[:7]  # YYYY-MM
+        monthly[month] += count
+
+    buckets = [
+        {"key": f"{month}-01T00:00:00.000Z", "value": count}
+        for month, count in sorted(monthly.items())
+    ]
+    return {
+        "type": "AggregationCollection",
+        "aggregations": [
+            {
+                "key": "datetime_monthly",
+                "buckets": buckets,
+                "interval": "monthly",
+            }
+        ],
+    }
+
+
+def upload_to_s3(data: dict, bucket: str, key: str, s3_endpoint: str | None = None) -> None:
+    """Upload JSON data to S3."""
+    s3_config: dict = {}
+    if s3_endpoint:
+        s3_config["endpoint_url"] = s3_endpoint
+    elif os.getenv("AWS_ENDPOINT_URL"):
+        s3_config["endpoint_url"] = os.getenv("AWS_ENDPOINT_URL")
+
+    s3_client = boto3.client("s3", **s3_config)
+    body = json.dumps(data, separators=(",", ":")).encode()
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body,
+        ContentType="application/json",
+    )
+    size_kb = len(body) / 1024
+    logger.info(f"Uploaded s3://{bucket}/{key} ({size_kb:.1f} KB)")
+
+
+def update_collection_links(
+    stac_api_url: str,
+    collection_id: str,
+    s3_gateway_url: str,
+    s3_bucket: str,
+    s3_prefix: str,
+) -> None:
+    """Fetch collection, replace pre-aggregation links, and PUT back."""
+    base_url = stac_api_url.rstrip("/")
+    collection_url = f"{base_url}/collections/{collection_id}"
+
+    with httpx.Client(timeout=30.0, follow_redirects=True) as http:
+        resp = http.get(collection_url)
+        resp.raise_for_status()
+        collection_data = resp.json()
+
+        # Remove existing pre-aggregation links
+        links = [
+            link
+            for link in collection_data.get("links", [])
+            if link.get("rel") != "pre-aggregation"
+        ]
+
+        # Add new pre-aggregation links
+        gateway_base = s3_gateway_url.rstrip("/")
+        path_prefix = f"{s3_bucket}/{s3_prefix}/{collection_id}"
+
+        links.append(
+            {
+                "rel": "pre-aggregation",
+                "href": f"{gateway_base}/{path_prefix}/daily.json",
+                "type": "application/json",
+                "title": "Daily Item Aggregation",
+                "aggregation:interval": "daily",
+            }
+        )
+        links.append(
+            {
+                "rel": "pre-aggregation",
+                "href": f"{gateway_base}/{path_prefix}/monthly.json",
+                "type": "application/json",
+                "title": "Monthly Item Aggregation",
+                "aggregation:interval": "monthly",
+            }
+        )
+
+        collection_data["links"] = links
+
+        put_resp = http.put(
+            collection_url,
+            json=collection_data,
+            headers={"Content-Type": "application/json"},
+        )
+        put_resp.raise_for_status()
+
+    logger.info(f"Updated collection {collection_id} with pre-aggregation links")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Pre-compute STAC item aggregations for timeline UI"
+    )
+    parser.add_argument("--collection", required=True, help="Collection ID")
+    parser.add_argument("--stac-api-url", required=True, help="STAC API base URL")
+    parser.add_argument("--s3-bucket", required=True, help="S3 bucket for output")
+    parser.add_argument(
+        "--s3-prefix", default="aggregations", help="S3 key prefix (default: aggregations)"
+    )
+    parser.add_argument(
+        "--s3-endpoint", default=None, help="S3 endpoint URL (falls back to AWS_ENDPOINT_URL)"
+    )
+    parser.add_argument(
+        "--s3-gateway-url",
+        default="https://s3.explorer.eopf.copernicus.eu",
+        help="Public HTTPS gateway for S3",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate JSON to stdout, skip upload and collection update",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        logger.info(f"Querying items for collection: {args.collection}")
+        daily_counts = count_items_by_datetime(args.stac_api_url, args.collection)
+
+        if not daily_counts:
+            logger.info("No items found, nothing to aggregate")
+            return 0
+
+        daily_agg = build_daily_aggregation(daily_counts)
+        monthly_agg = build_monthly_aggregation(daily_counts)
+
+        daily_buckets = len(daily_agg["aggregations"][0]["buckets"])
+        monthly_buckets = len(monthly_agg["aggregations"][0]["buckets"])
+        logger.info(f"Daily buckets: {daily_buckets}")
+        logger.info(f"Monthly buckets: {monthly_buckets}")
+
+        if args.dry_run:
+            logger.info("Dry run - printing daily aggregation to stdout")
+            json.dump(daily_agg, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+            logger.info("Dry run - printing monthly aggregation to stdout")
+            json.dump(monthly_agg, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+            return 0
+
+        # Upload to S3
+        prefix = f"{args.s3_prefix}/{args.collection}"
+        upload_to_s3(daily_agg, args.s3_bucket, f"{prefix}/daily.json", args.s3_endpoint)
+        upload_to_s3(monthly_agg, args.s3_bucket, f"{prefix}/monthly.json", args.s3_endpoint)
+
+        # Update collection links
+        update_collection_links(
+            args.stac_api_url,
+            args.collection,
+            args.s3_gateway_url,
+            args.s3_bucket,
+            args.s3_prefix,
+        )
+
+        logger.info("Aggregation complete")
+        return 0
+    except Exception as e:
+        logger.error(f"Aggregation failed: {e}", exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_aggregate_items.py
+++ b/tests/unit/test_aggregate_items.py
@@ -1,0 +1,348 @@
+"""Tests for scripts/aggregate_items.py."""
+
+import collections
+from datetime import datetime
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from pystac import Item
+
+from scripts.aggregate_items import (
+    build_daily_aggregation,
+    build_monthly_aggregation,
+    count_items_by_datetime,
+    main,
+    update_collection_links,
+)
+
+
+def _make_item(item_id: str, dt: datetime | None = None, dt_str: str | None = None) -> Item:
+    """Create a minimal STAC item with a datetime.
+
+    When *dt* is None, pystac requires start/end_datetime — we supply dummy
+    values so the Item can be constructed for testing fallback paths.
+    """
+    props: dict = {}
+    extra_kwargs: dict = {}
+    if dt_str:
+        props["datetime"] = dt_str
+    if dt is None:
+        # pystac enforces: if datetime is None, start/end must be provided
+        extra_kwargs["start_datetime"] = datetime(2000, 1, 1)
+        extra_kwargs["end_datetime"] = datetime(2000, 1, 2)
+    item = Item(
+        id=item_id,
+        geometry={"type": "Point", "coordinates": [0, 0]},
+        bbox=[0, 0, 0, 0],
+        datetime=dt,
+        properties=props,
+        **extra_kwargs,
+    )
+    return item
+
+
+class FakeItemSearch:
+    """Simulates STAC search results for aggregation tests."""
+
+    def __init__(self, items: list[Item]):
+        self._items = items
+
+    def pages(self):
+        return [SimpleNamespace(items=self._items)]
+
+
+class FakeStacClient:
+    """Simulates a pystac_client.Client."""
+
+    def __init__(self, items: list[Item]):
+        self._items = items
+        self.search_calls: list[dict] = []
+
+    def search(self, **kwargs):
+        self.search_calls.append(kwargs)
+        return FakeItemSearch(self._items)
+
+
+# --- Pure function tests (no mocking) ---
+
+
+class TestBuildDailyAggregation:
+    def test_format(self):
+        counts: collections.Counter[str] = collections.Counter({"2026-01-15": 10, "2026-01-16": 20})
+        result = build_daily_aggregation(counts)
+
+        assert result["type"] == "AggregationCollection"
+        assert len(result["aggregations"]) == 1
+        agg = result["aggregations"][0]
+        assert agg["key"] == "datetime_daily"
+        assert agg["interval"] == "daily"
+        assert len(agg["buckets"]) == 2
+        assert agg["buckets"][0] == {"key": "2026-01-15T00:00:00.000Z", "value": 10}
+        assert agg["buckets"][1] == {"key": "2026-01-16T00:00:00.000Z", "value": 20}
+
+    def test_empty_counter(self):
+        result = build_daily_aggregation(collections.Counter())
+        assert result["aggregations"][0]["buckets"] == []
+
+    def test_sorted_chronologically(self):
+        counts: collections.Counter[str] = collections.Counter(
+            {"2026-03-01": 1, "2025-12-01": 2, "2026-01-15": 3}
+        )
+        result = build_daily_aggregation(counts)
+        keys = [b["key"] for b in result["aggregations"][0]["buckets"]]
+        assert keys == [
+            "2025-12-01T00:00:00.000Z",
+            "2026-01-15T00:00:00.000Z",
+            "2026-03-01T00:00:00.000Z",
+        ]
+
+    def test_values_are_integers(self):
+        counts: collections.Counter[str] = collections.Counter({"2026-01-01": 523})
+        result = build_daily_aggregation(counts)
+        value = result["aggregations"][0]["buckets"][0]["value"]
+        assert isinstance(value, int)
+        assert value == 523
+
+
+class TestBuildMonthlyAggregation:
+    def test_sums_days_correctly(self):
+        counts: collections.Counter[str] = collections.Counter(
+            {"2026-01-15": 10, "2026-01-16": 20, "2026-02-01": 5}
+        )
+        result = build_monthly_aggregation(counts)
+
+        agg = result["aggregations"][0]
+        assert agg["key"] == "datetime_monthly"
+        assert agg["interval"] == "monthly"
+        assert len(agg["buckets"]) == 2
+        assert agg["buckets"][0] == {"key": "2026-01-01T00:00:00.000Z", "value": 30}
+        assert agg["buckets"][1] == {"key": "2026-02-01T00:00:00.000Z", "value": 5}
+
+    def test_sorted_chronologically(self):
+        counts: collections.Counter[str] = collections.Counter(
+            {"2026-03-01": 1, "2025-12-15": 2, "2026-01-10": 3}
+        )
+        result = build_monthly_aggregation(counts)
+        keys = [b["key"] for b in result["aggregations"][0]["buckets"]]
+        assert keys == [
+            "2025-12-01T00:00:00.000Z",
+            "2026-01-01T00:00:00.000Z",
+            "2026-03-01T00:00:00.000Z",
+        ]
+
+    def test_empty_counter(self):
+        result = build_monthly_aggregation(collections.Counter())
+        assert result["aggregations"][0]["buckets"] == []
+
+
+# --- Mocked STAC tests ---
+
+
+class TestCountItemsByDatetime:
+    def test_counts_items_by_date(self):
+        items = [
+            _make_item("a", dt=datetime(2026, 1, 15, 10, 0)),
+            _make_item("b", dt=datetime(2026, 1, 15, 11, 0)),
+            _make_item("c", dt=datetime(2026, 1, 16, 9, 0)),
+        ]
+        client = FakeStacClient(items)
+
+        with patch("scripts.aggregate_items.Client.open", return_value=client):
+            result = count_items_by_datetime("https://stac.test", "test-collection")
+
+        assert result["2026-01-15"] == 2
+        assert result["2026-01-16"] == 1
+
+    def test_falls_back_to_properties_datetime(self):
+        items = [
+            _make_item("a", dt=None, dt_str="2026-02-20T12:00:00Z"),
+        ]
+        client = FakeStacClient(items)
+
+        with patch("scripts.aggregate_items.Client.open", return_value=client):
+            result = count_items_by_datetime("https://stac.test", "test-collection")
+
+        assert result["2026-02-20"] == 1
+
+    def test_skips_items_without_datetime(self):
+        items = [
+            _make_item("a", dt=None),
+            _make_item("b", dt=datetime(2026, 1, 1, 0, 0)),
+        ]
+        client = FakeStacClient(items)
+
+        with patch("scripts.aggregate_items.Client.open", return_value=client):
+            result = count_items_by_datetime("https://stac.test", "test-collection")
+
+        assert result["2026-01-01"] == 1
+        assert len(result) == 1
+
+    def test_passes_fields_and_limit(self):
+        client = FakeStacClient([])
+
+        with patch("scripts.aggregate_items.Client.open", return_value=client):
+            count_items_by_datetime("https://stac.test", "my-collection")
+
+        assert len(client.search_calls) == 1
+        call = client.search_calls[0]
+        assert call["collections"] == ["my-collection"]
+        assert call["limit"] == 1000
+        assert "fields" in call
+
+    def test_empty_collection(self):
+        client = FakeStacClient([])
+
+        with patch("scripts.aggregate_items.Client.open", return_value=client):
+            result = count_items_by_datetime("https://stac.test", "empty")
+
+        assert len(result) == 0
+
+
+# --- Collection link tests ---
+
+
+class TestUpdateCollectionLinks:
+    def test_removes_old_pre_aggregation_links(self):
+        collection_data = {
+            "id": "test",
+            "links": [
+                {"rel": "self", "href": "https://api.test/collections/test"},
+                {"rel": "pre-aggregation", "href": "https://old/daily.json"},
+                {"rel": "root", "href": "https://api.test"},
+            ],
+        }
+
+        mock_response_get = MagicMock()
+        mock_response_get.json.return_value = collection_data
+        mock_response_get.raise_for_status = MagicMock()
+
+        mock_response_put = MagicMock()
+        mock_response_put.raise_for_status = MagicMock()
+
+        captured_put_data = {}
+
+        def mock_put(url, json=None, headers=None):  # noqa: ARG001
+            captured_put_data["json"] = json
+            return mock_response_put
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response_get
+        mock_client.put = mock_put
+
+        with patch("scripts.aggregate_items.httpx.Client", return_value=mock_client):
+            update_collection_links(
+                "https://api.test/stac",
+                "test",
+                "https://s3.gateway.test",
+                "my-bucket",
+                "aggregations",
+            )
+
+        links = captured_put_data["json"]["links"]
+        pre_agg_links = [lk for lk in links if lk["rel"] == "pre-aggregation"]
+        other_links = [lk for lk in links if lk["rel"] != "pre-aggregation"]
+
+        # Old pre-aggregation link removed, two new ones added
+        assert len(pre_agg_links) == 2
+        assert pre_agg_links[0]["aggregation:interval"] == "daily"
+        assert pre_agg_links[1]["aggregation:interval"] == "monthly"
+
+        # Other links preserved
+        assert len(other_links) == 2
+        rels = {lk["rel"] for lk in other_links}
+        assert rels == {"self", "root"}
+
+    def test_link_hrefs(self):
+        collection_data = {"id": "s2", "links": []}
+
+        mock_response_get = MagicMock()
+        mock_response_get.json.return_value = collection_data
+        mock_response_get.raise_for_status = MagicMock()
+
+        mock_response_put = MagicMock()
+        mock_response_put.raise_for_status = MagicMock()
+
+        captured_put_data = {}
+
+        def mock_put(url, json=None, headers=None):  # noqa: ARG001
+            captured_put_data["json"] = json
+            return mock_response_put
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response_get
+        mock_client.put = mock_put
+
+        with patch("scripts.aggregate_items.httpx.Client", return_value=mock_client):
+            update_collection_links(
+                "https://api.test/stac",
+                "s2",
+                "https://s3.explorer.eopf.copernicus.eu",
+                "my-bucket",
+                "agg",
+            )
+
+        links = captured_put_data["json"]["links"]
+        assert links[0]["href"] == (
+            "https://s3.explorer.eopf.copernicus.eu/my-bucket/agg/s2/daily.json"
+        )
+        assert links[1]["href"] == (
+            "https://s3.explorer.eopf.copernicus.eu/my-bucket/agg/s2/monthly.json"
+        )
+
+
+# --- Integration tests (main with --dry-run) ---
+
+
+class TestMainDryRun:
+    def test_dry_run_outputs_json(self):
+        items = [
+            _make_item("a", dt=datetime(2026, 1, 15, 10, 0)),
+            _make_item("b", dt=datetime(2026, 1, 16, 11, 0)),
+        ]
+        client = FakeStacClient(items)
+
+        with (
+            patch("scripts.aggregate_items.Client.open", return_value=client),
+            patch("sys.stdout", new_callable=StringIO) as mock_stdout,
+        ):
+            rc = main(
+                [
+                    "--collection",
+                    "test",
+                    "--stac-api-url",
+                    "https://stac.test",
+                    "--s3-bucket",
+                    "bucket",
+                    "--dry-run",
+                ]
+            )
+
+        assert rc == 0
+        output = mock_stdout.getvalue()
+        # Should contain two JSON documents (daily + monthly)
+        assert '"AggregationCollection"' in output
+        assert '"datetime_daily"' in output
+        assert '"datetime_monthly"' in output
+
+    def test_empty_collection_returns_zero(self):
+        client = FakeStacClient([])
+
+        with patch("scripts.aggregate_items.Client.open", return_value=client):
+            rc = main(
+                [
+                    "--collection",
+                    "empty",
+                    "--stac-api-url",
+                    "https://stac.test",
+                    "--s3-bucket",
+                    "bucket",
+                    "--dry-run",
+                ]
+            )
+
+        assert rc == 0


### PR DESCRIPTION
## Summary

### Pre-compute STAC Item Aggregations for Timeline UI

Adds a new standalone script that pre-computes daily and monthly item counts for a STAC collection, uploads them as static JSON files to S3, and adds discoverable `rel: "pre-aggregation"` links to the collection.

**Problem:** The Explorer timeline UI needs to show when satellite data is available, but `sentinel-2-l2a` has >500 items/day — fetching items at runtime is unsustainable, and pgSTAC doesn't support the STAC Aggregation Extension ([pgstac#257](https://github.com/stac-utils/pgstac/issues/257)).

**Solution:** Pre-compute counts as static JSON, serve via S3, discover via collection links.

Closes #96

### Changes
- [x] **`scripts/aggregate_items.py`** — New CLI script: queries items via `pystac-client` (fields extension, 1000/page), counts by date, builds daily/monthly AggregationCollection JSON, uploads to S3, updates collection links via Transaction API
- [x] **`tests/unit/test_aggregate_items.py`** — 16 unit tests covering pure functions, mocked STAC queries, collection link updates, and `--dry-run` integration
- [x] **`scripts/README_aggregate_items.md`** — Dedicated documentation following existing README patterns
- [x] **`README.md`** — Added script and docs to Repository Structure and Documentation sections

### Design decisions
- Uses `rel: "pre-aggregation"` (not `rel: "aggregate"`) to avoid conflicting with the official STAC Aggregation Extension
- Integer `value` fields in buckets (matches official spec format)
- No new dependencies — uses existing `pystac-client`, `boto3`, `httpx`

## Test plan

### Local verification
- [x] `uv run pytest tests/unit/test_aggregate_items.py -v` — all 16 tests pass
- [x] `uv run ruff check scripts/aggregate_items.py tests/unit/test_aggregate_items.py` — no lint errors
- [x] `uv run mypy scripts/aggregate_items.py` — no type errors

### Dry run against staging API
- [x] Run dry run against staging collection:
  ```bash
  uv run python scripts/aggregate_items.py \
      --collection sentinel-2-l2a-staging \
      --stac-api-url https://api.explorer.eopf.copernicus.eu/stac \
      --s3-bucket esa-zarr-sentinel-explorer-fra \
      --dry-run
  ```
- [x] Verify output is valid JSON with `type: "AggregationCollection"`
- [x] Verify daily buckets have `key` in `YYYY-MM-DDT00:00:00.000Z` format and integer `value`
- [x] Verify monthly buckets sum correctly (spot-check a month against daily)

### Full run against staging (upload + collection update)
- [x] Run full execution against staging collection:
  ```bash
  uv run python scripts/aggregate_items.py \
      --collection sentinel-2-l2a-staging \
      --stac-api-url https://api.explorer.eopf.copernicus.eu/stac \
      --s3-bucket esa-zarr-sentinel-explorer-fra \
      --s3-prefix aggregations \
      --s3-endpoint https://s3.de.io.cloud.ovh.net
  ```
- [x] Verify JSON files are accessible at S3 gateway:
  ```bash
  curl -s https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/aggregations/sentinel-2-l2a-staging/daily.json | python3 -m json.tool | head -15
  curl -s https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/aggregations/sentinel-2-l2a-staging/monthly.json | python3 -m json.tool | head -15
  ```
- [x] Verify collection has `pre-aggregation` links:
  ```bash
  curl -s https://api.explorer.eopf.copernicus.eu/stac/collections/sentinel-2-l2a-staging | python3 -m json.tool | grep -A5 pre-aggregation
  ```

### Idempotency
- [x] Run the full command a second time — verify it completes successfully and produces the same result (overwrites S3 files, replaces links, no duplicates)

