### PR TITLE
fix(security): bump pip 26.0.1 -> 26.1.2 to clear pip-audit CVEs

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2320,11 +2320,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why
The repo's **Security audit** check (pip-audit over `uv export`) has been failing on every PR. After merging the Dependabot bumps for urllib3 (#203) and idna (#207), the only remaining advisory on `main` is:

```
pip-audit: pip@26.0.1 — CVE-2026-3219 (fix: 26.1)
pip-audit: pip@26.0.1 — CVE-2026-6357 (fix: 26.1)
```

`pip` is not a project dependency — it's pulled into `uv.lock` transitively by the `pip-audit==2.10.0` dev dependency. Since the audit action runs `uv export` (which includes dev groups), pip-audit ends up flagging its own transitive pip.

## What
`uv lock --upgrade-package pip` → pip `26.0.1` → `26.1.2` (≥ 26.1 fix). Only `uv.lock` changes (3 lines).

## Verification
- `uv export` now emits `pip==26.1.2`, `urllib3==2.7.0`, `idna==3.15` — all above their fix versions.
- The Security audit check on this PR is the authoritative confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)