### PR TITLE
feat: add storage tier change events script

### DIFF
--- a/operator-tools/README.md
+++ b/operator-tools/README.md
@@ -299,6 +299,18 @@ python operator-tools/submit_storage_tier_workflows.py \
     --collection sentinel-2-l2a-staging \
     --storage-class STANDARD_IA \
     --webhook-url http://localhost:12000/samples
+
+# Registered-window backlog — window on when items were *registered*
+# (properties.created) rather than sensed, to drain a bulk-conversion backlog
+# to STANDARD. Uses a CQL2 filter instead of the datetime= range.
+python operator-tools/submit_storage_tier_workflows.py \
+    --date-field created \
+    --start-date 2025-11-01 \
+    --end-date 2026-04-08 \
+    --collection sentinel-2-l2a \
+    --storage-class STANDARD \
+    --process-all-assets \
+    --dry-run
 ```
 
 **All options:**
@@ -308,7 +320,8 @@ python operator-tools/submit_storage_tier_workflows.py \
 | `--start-date` | required | Start of date range (`YYYY-MM-DD`) |
 | `--end-date` | required | End of date range (`YYYY-MM-DD`) |
 | `--collection` | required | STAC collection ID |
-| `--storage-class` | `STANDARD_IA` | Target S3 storage class |
+| `--date-field` | `datetime` | Item date to window on: sensing `datetime`, registration `created`, or last-modified `updated`. Non-default fields use a CQL2 `between` filter |
+| `--storage-class` | `STANDARD` | Target S3 storage class |
 | `--stac-api-url` | prod API URL | STAC API endpoint to query |
 | `--s3-endpoint` | OVH Cloud | S3 endpoint passed to Argo workflows |
 | `--pipeline-image-version` | `v1.6.1` | Docker image tag for Argo jobs |

--- a/operator-tools/README.md
+++ b/operator-tools/README.md
@@ -230,7 +230,7 @@ uv run operator-tools/migrate_catalog.py clone sentinel-2-l2a-staging sentinel-2
 
 **Documentation:** See [README_MIGRATIONS.md](./README_MIGRATIONS.md) for the full safe migration procedure, CLI reference, and instructions for writing new migrations.
 
-### 4. `submit_test_workflow_wh.py` - HTTP Webhook Submission
+### 4. `submit_test_workflow_wh.py` - HTTP Webhook Submission (single item)
 
 Submits a single test STAC item via HTTP webhook endpoint.
 
@@ -253,9 +253,87 @@ Edit the script to change:
 
 - `source_url`: STAC item URL to process
 - `collection`: Target collection name
-- `action`: Processing action (e.g., `convert-v1-s2-hp`, or `convert-v1-s2-hp`)
+- `action`: Processing action (e.g., `convert-v1-s2-hp`)
 
-### 5. `submit_stac_items_notebook.ipynb` - Interactive STAC Search & Submit
+### 5. `submit_test_workflow_wh_list.py` - HTTP Webhook Submission (hardcoded list)
+
+Submits a hardcoded list of items via HTTP webhook, one workflow per item, with a 1s delay between submissions.
+
+**Use case:** Batch-reprocessing a known fixed set of items (list is edited directly in the script)
+
+**Usage:**
+
+```bash
+uv run operator-tools/submit_test_workflow_wh_list.py
+```
+
+**Configuration:** Edit the `products` list and `payload` fields inside the script.
+
+### 6. `submit_storage_tier_workflows.py` - Batch Storage Tier Change via Argo
+
+Queries STAC in 24h windows over a date range and submits one `batch-change-storage-tier` webhook payload per window, triggering the `eopf-storage-tier-batch-job` WorkflowTemplate via Argo Events. Each workflow fans out over all items in that window in parallel (up to `--parallelism` pods at a time). This is the preferred approach for large date ranges — one Argo Workflow per day keeps job history clean and avoids submitting hundreds of individual workflows.
+
+**Use case:** Change the S3 storage class (e.g., to `STANDARD_IA`) for thousands of items over a multi-month date range.
+
+**Prerequisites:**
+
+- Pipeline webhook service running (port-forward, see above)
+- `requests` and `pystac-client` Python packages (already in project deps)
+- Argo Events sensor `eopf-explorer-storage-tier` deployed in the cluster (see `platform-deploy` repo)
+
+**Usage:**
+
+```bash
+# Dry run — logs what would be submitted without sending any requests
+python operator-tools/submit_storage_tier_workflows.py \
+    --start-date 2024-01-01 \
+    --end-date 2024-06-01 \
+    --collection sentinel-2-l2a-staging \
+    --storage-class STANDARD_IA \
+    --dry-run
+
+# Live run (port-forward must be active)
+python operator-tools/submit_storage_tier_workflows.py \
+    --start-date 2024-01-01 \
+    --end-date 2024-06-01 \
+    --collection sentinel-2-l2a-staging \
+    --storage-class STANDARD_IA \
+    --webhook-url http://localhost:12000/samples
+```
+
+**All options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--start-date` | required | Start of date range (`YYYY-MM-DD`) |
+| `--end-date` | required | End of date range (`YYYY-MM-DD`) |
+| `--collection` | required | STAC collection ID |
+| `--storage-class` | `STANDARD_IA` | Target S3 storage class |
+| `--stac-api-url` | prod API URL | STAC API endpoint to query |
+| `--s3-endpoint` | OVH Cloud | S3 endpoint passed to Argo workflows |
+| `--pipeline-image-version` | `v1.6.1` | Docker image tag for Argo jobs |
+| `--process-all-assets` | false | Process all assets (not just reflectance) |
+| `--webhook-url` | `localhost:12000/samples` | Webhook endpoint |
+| `--delay` | `1.0` | Seconds between window submissions |
+| `--dry-run` | false | Log payloads without sending |
+
+**Payload format** (one per 24h window):
+```json
+{
+  "action": "batch-change-storage-tier",
+  "item_ids": ["S2A_MSIL2A_...", "S2B_MSIL2A_..."],
+  "collection": "sentinel-2-l2a-staging",
+  "storage_class": "STANDARD_IA",
+  "stac_api_url": "https://...",
+  "s3_endpoint": "https://...",
+  "pipeline_image_version": "v1.6.1",
+  "process_all_assets": "false"
+}
+```
+
+**Cluster-side:** The `eopf-explorer-storage-tier` Argo Events Sensor (in `platform-deploy`) listens for `action: "batch-change-storage-tier"` and triggers `eopf-storage-tier-batch-job`, which fans out over `item_ids` — running change-tier + STAC metadata update for each item in parallel. Empty windows (no items found) are skipped without submitting a webhook.
+
+### 7. `submit_stac_items_notebook.ipynb` - Interactive STAC Search & Submit
 
 Jupyter notebook for searching and batch submitting STAC items.
 
@@ -333,6 +411,9 @@ python manage_collections.py clean test-coll --clean-s3 -y
 | `manage_collections.py` | Viewing collection statistics | `python manage_collections.py info coll-id --s3-stats` |
 | `manage_collections.py` | Batch operations on all items | `python manage_collections.py clean coll-id --clean-s3 -y` |
 | `manage_collections.py` | Collection lifecycle management | `python manage_collections.py create/delete` |
+| `submit_test_workflow_wh.py` | Testing pipeline with one known item | edit script then `uv run submit_test_workflow_wh.py` |
+| `submit_test_workflow_wh_list.py` | Reprocessing a small known fixed set | edit products list then `uv run submit_test_workflow_wh_list.py` |
+| `submit_storage_tier_workflows.py` | Changing storage tier for a large date range (one Argo batch workflow per 24h window) | `python submit_storage_tier_workflows.py --start-date ... --dry-run` |
 
 ### Benefits of This Workflow
 

--- a/operator-tools/submit_storage_tier_workflows.py
+++ b/operator-tools/submit_storage_tier_workflows.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Submit storage tier change workflows via HTTP webhook for a date range of STAC items.
+
+Queries STAC in 24h windows and POSTs one webhook payload per window,
+triggering the eopf-storage-tier-batch-job WorkflowTemplate via Argo Events.
+Each workflow fans out to per-item parallel processing within Argo.
+"""
+
+import argparse
+import logging
+import sys
+import time
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import requests
+from pystac_client import Client
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def generate_time_windows(
+    start_date: datetime, end_date: datetime, window_hours: int = 24
+) -> list[tuple[str, str]]:
+    """Return list of (window_start_iso, window_end_iso) tuples covering start_date to end_date.
+
+    Each window is window_hours long; the last window is truncated to end_date.
+    """
+    windows = []
+    current = start_date
+    delta = timedelta(hours=window_hours)
+    while current < end_date:
+        window_end = min(current + delta, end_date)
+        windows.append(
+            (
+                current.isoformat().replace("+00:00", "Z"),
+                window_end.isoformat().replace("+00:00", "Z"),
+            )
+        )
+        current = window_end
+    return windows
+
+
+def query_stac_items(
+    stac_api_url: str, collection: str, window_start: str, window_end: str
+) -> list[str]:
+    """Query STAC for items with datetime in the given window. Returns list of item IDs."""
+    catalog = Client.open(stac_api_url)
+    search = catalog.search(
+        collections=[collection],
+        datetime=f"{window_start}/{window_end}",
+        limit=100,
+    )
+    return [item.id for item in search.items()]
+
+
+def submit_batch(webhook_url: str, payload: dict[str, object], dry_run: bool) -> bool:
+    """POST a JSON payload to the webhook endpoint. Returns True on success."""
+    if dry_run:
+        logger.info(f"[dry-run] Would submit: {payload}")
+        return True
+    try:
+        response = requests.post(
+            webhook_url,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if response.status_code != 200:
+            logger.warning(
+                f"Non-200 response for window with {len(cast(list[str], payload.get('item_ids', [])))} items: "
+                f"{response.status_code} {response.text}"
+            )
+        return response.status_code == 200
+    except Exception as e:
+        logger.error(f"Error submitting batch: {e}")
+        return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Submit storage tier batch workflows via webhook for a date range of STAC items."
+    )
+    parser.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
+    parser.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
+    parser.add_argument("--collection", required=True, help="STAC collection ID")
+    parser.add_argument("--storage-class", default="STANDARD_IA", help="S3 storage class")
+    parser.add_argument("--stac-api-url", default="https://api.explorer.eopf.copernicus.eu/stac")
+    parser.add_argument("--s3-endpoint", default="https://s3.de.io.cloud.ovh.net")
+    parser.add_argument("--pipeline-image-version", default="v1.6.1")
+    parser.add_argument("--process-all-assets", action="store_true")
+    parser.add_argument("--webhook-url", default="http://localhost:12000/samples")
+    parser.add_argument(
+        "--delay", type=float, default=1.0, help="Delay between window submissions in seconds"
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        start_date = datetime.fromisoformat(args.start_date).replace(tzinfo=UTC)
+        end_date = datetime.fromisoformat(args.end_date).replace(tzinfo=UTC)
+    except ValueError as e:
+        logger.error(f"Invalid date format: {e}")
+        sys.exit(1)
+
+    if end_date <= start_date:
+        logger.error("--end-date must be after --start-date")
+        sys.exit(1)
+
+    windows = generate_time_windows(start_date, end_date)
+    logger.info(f"Processing {len(windows)} 24h windows from {args.start_date} to {args.end_date}")
+
+    total_submitted = 0
+    total_failed = 0
+
+    for i, (window_start, window_end) in enumerate(windows, 1):
+        logger.info(f"[{i}/{len(windows)}] Querying window {window_start} to {window_end}")
+        item_ids = query_stac_items(args.stac_api_url, args.collection, window_start, window_end)
+        logger.info(f"  Found {len(item_ids)} items")
+
+        if not item_ids:
+            logger.info("  Skipping empty window")
+            continue
+
+        payload: dict[str, object] = {
+            "action": "batch-change-storage-tier",
+            "item_ids": item_ids,
+            "collection": args.collection,
+            "storage_class": args.storage_class,
+            "stac_api_url": args.stac_api_url,
+            "s3_endpoint": args.s3_endpoint,
+            "pipeline_image_version": args.pipeline_image_version,
+            "process_all_assets": str(args.process_all_assets).lower(),
+        }
+        success = submit_batch(args.webhook_url, payload, args.dry_run)
+        if success:
+            total_submitted += 1
+        else:
+            total_failed += 1
+
+        if i < len(windows):
+            time.sleep(args.delay)
+
+    logger.info(f"Done. Submitted: {total_submitted}, Failed: {total_failed}")
+
+
+if __name__ == "__main__":
+    main()

--- a/operator-tools/submit_storage_tier_workflows.py
+++ b/operator-tools/submit_storage_tier_workflows.py
@@ -46,15 +46,36 @@ def generate_time_windows(
 
 
 def query_stac_items(
-    stac_api_url: str, collection: str, window_start: str, window_end: str
+    stac_api_url: str,
+    collection: str,
+    window_start: str,
+    window_end: str,
+    date_field: str = "datetime",
 ) -> list[str]:
-    """Query STAC for items with datetime in the given window. Returns list of item IDs."""
+    """Query STAC for items whose ``date_field`` falls in the window. Returns item IDs.
+
+    ``date_field="datetime"`` uses pystac-client's native ``datetime=`` range
+    (the item's sensing time). Other fields (``created``, ``updated``) filter on
+    the registration/update timestamp via a CQL2 ``between`` filter, since those
+    properties are not reachable through the ``datetime=`` kwarg.
+    """
     catalog = Client.open(stac_api_url)
-    search = catalog.search(
-        collections=[collection],
-        datetime=f"{window_start}/{window_end}",
-        limit=100,
-    )
+    if date_field == "datetime":
+        search = catalog.search(
+            collections=[collection],
+            datetime=f"{window_start}/{window_end}",
+            limit=100,
+        )
+    else:
+        search = catalog.search(
+            collections=[collection],
+            filter={
+                "op": "between",
+                "args": [{"property": date_field}, window_start, window_end],
+            },
+            filter_lang="cql2-json",
+            limit=100,
+        )
     return [item.id for item in search.items()]
 
 
@@ -68,6 +89,7 @@ def submit_batch(webhook_url: str, payload: dict[str, object], dry_run: bool) ->
             webhook_url,
             json=payload,
             headers={"Content-Type": "application/json"},
+            timeout=30,
         )
         if response.status_code != 200:
             logger.warning(
@@ -87,7 +109,14 @@ def main() -> None:
     parser.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     parser.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     parser.add_argument("--collection", required=True, help="STAC collection ID")
-    parser.add_argument("--storage-class", default="STANDARD_IA", help="S3 storage class")
+    parser.add_argument(
+        "--date-field",
+        choices=["datetime", "created", "updated"],
+        default="datetime",
+        help="Item date to window on: sensing 'datetime' (default), registration "
+        "'created', or last-modified 'updated'. Non-default fields use a CQL2 filter.",
+    )
+    parser.add_argument("--storage-class", default="STANDARD", help="S3 storage class")
     parser.add_argument("--stac-api-url", default="https://api.explorer.eopf.copernicus.eu/stac")
     parser.add_argument("--s3-endpoint", default="https://s3.de.io.cloud.ovh.net")
     parser.add_argument("--pipeline-image-version", default="v1.6.1")
@@ -118,7 +147,9 @@ def main() -> None:
 
     for i, (window_start, window_end) in enumerate(windows, 1):
         logger.info(f"[{i}/{len(windows)}] Querying window {window_start} to {window_end}")
-        item_ids = query_stac_items(args.stac_api_url, args.collection, window_start, window_end)
+        item_ids = query_stac_items(
+            args.stac_api_url, args.collection, window_start, window_end, args.date_field
+        )
         logger.info(f"  Found {len(item_ids)} items")
 
         if not item_ids:

--- a/tests/unit/test_submit_storage_tier_workflows.py
+++ b/tests/unit/test_submit_storage_tier_workflows.py
@@ -1,0 +1,276 @@
+"""Unit tests for operator-tools/submit_storage_tier_workflows.py."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from submit_storage_tier_workflows import (
+    generate_time_windows,
+    query_stac_items,
+    submit_batch,
+)
+
+
+class TestGenerateTimeWindows:
+    def test_single_day(self) -> None:
+        start = datetime(2024, 1, 1, tzinfo=UTC)
+        end = datetime(2024, 1, 2, tzinfo=UTC)
+        windows = generate_time_windows(start, end)
+        assert len(windows) == 1
+        assert windows[0] == ("2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
+
+    def test_multi_day(self) -> None:
+        start = datetime(2024, 1, 1, tzinfo=UTC)
+        end = datetime(2024, 1, 4, tzinfo=UTC)
+        windows = generate_time_windows(start, end)
+        assert len(windows) == 3
+        assert windows[0] == ("2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
+        assert windows[1] == ("2024-01-02T00:00:00Z", "2024-01-03T00:00:00Z")
+        assert windows[2] == ("2024-01-03T00:00:00Z", "2024-01-04T00:00:00Z")
+
+    def test_partial_last_window(self) -> None:
+        start = datetime(2024, 1, 1, tzinfo=UTC)
+        end = datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC)
+        windows = generate_time_windows(start, end)
+        assert len(windows) == 2
+        assert windows[0] == ("2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
+        assert windows[1] == ("2024-01-02T00:00:00Z", "2024-01-02T12:00:00Z")
+
+    def test_custom_window_hours(self) -> None:
+        start = datetime(2024, 1, 1, tzinfo=UTC)
+        end = datetime(2024, 1, 2, tzinfo=UTC)
+        windows = generate_time_windows(start, end, window_hours=6)
+        assert len(windows) == 4
+        assert windows[0] == ("2024-01-01T00:00:00Z", "2024-01-01T06:00:00Z")
+        assert windows[-1] == ("2024-01-01T18:00:00Z", "2024-01-02T00:00:00Z")
+
+    def test_same_start_end_returns_empty(self) -> None:
+        start = datetime(2024, 1, 1, tzinfo=UTC)
+        windows = generate_time_windows(start, start)
+        assert windows == []
+
+
+class TestQueryStacItems:
+    def test_returns_item_ids(self) -> None:
+        mock_item_a = MagicMock()
+        mock_item_a.id = "item-a"
+        mock_item_b = MagicMock()
+        mock_item_b.id = "item-b"
+
+        mock_search = MagicMock()
+        mock_search.items.return_value = [mock_item_a, mock_item_b]
+
+        mock_catalog = MagicMock()
+        mock_catalog.search.return_value = mock_search
+
+        with patch("submit_storage_tier_workflows.Client") as mock_client:
+            mock_client.open.return_value = mock_catalog
+            result = query_stac_items(
+                "https://stac.example.com",
+                "sentinel-2",
+                "2024-01-01T00:00:00Z",
+                "2024-01-02T00:00:00Z",
+            )
+
+        assert result == ["item-a", "item-b"]
+        mock_client.open.assert_called_once_with("https://stac.example.com")
+        mock_catalog.search.assert_called_once_with(
+            collections=["sentinel-2"],
+            datetime="2024-01-01T00:00:00Z/2024-01-02T00:00:00Z",
+            limit=100,
+        )
+
+    def test_returns_empty_list_when_no_items(self) -> None:
+        mock_search = MagicMock()
+        mock_search.items.return_value = []
+
+        mock_catalog = MagicMock()
+        mock_catalog.search.return_value = mock_search
+
+        with patch("submit_storage_tier_workflows.Client") as mock_client:
+            mock_client.open.return_value = mock_catalog
+            result = query_stac_items(
+                "https://stac.example.com",
+                "sentinel-2",
+                "2024-01-01T00:00:00Z",
+                "2024-01-02T00:00:00Z",
+            )
+
+        assert result == []
+
+
+class TestSubmitBatch:
+    def test_dry_run_does_not_send_request(self) -> None:
+        payload: dict[str, object] = {
+            "action": "batch-change-storage-tier",
+            "item_ids": ["item-1", "item-2"],
+        }
+        with patch("submit_storage_tier_workflows.requests") as mock_requests:
+            result = submit_batch("http://localhost:12000/samples", payload, dry_run=True)
+        mock_requests.post.assert_not_called()
+        assert result is True
+
+    def test_success_returns_true(self) -> None:
+        payload: dict[str, object] = {
+            "action": "batch-change-storage-tier",
+            "item_ids": ["item-1", "item-2"],
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("submit_storage_tier_workflows.requests.post", return_value=mock_response):
+            result = submit_batch("http://localhost:12000/samples", payload, dry_run=False)
+
+        assert result is True
+
+    def test_non_200_returns_false(self) -> None:
+        payload: dict[str, object] = {
+            "action": "batch-change-storage-tier",
+            "item_ids": ["item-1"],
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+
+        with patch("submit_storage_tier_workflows.requests.post", return_value=mock_response):
+            result = submit_batch("http://localhost:12000/samples", payload, dry_run=False)
+
+        assert result is False
+
+    def test_request_exception_returns_false(self) -> None:
+        payload: dict[str, object] = {
+            "action": "batch-change-storage-tier",
+            "item_ids": ["item-1"],
+        }
+
+        with patch(
+            "submit_storage_tier_workflows.requests.post",
+            side_effect=Exception("connection refused"),
+        ):
+            result = submit_batch("http://localhost:12000/samples", payload, dry_run=False)
+
+        assert result is False
+
+    def test_payload_contains_item_ids_list(self) -> None:
+        payload: dict[str, object] = {
+            "action": "batch-change-storage-tier",
+            "item_ids": ["item-a", "item-b", "item-c"],
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        captured: list[dict[str, object]] = []
+
+        def capture_post(url: str, json: dict[str, object], **kwargs: object) -> MagicMock:
+            captured.append(json)
+            return mock_response
+
+        with patch("submit_storage_tier_workflows.requests.post", side_effect=capture_post):
+            submit_batch("http://localhost:12000/samples", payload, dry_run=False)
+
+        assert captured[0]["item_ids"] == ["item-a", "item-b", "item-c"]
+
+
+class TestMainEmptyWindowSkip:
+    def test_empty_window_not_submitted(self) -> None:
+        """Windows with no items should not trigger a POST."""
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "submit_storage_tier_workflows.py",
+                    "--start-date",
+                    "2024-01-01",
+                    "--end-date",
+                    "2024-01-03",
+                    "--collection",
+                    "sentinel-2-l2a",
+                    "--dry-run",
+                ],
+            ),
+            patch("submit_storage_tier_workflows.query_stac_items", return_value=[]),
+            patch("submit_storage_tier_workflows.submit_batch") as mock_submit,
+        ):
+            from submit_storage_tier_workflows import main
+
+            main()
+
+        mock_submit.assert_not_called()
+
+    def test_batch_payload_structure(self) -> None:
+        """Submitted payload must contain item_ids list and correct action."""
+        submitted_payloads: list[dict[str, object]] = []
+
+        def capture(url: str, payload: dict[str, object], dry_run: bool) -> bool:
+            submitted_payloads.append(payload)
+            return True
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "submit_storage_tier_workflows.py",
+                    "--start-date",
+                    "2024-01-01",
+                    "--end-date",
+                    "2024-01-02",
+                    "--collection",
+                    "sentinel-2-l2a",
+                    "--dry-run",
+                ],
+            ),
+            patch(
+                "submit_storage_tier_workflows.query_stac_items",
+                return_value=["item-1", "item-2"],
+            ),
+            patch("submit_storage_tier_workflows.submit_batch", side_effect=capture),
+        ):
+            from submit_storage_tier_workflows import main
+
+            main()
+
+        assert len(submitted_payloads) == 1
+        assert submitted_payloads[0]["item_ids"] == ["item-1", "item-2"]
+        assert submitted_payloads[0]["action"] == "batch-change-storage-tier"
+        assert "parallelism" not in submitted_payloads[0]
+
+
+class TestMainDateValidation:
+    def test_end_before_start_exits(self) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "submit_storage_tier_workflows.py",
+                "--start-date",
+                "2024-06-01",
+                "--end-date",
+                "2024-01-01",
+                "--collection",
+                "sentinel-2-l2a",
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from submit_storage_tier_workflows import main
+
+                main()
+            assert exc_info.value.code == 1
+
+    def test_invalid_date_format_exits(self) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "submit_storage_tier_workflows.py",
+                "--start-date",
+                "not-a-date",
+                "--end-date",
+                "2024-01-01",
+                "--collection",
+                "sentinel-2-l2a",
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from submit_storage_tier_workflows import main
+
+                main()
+            assert exc_info.value.code == 1

--- a/tests/unit/test_submit_storage_tier_workflows.py
+++ b/tests/unit/test_submit_storage_tier_workflows.py
@@ -100,6 +100,64 @@ class TestQueryStacItems:
 
         assert result == []
 
+    def test_date_field_created_uses_cql2_between(self) -> None:
+        """A non-default date_field switches to a CQL2 `between` filter on that property."""
+        mock_item = MagicMock()
+        mock_item.id = "item-a"
+        mock_search = MagicMock()
+        mock_search.items.return_value = [mock_item]
+
+        mock_catalog = MagicMock()
+        mock_catalog.search.return_value = mock_search
+
+        with patch("submit_storage_tier_workflows.Client") as mock_client:
+            mock_client.open.return_value = mock_catalog
+            result = query_stac_items(
+                "https://stac.example.com",
+                "sentinel-2",
+                "2024-01-01T00:00:00Z",
+                "2024-01-02T00:00:00Z",
+                date_field="created",
+            )
+
+        assert result == ["item-a"]
+        mock_catalog.search.assert_called_once_with(
+            collections=["sentinel-2"],
+            filter={
+                "op": "between",
+                "args": [
+                    {"property": "created"},
+                    "2024-01-01T00:00:00Z",
+                    "2024-01-02T00:00:00Z",
+                ],
+            },
+            filter_lang="cql2-json",
+            limit=100,
+        )
+
+    def test_default_date_field_uses_datetime_range(self) -> None:
+        """The default date_field keeps the native pystac-client datetime= range query."""
+        mock_search = MagicMock()
+        mock_search.items.return_value = []
+        mock_catalog = MagicMock()
+        mock_catalog.search.return_value = mock_search
+
+        with patch("submit_storage_tier_workflows.Client") as mock_client:
+            mock_client.open.return_value = mock_catalog
+            query_stac_items(
+                "https://stac.example.com",
+                "sentinel-2",
+                "2024-01-01T00:00:00Z",
+                "2024-01-02T00:00:00Z",
+                date_field="datetime",
+            )
+
+        mock_catalog.search.assert_called_once_with(
+            collections=["sentinel-2"],
+            datetime="2024-01-01T00:00:00Z/2024-01-02T00:00:00Z",
+            limit=100,
+        )
+
 
 class TestSubmitBatch:
     def test_dry_run_does_not_send_request(self) -> None:
@@ -234,6 +292,83 @@ class TestMainEmptyWindowSkip:
         assert submitted_payloads[0]["item_ids"] == ["item-1", "item-2"]
         assert submitted_payloads[0]["action"] == "batch-change-storage-tier"
         assert "parallelism" not in submitted_payloads[0]
+
+
+class TestMainDateFieldForwarding:
+    def test_date_field_forwarded_to_query(self) -> None:
+        """`--date-field created` reaches query_stac_items."""
+        captured: list[str] = []
+
+        def capture_query(
+            stac_api_url: str,
+            collection: str,
+            window_start: str,
+            window_end: str,
+            date_field: str,
+        ) -> list[str]:
+            captured.append(date_field)
+            return []
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "submit_storage_tier_workflows.py",
+                    "--start-date",
+                    "2024-01-01",
+                    "--end-date",
+                    "2024-01-02",
+                    "--collection",
+                    "sentinel-2-l2a",
+                    "--date-field",
+                    "created",
+                    "--dry-run",
+                ],
+            ),
+            patch(
+                "submit_storage_tier_workflows.query_stac_items",
+                side_effect=capture_query,
+            ),
+        ):
+            from submit_storage_tier_workflows import main
+
+            main()
+
+        assert captured == ["created"]
+
+    def test_default_storage_class_is_standard(self) -> None:
+        """The submitted payload defaults storage_class to STANDARD."""
+        submitted_payloads: list[dict[str, object]] = []
+
+        def capture(url: str, payload: dict[str, object], dry_run: bool) -> bool:
+            submitted_payloads.append(payload)
+            return True
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "submit_storage_tier_workflows.py",
+                    "--start-date",
+                    "2024-01-01",
+                    "--end-date",
+                    "2024-01-02",
+                    "--collection",
+                    "sentinel-2-l2a",
+                    "--dry-run",
+                ],
+            ),
+            patch(
+                "submit_storage_tier_workflows.query_stac_items",
+                return_value=["item-1"],
+            ),
+            patch("submit_storage_tier_workflows.submit_batch", side_effect=capture),
+        ):
+            from submit_storage_tier_workflows import main
+
+            main()
+
+        assert submitted_payloads[0]["storage_class"] == "STANDARD"
 
 
 class TestMainDateValidation:


### PR DESCRIPTION
## Summary

branched from #103 (now rebased on `main`; the #103 CLI-command commit is merged, so this PR is just the submitter script + the `--date-field` extension below)

- Adds `submit_storage_tier_workflows.py` operator tool that queries STAC in 24h windows over a date range and submits one `batch-change-storage-tier` webhook payload per window to trigger the `eopf-storage-tier-batch-job` WorkflowTemplate deployed in https://github.com/EOPF-Explorer/platform-deploy/pull/130 via Argo Events
- Adds unit tests (covering time-window generation, STAC querying, dry-run, error handling, and payload structure)
- Updates `operator-tools/README.md` with full usage docs and a tool-selection reference table

## Update: `--date-field` (window on registration time)

The submitter originally windowed only on sensing `datetime`. To drain the S2 backlog by *registration* time (bulk-converted items were registered long after they were sensed), this adds:

- `--date-field {datetime,created,updated}` (default `datetime`, backward compatible). Non-default fields swap the pystac-client `datetime=` range for a CQL2 `between` filter on the chosen property — same pattern `scripts/query_stac.py` uses to harvest by `updated`.
- `--storage-class` default flipped `STANDARD_IA` → `STANDARD` (STANDARD_IA is unused in the deployment; documented commands stay explicit).
- `timeout=30` on the webhook POST (ruff S113, on this script's own code) so a hung endpoint can't stall the per-window loop.
- README gains the registered-window backlog example.

**Planned use** (#182 follow-up): a one-off prod run over `sentinel-2-l2a`, windowing on `--date-field created` for items registered `2025-11-01 → (today − 3 months)`, moving their S3 objects to STANDARD. Dry-run first, then live via port-forward. The Sensor + batch template are date-agnostic (they consume resolved `item_ids`), so no cluster-side change is needed for this capability.

## Why

Changing S3 storage classes for thousands of items over a multi-month date range is too slow when done sequentially on a local machine. The script fans work out to Argo: one workflow per 24h window, with intra-window parallelism handled by the `eopf-storage-tier-batch-job` template. Empty windows are skipped automatically. Windowing on `created` lets us target the registration backlog that a sensing-date window would miss.

## Test plan

- [x] `uv run --group test pytest tests/unit/test_submit_storage_tier_workflows.py` passes (incl. new `--date-field` / CQL2 / default-storage-class cases)
- [x] `uv run --group test pytest tests/unit/test_change_storage_tier_commands.py` passes
- [x] Full pre-commit gate green (ruff / ruff-format / mypy / pytest)
- [x] `--date-field created` builds a CQL2 `between` on `created`; default `datetime` path unchanged (asserted via mocked `Client.search` kwargs)
- [x] Dry run against staging collection
- [x] Live run (port-forward active) submits correct payload shape and logs `action: batch-change-storage-tier` with item IDs per window