### PR TITLE
Pin GitHub Actions to commit SHAs (coordination#239)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         fetch-depth: 0  # Fetch all history and tags
         ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
@@ -75,7 +75,7 @@ jobs:
     - name: Docker meta
       if: github.event_name != 'workflow_run' || steps.check_release.outputs.should_skip != 'true'
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: ${{ secrets.OVH_HARBOR_REGISTRY }}/eopf-sentinel-zarr-explorer/data-pipeline
         tags: |
@@ -88,11 +88,11 @@ jobs:
 
     - name: Set up Docker Buildx
       if: github.event_name != 'workflow_run' || steps.check_release.outputs.should_skip != 'true'
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Log in to OVH Container Registry
       if: github.event_name != 'workflow_run' || steps.check_release.outputs.should_skip != 'true'
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ secrets.OVH_HARBOR_REGISTRY }}
         username: ${{ secrets.OVH_HARBOR_USERNAME }}
@@ -100,7 +100,7 @@ jobs:
 
     - name: Build and push Docker image
       if: github.event_name != 'workflow_run' || steps.check_release.outputs.should_skip != 'true'
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: .
         file: docker/Dockerfile

--- a/.github/workflows/harbor-cleanup.yml
+++ b/.github/workflows/harbor-cleanup.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses:  googleapis/release-please-action@v4
+      - uses:  googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
         with:
           config-file: "release-please-config.json"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.13"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
       with:
         version: "latest"
 
@@ -27,7 +27,7 @@ jobs:
       run: uv sync --all-groups
 
     - name: Set up pre-commit cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.cache/pre-commit
         key: pre-commit-3.13-${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
## Summary

Pins third-party GitHub Actions in workflow files from tags/branches to immutable commit SHAs, with `# pin@<ref>` comments for traceability and future updates.

Implements **section 1.1** as tracked in [EOPF-Explorer/coordination#239](https://github.com/EOPF-Explorer/coordination/issues/239).

## Notes

- Generated with [pin-github-action](https://www.npmjs.com/package/pin-github-action) (`mheap/pin-github-action` Docker image).
- `docker://` and local `./` actions are unchanged by the tool.

Made with [Cursor](https://cursor.com)