### PR TITLE
fix: exclude dependabot from PUSH_IMAGE to prevent login failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       security-events: write # Upload Trivy SARIF to GitHub Advanced Security / Security tab.
 
     env:
-      PUSH_IMAGE: ${{ github.repository == 'EOPF-Explorer/data-pipeline' && (github.event_name == 'workflow_call' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) }}
+      PUSH_IMAGE: ${{ github.repository == 'EOPF-Explorer/data-pipeline' && github.actor != 'dependabot[bot]' && (github.event_name == 'workflow_call' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) }}
 
     steps:
     - name: Checkout code (release tag from Release Please)


### PR DESCRIPTION
## Summary

- Dependabot branches live on the same repo (not a fork), so `github.event.pull_request.head.repo.full_name == github.repository` evaluated to `true`, setting `PUSH_IMAGE=true` for Dependabot PRs
- This caused the registry login step to run without credentials, failing with `Username and password required`
- Fix: add `github.actor != 'dependabot[bot]'` to the `PUSH_IMAGE` expression

## Test plan

- [ ] Verify Dependabot PRs pass the Build Docker Image check after merge
- [ ] Verify non-Dependabot PRs from the same repo still push the image correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)