### PR TITLE
fix: fix all zarr assets media type and remove zipped_product asset

### DIFF
--- a/scripts/register_v0.py
+++ b/scripts/register_v0.py
@@ -219,6 +219,32 @@ def add_derived_from_link(item: Item, source_url: str) -> None:
     logger.debug(f"Added derived_from link: {source_url}")
 
 
+def fix_zarr_asset_media_types(item: Item) -> None:
+    """Fix media types for zarr assets and remove non-zarr source assets.
+
+    Source STAC items may have incorrect media types (e.g., 'application/vnd+zarr'
+    instead of 'application/vnd.zarr') and assets that don't belong in the
+    converted product (e.g., zipped_product pointing to external download service).
+    """
+    # Fix zarr media types: vnd+zarr -> vnd.zarr; version=3
+    fixed_count = 0
+    for asset in item.assets.values():
+        if asset.media_type == "application/vnd+zarr":
+            asset.media_type = "application/vnd.zarr; version=3"
+            fixed_count += 1
+    if fixed_count > 0:
+        logger.info(f"   🔧 Fixed media type on {fixed_count} zarr asset(s)")
+
+    # Remove assets that reference external services, not our zarr data
+    removed = []
+    for key in list(item.assets.keys()):
+        if key == "zipped_product":
+            item.assets.pop(key)
+            removed.append(key)
+    if removed:
+        logger.info(f"   🗑️  Removed source-only asset(s): {', '.join(removed)}")
+
+
 def remove_xarray_integration(item: Item) -> None:
     """Remove XArray-specific fields from assets (ADR-111 compliance)."""
     removed_count = 0
@@ -303,20 +329,23 @@ def run_registration(
     else:
         logger.warning("   ⚠️  No source zarr found - assets not rewritten")
 
-    # 3. Add projection metadata from zarr
+    # 3. Fix zarr asset media types and remove non-zarr source assets
+    fix_zarr_asset_media_types(item)
+
+    # 4. Add projection metadata from zarr
     add_projection_from_zarr(item)
 
-    # 4. Remove XArray integration fields (ADR-111 compliance)
+    # 5. Remove XArray integration fields (ADR-111 compliance)
     remove_xarray_integration(item)
 
-    # 5. Add visualization links (viewer, xyz, tilejson)
+    # 6. Add visualization links (viewer, xyz, tilejson)
     add_visualization_links(item, raster_api_url, collection)
     logger.info("   🎨 Added visualization links")
 
-    # 6. Add thumbnail asset for STAC browsers
+    # 7. Add thumbnail asset for STAC browsers
     add_thumbnail_asset(item, raster_api_url, collection)
 
-    # 7. Add derived_from link to source item
+    # 8. Add derived_from link to source item
     add_derived_from_link(item, source_url)
 
     # 8. Register to STAC API

--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -341,6 +341,32 @@ def add_derived_from_link(item: Item, source_url: str) -> None:
     logger.debug(f"Added derived_from link: {source_url}")
 
 
+def fix_zarr_asset_media_types(item: Item) -> None:
+    """Fix media types for zarr assets and remove non-zarr source assets.
+
+    Source STAC items may have incorrect media types (e.g., 'application/vnd+zarr'
+    instead of 'application/vnd.zarr') and assets that don't belong in the
+    converted product (e.g., zipped_product pointing to external download service).
+    """
+    # Fix zarr media types: vnd+zarr -> vnd.zarr; version=3
+    fixed_count = 0
+    for asset in item.assets.values():
+        if asset.media_type == "application/vnd+zarr":
+            asset.media_type = "application/vnd.zarr; version=3"
+            fixed_count += 1
+    if fixed_count > 0:
+        logger.info(f"   🔧 Fixed media type on {fixed_count} zarr asset(s)")
+
+    # Remove assets that reference external services, not our zarr data
+    removed = []
+    for key in list(item.assets.keys()):
+        if key == "zipped_product":
+            item.assets.pop(key)
+            removed.append(key)
+    if removed:
+        logger.info(f"   🗑️  Removed source-only asset(s): {', '.join(removed)}")
+
+
 def remove_xarray_integration(item: Item) -> None:
     """Remove XArray-specific fields from assets (ADR-111 compliance)."""
     removed_count = 0
@@ -689,23 +715,26 @@ def run_registration(
     else:
         logger.warning("   ⚠️  No source zarr found - assets not rewritten")
 
-    # 3. Add store link to root Zarr location (best practice)
+    # 3. Fix zarr asset media types and remove zipped_product source asset
+    fix_zarr_asset_media_types(item)
+
+    # 4. Add store link to root Zarr location (best practice)
     add_store_link(item, geozarr_url)
 
-    # 4. Consolidate reflectance assets into single asset with bands/cube metadata
+    # 5. Consolidate reflectance assets into single asset with bands/cube metadata
     consolidate_reflectance_assets(item, geozarr_url)
 
-    # 5. Add projection metadata from zarr
+    # 6. Add projection metadata from zarr
     add_projection_from_zarr(item)
 
-    # 6. Remove XArray integration fields (ADR-111 compliance)
+    # 7. Remove XArray integration fields (ADR-111 compliance)
     remove_xarray_integration(item)
 
-    # 7. Add alternate S3 URLs to assets (alternate-assets + storage extensions)
+    # 8. Add alternate S3 URLs to assets (alternate-assets + storage extensions)
     # This also queries and adds storage:tier to each asset's alternate
     add_alternate_s3_assets(item, s3_endpoint)
 
-    # 8. Add visualization links (viewer, xyz, tilejson)
+    # 9. Add visualization links (viewer, xyz, tilejson)
     add_visualization_links(item, raster_api_url, collection)
     logger.info("   🎨 Added visualization links")
 

--- a/tests/fixtures/stac_to_register/S2A_MSIL2A_20251113T102311_N0511_R065_T32TNQ_20251113T142515.json
+++ b/tests/fixtures/stac_to_register/S2A_MSIL2A_20251113T102311_N0511_R065_T32TNQ_20251113T142515.json
@@ -254,7 +254,7 @@
     "AOT_10m": {
       "gsd": 10,
       "href": "https://objects.eodc.eu:443/e05ab01a9d56408d82ac32d69a5aae2a:202511-s02msil2a-eu/13/products/cpm_v262/S2A_MSIL2A_20251113T102311_N0511_R065_T32TNQ_20251113T142515.zarr/quality/atmosphere/r10m/aot",
-      "type": "application/vnd.zarr",
+      "type": "application/vnd+zarr",
       "roles": ["data"],
       "title": "Aerosol optical thickness (AOT)",
       "nodata": 0,
@@ -518,7 +518,7 @@
     "SCL_20m": {
       "gsd": 20,
       "href": "https://objects.eodc.eu:443/e05ab01a9d56408d82ac32d69a5aae2a:202511-s02msil2a-eu/13/products/cpm_v262/S2A_MSIL2A_20251113T102311_N0511_R065_T32TNQ_20251113T142515.zarr/conditions/mask/l2a_classification/r20m/scl",
-      "type": "application/vnd.zarr",
+      "type": "application/vnd+zarr",
       "roles": ["data"],
       "title": "Scene classification map (SCL)",
       "nodata": 0,
@@ -560,7 +560,7 @@
     "WVP_10m": {
       "gsd": 10,
       "href": "https://objects.eodc.eu:443/e05ab01a9d56408d82ac32d69a5aae2a:202511-s02msil2a-eu/13/products/cpm_v262/S2A_MSIL2A_20251113T102311_N0511_R065_T32TNQ_20251113T142515.zarr/quality/atmosphere/r10m/wvp",
-      "type": "application/vnd.zarr",
+      "type": "application/vnd+zarr",
       "roles": ["data"],
       "title": "Water vapour (WVP)",
       "nodata": 0,

--- a/tests/test_fix_zarr_assets.py
+++ b/tests/test_fix_zarr_assets.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Unit tests for fix_zarr_asset_media_types function."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pystac import Asset, Item
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from register_v1 import fix_zarr_asset_media_types
+
+
+def get_fixture_files():
+    """Get all STAC item fixture files."""
+    fixtures_dir = Path(__file__).parent / "fixtures" / "stac_to_register"
+    return list(fixtures_dir.glob("*.json"))
+
+
+@pytest.fixture(params=get_fixture_files())
+def stac_item(request):
+    """Load a STAC item from fixtures."""
+    with open(request.param) as f:
+        return Item.from_dict(json.load(f))
+
+
+class TestFixZarrAssetMediaTypes:
+    """Test suite for fix_zarr_asset_media_types function."""
+
+    def test_fixes_vnd_plus_zarr_media_type(self, stac_item):
+        """Test that application/vnd+zarr is corrected to application/vnd.zarr; version=3."""
+        # Verify fixture has wrong media type before fix
+        wrong_assets = [
+            key
+            for key, asset in stac_item.assets.items()
+            if asset.media_type == "application/vnd+zarr"
+        ]
+        assert len(wrong_assets) > 0, "Fixture should have assets with wrong media type"
+
+        fix_zarr_asset_media_types(stac_item)
+
+        # No assets should have the wrong media type after fix
+        for key, asset in stac_item.assets.items():
+            assert (
+                asset.media_type != "application/vnd+zarr"
+            ), f"Asset {key} still has wrong media type"
+
+    def test_aot_scl_wvp_get_version_3(self, stac_item):
+        """Test that AOT, SCL, WVP assets get version=3 in media type."""
+        fix_zarr_asset_media_types(stac_item)
+
+        for key in ["AOT_10m", "SCL_20m", "WVP_10m"]:
+            if key in stac_item.assets:
+                assert (
+                    stac_item.assets[key].media_type == "application/vnd.zarr; version=3"
+                ), f"Asset {key} should have 'application/vnd.zarr; version=3'"
+
+    def test_removes_zipped_product_asset(self, stac_item):
+        """Test that zipped_product asset is removed."""
+        assert "zipped_product" in stac_item.assets, "Fixture should have zipped_product"
+
+        fix_zarr_asset_media_types(stac_item)
+
+        assert "zipped_product" not in stac_item.assets, "zipped_product should be removed"
+
+    def test_preserves_correct_zarr_media_types(self):
+        """Test that assets with correct media type are not modified."""
+        item = Item(
+            id="test",
+            geometry={"type": "Point", "coordinates": [0, 0]},
+            bbox=[0, 0, 0, 0],
+            datetime=datetime(2025, 1, 1, tzinfo=UTC),
+            properties={},
+        )
+        item.add_asset(
+            "good",
+            Asset(href="https://example.com/data.zarr/test", media_type="application/vnd.zarr"),
+        )
+        item.add_asset(
+            "good_v3",
+            Asset(
+                href="https://example.com/data.zarr/test2",
+                media_type="application/vnd.zarr; version=3",
+            ),
+        )
+
+        fix_zarr_asset_media_types(item)
+
+        assert item.assets["good"].media_type == "application/vnd.zarr"
+        assert item.assets["good_v3"].media_type == "application/vnd.zarr; version=3"
+
+    def test_preserves_non_zarr_assets(self, stac_item):
+        """Test that non-zarr assets (thumbnail, etc.) are not modified."""
+        # Add a non-zarr asset
+        stac_item.add_asset(
+            "test_png",
+            Asset(href="https://example.com/thumb.png", media_type="image/png"),
+        )
+
+        fix_zarr_asset_media_types(stac_item)
+
+        assert stac_item.assets["test_png"].media_type == "image/png"


### PR DESCRIPTION
## Summary

- Fix incorrect media type (`application/vnd+zarr` → `application/vnd.zarr; version=3`) on AOT, SCL, and WVP assets that were missed by #100
- Remove `zipped_product` asset that references an external zip download service unrelated to our converted zarr data

Follow-on fix for the issues discussed in https://github.com/EOPF-Explorer/data-pipeline/issues/97#issuecomment-4055347294.

## Test plan

- [x] Added `tests/test_fix_zarr_assets.py` with 5 tests covering media type correction, zipped_product removal, and preservation of correct assets
- [x] Updated test fixture to reflect actual source data (wrong `vnd+zarr` media type)
- [x] All 182 tests pass
- [x] Re-register a staging item and verify assets on the STAC API