### PR TITLE
fix: defer TCPConnector creation to async context (Python 3.13 crash)

### DIFF
--- a/scripts/convert_v1_s2.py
+++ b/scripts/convert_v1_s2.py
@@ -11,11 +11,11 @@ import tempfile
 from typing import Any
 from urllib.parse import urlparse
 
+import aiohttp
 import fsspec
 import httpx
 import xarray as xr
 import zarr
-from aiohttp import TCPConnector
 from eopf_geozarr.conversion.fs_utils import (
     get_storage_options,
 )
@@ -157,12 +157,17 @@ def run_conversion(
         )
         merged_target: dict[str, Any] = dict(storage_options) if storage_options else {}
         merged_target["asynchronous"] = True
-        client_kwargs: dict[str, Any] = dict(merged_target.get("client_kwargs") or {})
-        client_kwargs["connector"] = TCPConnector(
-            limit=max_conn,
-            limit_per_host=max_conn,
-        )
-        merged_target["client_kwargs"] = client_kwargs
+        # TCPConnector must be created inside an async context (aiohttp 3.9+ /
+        # Python 3.12+ call asyncio.get_running_loop() in __init__).  Pass a
+        # custom get_client factory so the connector is built lazily, safely
+        # inside fsspec's own async path.
+        _extra_client_kwargs: dict[str, Any] = dict(merged_target.pop("client_kwargs", None) or {})
+
+        async def _get_client(**kwargs: Any) -> aiohttp.ClientSession:
+            connector = aiohttp.TCPConnector(limit=max_conn, limit_per_host=max_conn)
+            return aiohttp.ClientSession(connector=connector, **{**_extra_client_kwargs, **kwargs})
+
+        merged_target["get_client"] = _get_client
 
         storage_options = {
             "protocol": "simplecache",


### PR DESCRIPTION
## Summary

Fixes a `RuntimeError: no running event loop` crash introduced in #168 when running on Python 3.13.

`aiohttp 3.9+` calls `asyncio.get_running_loop()` in `TCPConnector.__init__`, which raises when called from synchronous code (no event loop running in the main thread at that point).

## Root cause

```python
# sync code — no event loop running
client_kwargs["connector"] = TCPConnector(limit=max_conn, ...)
# → TCPConnector.__init__ → asyncio.get_running_loop() → RuntimeError
```

## Fix

Replace the pre-built `TCPConnector` in `client_kwargs` with a custom async `get_client` factory — fsspec's intended extension point — so the connector is created lazily inside fsspec's own event loop at first connection time:

```python
async def _get_client(**kwargs):
    connector = aiohttp.TCPConnector(limit=max_conn, limit_per_host=max_conn)
    return aiohttp.ClientSession(connector=connector, **{**_extra_client_kwargs, **kwargs})

merged_target["get_client"] = _get_client
```

## Test plan

- [x] Deploy to staging and confirm `S2B_MSIL2A_*` conversions complete without `RuntimeError: no running event loop`
- [x] Confirm connection limit env var `ZARR_SOURCE_HTTP_MAX_CONNECTIONS` still takes effect
- [x] Confirm `/quality/atmosphere/r10m` group (aot, wvp) converts — see staging findings in PR comment
