### PR TITLE
docs(spec): S1 GRD RTC productionization (phase 6)

### DIFF
--- a/claude-docs/plans/s1_grd_phase6_productionization.md
+++ b/claude-docs/plans/s1_grd_phase6_productionization.md
@@ -23,9 +23,9 @@ per-tile cube writes; tests at each new-code boundary; **staging only** (prod = 
 | `eopf-explorer-s1tiling` / `ingest-v1-s1rtc` WorkflowTemplates | ✅ merged (PR#207) |
 | s1tiling cfg render (tile/orbit/date) | ✅ exists; `platform_list` not parametrized (T2) |
 | `s1-dem` PVC (31TCH only, manual) + EGM2008 geoid | ✅ bound; no auto-fetch (T3) |
-| Ingest = **fresh store per run** | ⚠️ → **dual**: per-acq store + append to per-tile cube (T4); append validated by PoC |
-| `eopf_geozarr.build_s1_rtc_stac_item` = one item per store | ✅ reuse as-is with **per-acquisition ids** (T5; no upstream change) |
-| titiler store resolution | ⚠️ reconstructs `{base}/{collection}/{item_id}.zarr`, ignores href (Spike 3) → stores must be named = item-id |
+| Ingest = **fresh store per run** | ⚠️ → **append scene to per-tile cube** (T4); append validated by PoC |
+| `eopf_geozarr.build_s1_rtc_stac_item` = one item per store | ✅ reuse with **per-acquisition ids** + `sel=time` links (T5; no upstream change) |
+| titiler store resolution | ⚠️ reconstructs + ignores href (Spike 3); **I2/option 2** (`ecde99c`) to fix it — not yet effective; blocks per-acq rendering |
 | Local watcher query/bbox/dedup logic | ✅ port; dedup → per-acquisition STAC item-exists (T6) |
 | Blind daily cron + sensor (sub-issue 8) | ✅ shipped, suspended — replaced by the data-driven trigger (T6) |
 
@@ -38,8 +38,8 @@ merged templates + spec P1–P8
    ├── T1 quality-gate step (ingest) ─────────────┐
    ├── T2 platform S1A+S1C (render) ──────────────┤
    ├── T3 ensure-dem auto-fetch ──────────────────┤
-   ├── T4 dual ingest (per-acq store + cube append + mutex) ─┤   ┐ P8 dual storage
-   └── T5 per-acquisition catalogue (renders directly) ──────┘ (T4 → T5)
+   ├── T4 datacube ingest (append to per-tile cube + mutex) ─┤   ┐ P8 cube + per-acq items
+   └── T5 per-acquisition catalogue (sel=time; needs I2/opt-2) ┘ (T4 → T5)
                          │
                          ▼
         T6 trigger → Argo (dedup = per-acq item-exists + cube time-present)
@@ -68,13 +68,19 @@ Add a `quality-gate` step in the ingest template *between* ingest and register: 
 - [ ] FAIL → no item registered; PASS → registered; WARN → registered + annotated
 - [ ] FAIL alerts via OQ #3
 
-### Task 2 — Enable S1A + S1C (platform render)  <status: ready>
-**What**: parametrize `platform_list` in the s1tiling template `sed` render (default `S1A S1C`); prove
-s1tiling handles S1C by a direct submit. (Query-side S1D skip = T6.)
-**Verify**: cluster — live S1C scene (31TCH 2026-06-06) → A→B → item + `validate_s1_rtc` PASS.
+### Task 2 — Enable S1A + S1C (platform render) + off-platform-download tolerance  <status: ready>
+**What**: (a) parametrize `platform_list` in the s1tiling template `sed` render (default `S1A S1C`);
+prove s1tiling handles S1C by a direct submit (query-side S1D skip = T6). (b) **Tolerate off-platform
+download failures** — the PoC showed s1tiling downloads *all* platforms in the window and exits
+non-zero if S1D/S1C downloads fail, even when the requested platform produced output (and that
+non-zero exit then skips the S3 sync). Change the s1tiling step's success contract to **"requested-
+platform GeoTIFFs present in `data_out/{tile}`"** rather than "S1Processor exit 0".
+**Verify**: cluster — live S1C scene (clean window) → A→B → item + `validate_s1_rtc` PASS; a window with a failing S1D download still succeeds (target output synced).
 **Acceptance**:
 - [ ] S1C scene processes A→B end-to-end; item queryable + PASS
 - [ ] `platform_list` rendered from a param (default `S1A S1C`), not hardcoded
+- [ ] s1tiling step succeeds (and syncs) when the requested platform produced output despite
+      off-platform download failures
 
 ### Task 3 — `ensure-dem` auto-fetch step  <status: blocked by OQ #4>
 **What**: `scripts/ensure_dem.py` — tile → swath bbox → fetch missing GLO-30 COGs from public
@@ -86,35 +92,35 @@ Argo `ensure-dem` step before s1tiling, writing the `s1-dem` PVC. Geoid pre-stag
 - [ ] previously-unprovisioned tile runs end-to-end, no manual DEM upload
 - [ ] idempotent re-run fetches nothing; OQ #4 resolved
 
-### Task 4 — Dual-storage ingest: per-acquisition store + per-tile cube append  <status: ready (PoC-validated mechanics)>
-**What**: ingest writes **two** artifacts per scene (P8): (a) a **per-acquisition single-time store**
-named = its item id (`s1-rtc-{tile}-{datetime}.zarr`) for rendering, and (b) **append the scene as a
-new `time` slice into the per-tile cube** (`s1-rtc-{tile}.zarr`) for analysis (Zarr region/append;
-**skip a time already present**). Serialise cube writes with an **Argo `synchronization` mutex keyed on
-the tile**. The PoC proved the append works via the existing `ingest_s1tiling_acquisition` (`mode=r+`);
-the per-acquisition store is the proven phase-5 single-acquisition store.
-**Verify**: `uv run pytest tests/unit/test_ingest_dual.py` (per-acq store + cube append; duplicate-time skip); cluster: 2 scenes same tile → 2 per-acq stores + a 2-time cube; concurrent submit → no corruption.
+### Task 4 — Datacube ingest: append scene to the per-tile cube  <status: ready (PoC-validated)>
+**What**: ingest **appends the scene as a new `time` slice into the per-tile cube**
+(`s1-rtc-{tile}.zarr`, `sentinel-1-grd-rtc-staging`) via the existing `ingest_s1tiling_acquisition`
+(`mode=r+`, PoC-validated); **skip a `time` already present**; serialise per-tile writes with an **Argo
+`synchronization` mutex keyed on the tile**. *(Fallback if I2/option 2 stalls: also write a
+per-acquisition single-time store named = item-id for reconstruction-based rendering — dual storage.)*
+**Verify**: `uv run pytest tests/unit/test_ingest_cube.py` (append into empty/existing cube; duplicate-time skip); cluster: 2 scenes same tile → a 2-time cube; concurrent submit → no corruption.
 **Acceptance**:
-- [ ] Each scene yields its own single-time store (name = item id) **and** a `time` slice in the cube
-- [ ] Re-ingesting an existing time is a no-op (no duplicate slice/store)
-- [ ] Concurrent same-tile cube writes serialised (mutex) — no corruption
+- [ ] A 2nd acquisition appends a `time` slice (cube has N times), unit-tested
+- [ ] Re-ingesting an existing time is a no-op
+- [ ] Concurrent same-tile writes serialised (mutex) — no corruption
 - [ ] `xr.open_dataset(cube)` exposes all scenes on `time`
 
-### Task 5 — Per-acquisition catalogue (renders directly)  <status: ready>
-**What**: emit **one STAC item per acquisition** (`s1-rtc-{tile}-{datetime}`, single `datetime`)
-pointing at its **per-acquisition store** → **renders directly** (store-name = item-id matches titiler
-reconstruction; **no `sel=time`, no titiler change** — Spike 3). Reuse the phase-5 builder with
-per-acquisition ids; `register_v1_s1_rtc.py` upserts each. Also (re)register the per-tile cube item
-for analysis. **No upstream data-model change required.**
-**Verify**: `uv run pytest tests/unit/test_register_v1_s1_rtc.py` (per-acquisition ids); cluster: each item's XYZ/preview renders (HTTP 200); distinct dates → distinct items.
+### Task 5 — Per-acquisition catalogue (renders via `sel=time`)  <status: blocked by I2/option 2>
+**What**: emit **one STAC item per acquisition** (`s1-rtc-{tile}-{datetime}`, single `datetime`,
+collection `sentinel-1-grd-rtc-acquisitions`) pointing at the **per-tile cube** via asset href, with
+viz/xyz/tilejson links carrying `sel=time=nearest::{datetime}`. **Renders once I2/option 2** (titiler
+resolves the store from the href; platform-deploy `ecde99c`) **is deployed + verified** (re-tested
+2026-06-08: not yet effective). Reuse the phase-5 builder with per-acquisition ids; also (re)register
+the per-tile cube item (`sentinel-1-grd-rtc-staging`) for analysis. No upstream data-model change.
+**Verify**: `uv run pytest tests/unit/test_register_v1_s1_rtc.py` (per-acquisition ids + `sel=time` links); cluster (after option 2 live): each item's XYZ/preview renders its slice (HTTP 200); distinct dates → distinct slices.
 **Acceptance**:
-- [ ] One item per acquisition (id `s1-rtc-{tile}-{datetime}`, single `datetime`), renders directly (200)
+- [ ] One item per acquisition (id `s1-rtc-{tile}-{datetime}`, single `datetime`), `sel=time` links
 - [ ] Per-tile cube item present for analysis; per-acquisition items are the time-series index
-- [ ] No `sel=time` / titiler dependency on the per-acquisition render path
+- [ ] Renders 200 **once I2/option 2 is live** (until then: blocked, or dual-storage fallback)
 
-> **CP-A (after T1–T5)**: a single discovered product (any tile, S1A/S1C) yields a per-acquisition
-> store + item that **renders directly**, is quality-gated, and is also appended to the tile cube
-> (openable as a datacube). The dual-storage model is proven on one product.
+> **CP-A (after T1–T5)**: a single discovered product (any tile, S1A/S1C) is quality-gated and
+> appended to the tile cube (openable as a datacube), and gets a per-acquisition item that renders its
+> slice via `sel=time` **once I2/option 2 is live** (else dual-storage fallback). Model proven on one product.
 
 ### Task 6 — Port the CDSE watcher to an Argo CronWorkflow (data-driven trigger)  <status: blocked by 1–5>
 **What**: trigger entrypoint (reuse `tile_bbox`/`query_cdse`) queries CDSE for a tile+window, filters
@@ -166,9 +172,9 @@ cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst
 | 2 | Backfill lookback window (days) | T8 | Loïc |
 | 3 | Alerting path (quality-gate FAIL + persistent failures) | T1, T9 | Loïc / infra |
 | 4 | `ensure-dem` discovery (eodag vs direct) + PVC cache layout | T3 | Loïc / me (during T3) |
-| 5 | Per-acquisition store path must match titiler's reconstructed `{base}/{collection}/{item_id}.zarr` — confirm the titiler store base + collection for the per-acquisition collection | T4, T5 | Loïc / infra |
+| 5 | **I2 / option 2** — deploy + verify titiler resolves the store from the item asset href (platform-deploy `ecde99c` adds `TITILER_EOPF_API_ROOT_URL`; re-tested 2026-06-08 **NOT yet effective**). Blocks per-acquisition rendering; fallback = dual storage. | T5 | Loïc / infra (E. Mathot) |
 
-*(Resolved: P8 = dual storage; DEM source = public `copernicus-dem-30m`; Spike 3 = titiler reconstructs store from `{base}/{collection}/{item_id}.zarr` (ignores href) → per-acq stores named = item-id render directly, no titiler change. Dual-storage write cost accepted.)*
+*(Resolved: P8 = shared per-tile cube + per-acquisition items rendering via `sel=time` (option 2); DEM source = public `copernicus-dem-30m`; Spike 3 = titiler currently reconstructs the store + ignores href, so option 2 (`ecde99c`) must land to enable per-acquisition rendering — dual storage is the fallback.)*
 
 ---
 
@@ -177,8 +183,8 @@ cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst
 | Risk | Impact | Mitigation |
 |------|--------|------------|
 | Concurrent same-tile cube writes corrupt the Zarr | **High** | per-tile Argo `synchronization` mutex (T4); region writes; time-present skip |
-| Dual-storage cost (each scene written twice) | Med | accepted (P8); per-acq store is small; cube append is incremental. If titiler later resolves the asset href (I-8 Option A), collapse to single storage |
-| Per-acquisition store not at titiler's reconstructed path → 500 | **High** | stores MUST land at `{titiler-base}/{collection}/{item_id}.zarr` (store-name = item-id); validate one render early (PoC showed the reconstruction rule) |
+| **I2/option 2 (titiler href resolution) not effective** → per-acquisition rendering blocked | **High** (T5) | `ecde99c` adds `TITILER_EOPF_API_ROOT_URL`; deploy + re-verify (re-tested 2026-06-08: still reconstructs). Fallback = dual storage (per-acq stores named = item-id render via reconstruction). Cube + xarray load unaffected |
+| Dual-storage fallback cost (each scene written twice) | Low–Med | only if option 2 stalls; per-acq store is small, cube append incremental |
 | S1C has an unforeseen RTC issue despite the orbit table | Med | T2 is a live S1C verify gate before relying on it; fall back to S1A-only |
 | s1tiling exits non-zero when off-platform (S1C/S1D) downloads fail, even though target succeeded | Med | tolerate off-platform download failures in the s1tiling step (don't fail the run if the wanted platform produced output) — observed in the PoC scene-2 run |
 | `ensure-dem` swath/tile-name derivation wrong → missing DEM | High (silent bad RTC) | unit-test vs known 31TCH set; s1tiling errors on <100% DEM coverage |
@@ -192,9 +198,9 @@ cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst
 ## Done definition
 
 CronWorkflow (6 h, data-driven) submits child Workflows only for new S1A/S1C products across the AOI;
-each tile auto-provisions its DEM; ingest writes a **per-acquisition store** (renders directly) **and
-appends to a per-tile cube** (per-tile writes serialised); ingest is quality-gated (FAIL ⇒ no
-register); each acquisition has a **per-acquisition STAC item that renders directly** (store-name =
-item-id, no titiler change); S1D is skipped; backfill ran once on enable; the acceptance soak
-(5 × 14 × ≥95%) passes on staging and a tile opens as a datacube; the blind cron is retired. Prod
-promotion is Phase 7.
+each tile auto-provisions its DEM; ingest **appends each scene to the per-tile cube** (per-tile writes
+serialised); ingest is quality-gated (FAIL ⇒ no register); each acquisition has a **per-acquisition
+STAC item that renders its slice via `sel=time`** once **I2/option 2** (titiler href resolution) is
+live (dual-storage fallback otherwise); a tile opens as a datacube (xarray) regardless; S1D is skipped;
+backfill ran once on enable; the acceptance soak (5 × 14 × ≥95%) passes on staging; the blind cron is
+retired. Prod promotion is Phase 7.

--- a/claude-docs/plans/s1_grd_phase6_productionization.md
+++ b/claude-docs/plans/s1_grd_phase6_productionization.md
@@ -1,0 +1,198 @@
+# Plan: S1 GRD RTC Productionization — Phase 6 (`claude-docs/specs/s1_grd_phase6_productionization.md`)
+
+**Goal**: an automated, multi-tile, in-cluster S1 GRD RTC service on **staging** — a data-driven
+trigger discovers new CDSE S1A/S1C products, auto-provisions the DEM per tile, and runs
+s1tiling → ingest → quality-gate → register. **Tracked in #226.**
+**Constraint**: keep Script A/B + the merged Argo templates as the single source of pipeline logic
+(new work only *orchestrates* and *gates*); path-guard every destructive op; tests at each new-code
+boundary; **staging only** (prod = Phase 7).
+
+> **Repo split** (as in `subissue_8_cron_sensor.md`): plan authored here (spec lives here); new
+> **scripts** (`ensure_dem.py`, `validate_s1_rtc.py`, trigger entrypoint) ship in **data-pipeline**
+> and bake into the image; new **Argo manifests** (CronWorkflow, ensure-dem step, quality-gate step)
+> ship in **platform-deploy** (`workspaces/devseed-staging/data-pipeline/`). Branch off `main` in each
+> repo *after* the phase-5 PRs (#186 + platform-deploy #207/#208) are merged.
+
+---
+
+## Current state
+
+| Resource | Status |
+|----------|--------|
+| `eopf-explorer-s1tiling` / `ingest-v1-s1rtc` WorkflowTemplates | ✅ merged (PR#207) — child Workflows for decision B |
+| s1tiling cfg render (tile/orbit/date) in template | ✅ exists; **platform_list not yet parametrized** (Task 2) |
+| `s1-dem` PVC (31TCH swath only, manual) + EGM2008 geoid | ✅ bound; **no auto-fetch** (Task 3) |
+| Local watcher `watch_cdse_and_process.py` (query/bbox/dedup) | ✅ logic to port; dedup is file-based → STAC-existence (Task 4) |
+| `validate_s1_grd_rtc` notebook (PASS/WARN/FAIL checks) | ✅ logic to wrap as a CLI gate (Task 1) |
+| Blind daily cron + webhook sensor (sub-issue 8) | ✅ shipped, **suspended** — replaced by the data-driven trigger (Task 4) |
+| Data-driven trigger / ensure-dem / quality-gate steps | ❌ this plan |
+
+---
+
+## Dependency graph
+
+```
+merged templates (s1tiling, ingest)            spec decisions (P1–P7)
+        │                                              │
+        ├── Task 1  quality-gate step (ingest)  ───────┐
+        ├── Task 2  platform S1A+S1C (render)   ───────┤
+        ├── Task 3  ensure-dem auto-fetch       ──┐    │
+        │                                         ▼    ▼
+        └── Task 4  trigger → Argo (query→dedup→submit) ──► Task 5  multi-tile AOI ──┐
+                                  │                                                  ├─► Task 7  soak
+                                  └── Task 6  bounded backfill ──────────────────────┘
+        CP-A after T1–T3 (single product, any tile, S1A+S1C, gated)
+        CP-B after T6   (full automated data-driven multi-tile + backfill)
+        CP-C  = Task 7  (acceptance soak → phase done)
+```
+
+Build order favours **vertical slices that ship value early**: each of T1–T3 improves the *existing*
+single-tile pipeline independently; T4 adds the trigger; T5/T6 scale it; T7 proves it.
+
+---
+
+## Tasks
+
+> Each task: code/manifest + tests; cluster `Verify` steps are run by an operator (no cluster in the
+> dev env). Unit tests for new **scripts** run in CI (`uv run pytest`).
+
+### Task 1 — Quality-gate step (gate register on validation FAIL)  <status: ready>
+**What**: wrap the `validate_s1_grd_rtc` checks into `scripts/validate_s1_rtc.py` — a CLI taking a
+store URI, exiting **0=PASS / 1=WARN / 2=FAIL** with a structured summary. Add a `quality-gate` step
+to the **ingest template** *between* ingest and register: exit 2 → fail the workflow (no register) +
+alert; exit 1 → register + annotate; exit 0 → register. (Mirrors spec P1; **needs OQ #3** for the
+alert path.)
+**Verify**:
+```bash
+uv run pytest tests/unit/test_validate_s1_rtc.py          # PASS/WARN/FAIL on fixtures
+# cluster: run ingest on a good store (registers) and a corrupted store (fails, no item)
+```
+**Acceptance criteria**:
+- [ ] CLI returns 0/1/2 for PASS/WARN/FAIL, unit-tested on good + corrupted fixtures
+- [ ] FAIL → workflow fails, **no STAC item registered**; PASS → item registered
+- [ ] WARN → item registered with an annotation
+- [ ] FAIL emits an alert via the OQ #3 path
+
+### Task 2 — Enable S1A + S1C (platform render)  <status: ready>
+**What**: parametrize `platform_list` in the s1tiling template's `sed` render (default `S1A S1C`), so
+s1tiling will process an S1C scene. (Spec §3; spike confirms S1C is in the orbit table, S1D is not.)
+The query-side **S1D skip** lives in the trigger (Task 4) — this task only proves s1tiling itself
+handles S1C, by a direct submit.
+**Verify**:
+```bash
+# cluster: submit s1tiling for a live S1C scene (e.g. 31TCH 2026-06-06) → A→B → item + validation PASS
+```
+**Acceptance criteria**:
+- [ ] An **S1C** scene processes A→B end-to-end; item queryable + `validate_s1_rtc` PASS
+- [ ] `platform_list` is rendered from a param (not hardcoded), default `S1A S1C`
+
+### Task 3 — `ensure-dem` auto-fetch step (any tile)  <status: blocked by OQ #4>
+**What**: `scripts/ensure_dem.py` — given a tile, compute the S1 IW **swath** bbox, fetch missing
+GLO-30 COGs from the public **`copernicus-dem-30m`** bucket over HTTPS (anon), rename to the
+`Product10` convention, (re)build `DEM_Union.gpkg`; **idempotent** (skip cached tiles). Add an
+`ensure-dem` step before s1tiling writing to the `s1-dem` PVC. Geoid is pre-staged (not fetched).
+**Verify**:
+```bash
+uv run pytest tests/unit/test_ensure_dem.py     # tile→bbox→tile-name derivation; skip-existing; bad tile rejected
+# cluster: run for a NEW tile (not 31TCH) → DEM tiles appear, s1tiling proceeds; re-run skips
+```
+**Acceptance criteria**:
+- [ ] Tile → swath-bbox → GLO-30 tile-name derivation, unit-tested (incl. malformed tile rejected)
+- [ ] A previously-unprovisioned tile runs end-to-end with **no manual DEM upload**
+- [ ] Idempotent: re-run fetches nothing; `DEM_Union.gpkg` consistent
+- [ ] OQ #4 resolved (discovery method; PVC cache layout) and reflected in the step
+
+> **CP-A (after T1–T3)**: a single discovered product, *any* tile, S1A or S1C, runs end-to-end on
+> staging and is quality-gated. The pipeline is no longer 31TCH/S1A-bound. Smallest shippable phase-6 slice.
+
+### Task 4 — Port the CDSE watcher to an Argo CronWorkflow (data-driven trigger)  <status: blocked by 1,2,3>
+**What**: a trigger entrypoint (reuse `tile_bbox`/`query_cdse` from `watch_cdse_and_process.py`) that
+queries CDSE for a tile+window, **filters platform to {S1A,S1C} (skips S1D, logged)**, and emits the
+**new** products — dedup switched from the local JSON state file to a **STAC item-exists check**
+(spec P2). A **CronWorkflow** (every **6 h**) runs the query step and submits one child `Workflow` per
+new product via `workflowTemplateRef` (decision B), **replacing** the suspended blind cron.
+**Verify**:
+```bash
+uv run pytest tests/unit/test_trigger.py        # query→dedup (mocked STAC); new vs already-registered
+# cluster: argo submit --from cronworkflow/... over a data-bearing window → submits only NEW products;
+#          no-data window → submits nothing; immediate re-run → 0 submitted (existence-dedup)
+```
+**Acceptance criteria**:
+- [ ] Submits a child Workflow **only** for products with no existing STAC item (dedup), unit-tested
+- [ ] No-data window submits nothing (zero blind s1tiling runs)
+- [ ] Re-run over the same window submits 0 (idempotent)
+- [ ] S1D products are filtered out at query time with a logged reason (no child Workflow)
+- [ ] The suspended sub-issue-8 cron is retired/replaced (one trigger of record)
+
+### Task 5 — Multi-tile AOI iteration  <status: blocked by 3,4; OQ #1>
+**What**: the CronWorkflow iterates the configured **AOI** tile set; each tile self-provisions its DEM
+(T3) and is queried/deduped/submitted independently (T4). Per-tile failure must not abort the others.
+**Verify**:
+```bash
+# cluster: cron over a ≥2-tile AOI → per-tile child Workflows; a never-seen tile auto-provisions DEM;
+#          one tile failing does not stop the others
+```
+**Acceptance criteria**:
+- [ ] Cron processes every tile in the AOI; per-tile isolation (one failure ≠ whole-run failure)
+- [ ] A new AOI tile auto-provisions its DEM (no manual step)
+- [ ] AOI is config-driven (OQ #1 set)
+
+### Task 6 — Bounded backfill on enable  <status: blocked by 4; OQ #2>
+**What**: the trigger accepts a **backfill lookback** (distinct from the steady-state 6 h window) used
+once on enable; existence-dedup (P2) prevents reprocessing already-registered items.
+**Verify**:
+```bash
+# cluster: enable with backfill=N days → the historical window is processed once;
+#          subsequent scheduled runs only pick up forward products
+```
+**Acceptance criteria**:
+- [ ] The configured lookback is processed on enable **without duplicating** forward items
+- [ ] Backfill volume respects the concurrency limits (no thundering herd) — semaphore honoured
+- [ ] OQ #2 (window size) set
+
+> **CP-B (after T6)**: full automated, data-driven, multi-tile trigger with backfill running on
+> staging. Functionally complete — ready to soak.
+
+### Task 7 — Acceptance soak  <status: blocked by 5,6; OQ #1,#3>
+**What**: run the full system on staging for the soak window; track success rate per the spec bar.
+**Verify**:
+```bash
+# cluster: observe ≥ 14 days across the 5 soak tiles; tally workflow success/fail from Argo + STAC
+```
+**Acceptance criteria**:
+- [ ] **5 tiles × 14 days × ≥ 95% success** on staging
+- [ ] Failures alert via the OQ #3 path and are triaged (no silent drops)
+- [ ] Outcome recorded on #226; phase declared done (staging)
+
+---
+
+## Open questions (pinned to tasks)
+
+| OQ | Question | Blocks | Owner |
+|----|----------|--------|-------|
+| 1 | AOI tile set (+ the 5 soak tiles) | T5, T7 | Loïc / science |
+| 2 | Backfill lookback window (days) | T6 | Loïc |
+| 3 | Alerting path (quality-gate FAIL + persistent failures) | T1, T7 | Loïc / infra |
+| 4 | `ensure-dem` discovery (eodag earth_search vs direct names) + PVC cache layout | T3 | Loïc / me, during T3 |
+
+*(Resolved in spec §7: DEM source = public `copernicus-dem-30m` over HTTPS, no auth.)*
+
+---
+
+## Risks & mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| S1C has an unforeseen RTC issue despite being in the orbit table | Med — Task 2 stalls | Task 2 is a *live* S1C verify gate before relying on it; fall back to S1A-only if it fails |
+| `ensure-dem` swath-bbox / tile-name derivation wrong → missing DEM coverage | High — silent bad RTC | Unit-test the derivation against the known 31TCH tile set; s1tiling already errors on <100% DEM coverage |
+| STAC-existence dedup races indexing latency → duplicate submit | Low | ingest skip-gate is the backstop; child Workflow self-skips (exit-2 contract) |
+| Backfill thundering herd overwhelms the cluster | Med | honour the `v1-s1rtc`/cron semaphores; cap backfill concurrency (Task 6) |
+| `copernicus-dem-30m` anon HTTPS unavailable/rate-limited in-cluster | Med — Task 3 | retry/backoff in `ensure_dem.py`; cache on the PVC so it's a one-time cost per tile |
+| Cross-repo drift (data-pipeline image vs platform-deploy template pin) | Med | pin `pipeline_image_version` to the merged-`main` SHA; document the bump (per #186 follow-up) |
+
+## Done definition
+
+CronWorkflow (6 h, data-driven) submits child Workflows only for new S1A/S1C products across the AOI;
+each tile auto-provisions its DEM; ingest is quality-gated (FAIL ⇒ no register); S1D is skipped;
+backfill ran once on enable; the acceptance soak (5 × 14 × ≥95%) passes on staging; the blind cron is
+retired. Prod promotion is Phase 7.

--- a/claude-docs/plans/s1_grd_phase6_productionization.md
+++ b/claude-docs/plans/s1_grd_phase6_productionization.md
@@ -23,9 +23,9 @@ per-tile cube writes; tests at each new-code boundary; **staging only** (prod = 
 | `eopf-explorer-s1tiling` / `ingest-v1-s1rtc` WorkflowTemplates | ✅ merged (PR#207) |
 | s1tiling cfg render (tile/orbit/date) | ✅ exists; `platform_list` not parametrized (T2) |
 | `s1-dem` PVC (31TCH only, manual) + EGM2008 geoid | ✅ bound; no auto-fetch (T3) |
-| Ingest = **fresh store per run** | ⚠️ must become **time-slice insert into a per-tile cube** (T4) |
-| `eopf_geozarr.build_s1_rtc_stac_item` = **one item per store (datetime range)** | ⚠️ must emit **one item per `time` slice** (T5, upstream) |
-| titiler-eopf `sel=time` rendering | ✅ verified 0.9.0 (Spike 1) |
+| Ingest = **fresh store per run** | ⚠️ → **dual**: per-acq store + append to per-tile cube (T4); append validated by PoC |
+| `eopf_geozarr.build_s1_rtc_stac_item` = one item per store | ✅ reuse as-is with **per-acquisition ids** (T5; no upstream change) |
+| titiler store resolution | ⚠️ reconstructs `{base}/{collection}/{item_id}.zarr`, ignores href (Spike 3) → stores must be named = item-id |
 | Local watcher query/bbox/dedup logic | ✅ port; dedup → per-acquisition STAC item-exists (T6) |
 | Blind daily cron + sensor (sub-issue 8) | ✅ shipped, suspended — replaced by the data-driven trigger (T6) |
 
@@ -38,8 +38,8 @@ merged templates + spec P1–P8
    ├── T1 quality-gate step (ingest) ─────────────┐
    ├── T2 platform S1A+S1C (render) ──────────────┤
    ├── T3 ensure-dem auto-fetch ──────────────────┤
-   ├── T4 cube ingest (time-slice insert + mutex) ─┤   ┐ P8 datacube
-   └── T5 per-acquisition catalogue (builder PR + sel links) ┘ (T4 ⟂ T5)
+   ├── T4 dual ingest (per-acq store + cube append + mutex) ─┤   ┐ P8 dual storage
+   └── T5 per-acquisition catalogue (renders directly) ──────┘ (T4 → T5)
                          │
                          ▼
         T6 trigger → Argo (dedup = per-acq item-exists + cube time-present)
@@ -86,33 +86,35 @@ Argo `ensure-dem` step before s1tiling, writing the `s1-dem` PVC. Geoid pre-stag
 - [ ] previously-unprovisioned tile runs end-to-end, no manual DEM upload
 - [ ] idempotent re-run fetches nothing; OQ #4 resolved
 
-### Task 4 — Datacube ingest: insert acquisition as a `time` slice  <status: blocked by spec P8>
-**What**: change ingest from *fresh store per run* to **inserting the scene as a new `time` slice into
-the per-tile cube** (`s1-grd-rtc-{tile}.zarr`) via a Zarr region/append write; **skip if the time is
-already present** (idempotency). Serialise concurrent writes to the same tile with an **Argo
-`synchronization` mutex keyed on the tile**. (P8 storage; the contamination-fix cleanup logic adapts —
-no wholesale overwrite.)
-**Verify**: `uv run pytest tests/unit/test_ingest_cube_insert.py` (insert into empty/existing cube; duplicate-time skip); cluster: 2 scenes same tile → both time slices present, store opens as a cube; concurrent submit → no corruption.
+### Task 4 — Dual-storage ingest: per-acquisition store + per-tile cube append  <status: ready (PoC-validated mechanics)>
+**What**: ingest writes **two** artifacts per scene (P8): (a) a **per-acquisition single-time store**
+named = its item id (`s1-rtc-{tile}-{datetime}.zarr`) for rendering, and (b) **append the scene as a
+new `time` slice into the per-tile cube** (`s1-rtc-{tile}.zarr`) for analysis (Zarr region/append;
+**skip a time already present**). Serialise cube writes with an **Argo `synchronization` mutex keyed on
+the tile**. The PoC proved the append works via the existing `ingest_s1tiling_acquisition` (`mode=r+`);
+the per-acquisition store is the proven phase-5 single-acquisition store.
+**Verify**: `uv run pytest tests/unit/test_ingest_dual.py` (per-acq store + cube append; duplicate-time skip); cluster: 2 scenes same tile → 2 per-acq stores + a 2-time cube; concurrent submit → no corruption.
 **Acceptance**:
-- [ ] A 2nd acquisition appends a `time` slice (cube has N times), unit-tested
-- [ ] Re-ingesting an existing time is a no-op (no duplicate slice)
-- [ ] Concurrent same-tile writes serialised (mutex) — no corruption
+- [ ] Each scene yields its own single-time store (name = item id) **and** a `time` slice in the cube
+- [ ] Re-ingesting an existing time is a no-op (no duplicate slice/store)
+- [ ] Concurrent same-tile cube writes serialised (mutex) — no corruption
 - [ ] `xr.open_dataset(cube)` exposes all scenes on `time`
 
-### Task 5 — Per-acquisition catalogue (builder + `sel=time` links)  <status: blocked by OQ #5>
-**What**: (a) **upstream `eopf-geozarr`**: emit **one STAC item per `time` slice**
-(`s1-rtc-{tile}-{datetime}`, `datetime`=scene time, assets → cube) instead of one-per-store; (b)
-`scripts/register_v1.py`: append `&sel=time=nearest::{datetime}` to the S1 viz/xyz/tilejson/thumbnail
-links (~few lines); (c) `register_v1_s1_rtc.py`: upsert the **list** of per-acquisition items. (P8 catalogue.)
-**Verify**: `uv run pytest tests/unit/test_register_v1_s1_rtc.py` (per-acquisition ids + `sel=time` in links); cluster: an item's XYZ/preview renders its slice (`sel=time`), distinct dates → distinct items.
+### Task 5 — Per-acquisition catalogue (renders directly)  <status: ready>
+**What**: emit **one STAC item per acquisition** (`s1-rtc-{tile}-{datetime}`, single `datetime`)
+pointing at its **per-acquisition store** → **renders directly** (store-name = item-id matches titiler
+reconstruction; **no `sel=time`, no titiler change** — Spike 3). Reuse the phase-5 builder with
+per-acquisition ids; `register_v1_s1_rtc.py` upserts each. Also (re)register the per-tile cube item
+for analysis. **No upstream data-model change required.**
+**Verify**: `uv run pytest tests/unit/test_register_v1_s1_rtc.py` (per-acquisition ids); cluster: each item's XYZ/preview renders (HTTP 200); distinct dates → distinct items.
 **Acceptance**:
-- [ ] Builder emits one item per `time` slice (id `s1-rtc-{tile}-{datetime}`, single `datetime`)
-- [ ] Viz/XYZ/tilejson/thumbnail links carry `sel=time=nearest::{datetime}` and render the right slice
-- [ ] Register upserts all per-acquisition items; OQ #5 (data-model PR) landed
+- [ ] One item per acquisition (id `s1-rtc-{tile}-{datetime}`, single `datetime`), renders directly (200)
+- [ ] Per-tile cube item present for analysis; per-acquisition items are the time-series index
+- [ ] No `sel=time` / titiler dependency on the per-acquisition render path
 
-> **CP-A (after T1–T5)**: a single discovered product (any tile, S1A/S1C) lands as a `time` slice in
-> the tile cube, is quality-gated, and gets a per-acquisition item that renders via `sel=time`. The
-> datacube model is proven on one product.
+> **CP-A (after T1–T5)**: a single discovered product (any tile, S1A/S1C) yields a per-acquisition
+> store + item that **renders directly**, is quality-gated, and is also appended to the tile cube
+> (openable as a datacube). The dual-storage model is proven on one product.
 
 ### Task 6 — Port the CDSE watcher to an Argo CronWorkflow (data-driven trigger)  <status: blocked by 1–5>
 **What**: trigger entrypoint (reuse `tile_bbox`/`query_cdse`) queries CDSE for a tile+window, filters
@@ -164,9 +166,9 @@ cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst
 | 2 | Backfill lookback window (days) | T8 | Loïc |
 | 3 | Alerting path (quality-gate FAIL + persistent failures) | T1, T9 | Loïc / infra |
 | 4 | `ensure-dem` discovery (eodag vs direct) + PVC cache layout | T3 | Loïc / me (during T3) |
-| 5 | **`eopf-geozarr` per-acquisition builder PR** — owner + timeline | T5 | Loïc / data-model |
+| 5 | Per-acquisition store path must match titiler's reconstructed `{base}/{collection}/{item_id}.zarr` — confirm the titiler store base + collection for the per-acquisition collection | T4, T5 | Loïc / infra |
 
-*(Resolved in spec §7: DEM source = public `copernicus-dem-30m`; Spike 1 titiler `sel=time`; Spike 2 sizing.)*
+*(Resolved: P8 = dual storage; DEM source = public `copernicus-dem-30m`; Spike 3 = titiler reconstructs store from `{base}/{collection}/{item_id}.zarr` (ignores href) → per-acq stores named = item-id render directly, no titiler change. Dual-storage write cost accepted.)*
 
 ---
 
@@ -175,8 +177,10 @@ cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst
 | Risk | Impact | Mitigation |
 |------|--------|------------|
 | Concurrent same-tile cube writes corrupt the Zarr | **High** | per-tile Argo `synchronization` mutex (T4); region writes; time-present skip |
-| `eopf-geozarr` per-acquisition builder slips (upstream) | **High** — T5 blocks T6 register | land OQ #5 early; interim: a local builder wrapper over the existing geometry/proj logic |
+| Dual-storage cost (each scene written twice) | Med | accepted (P8); per-acq store is small; cube append is incremental. If titiler later resolves the asset href (I-8 Option A), collapse to single storage |
+| Per-acquisition store not at titiler's reconstructed path → 500 | **High** | stores MUST land at `{titiler-base}/{collection}/{item_id}.zarr` (store-name = item-id); validate one render early (PoC showed the reconstruction rule) |
 | S1C has an unforeseen RTC issue despite the orbit table | Med | T2 is a live S1C verify gate before relying on it; fall back to S1A-only |
+| s1tiling exits non-zero when off-platform (S1C/S1D) downloads fail, even though target succeeded | Med | tolerate off-platform download failures in the s1tiling step (don't fail the run if the wanted platform produced output) — observed in the PoC scene-2 run |
 | `ensure-dem` swath/tile-name derivation wrong → missing DEM | High (silent bad RTC) | unit-test vs known 31TCH set; s1tiling errors on <100% DEM coverage |
 | STAC-existence dedup races indexing latency | Low | cube time-present check is the backstop |
 | Backfill thundering herd | Med | semaphore + per-tile mutex; cap backfill concurrency (T8) |
@@ -188,8 +192,9 @@ cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst
 ## Done definition
 
 CronWorkflow (6 h, data-driven) submits child Workflows only for new S1A/S1C products across the AOI;
-each tile auto-provisions its DEM and **accumulates a multi-temporal cube** (one `time` slice per
-acquisition, per-tile writes serialised); ingest is quality-gated (FAIL ⇒ no register); each
-acquisition has a **per-acquisition STAC item** rendering via `sel=time`; S1D is skipped; backfill ran
-once on enable; the acceptance soak (5 × 14 × ≥95%) passes on staging and a tile opens as a cube; the
-blind cron is retired. Prod promotion is Phase 7.
+each tile auto-provisions its DEM; ingest writes a **per-acquisition store** (renders directly) **and
+appends to a per-tile cube** (per-tile writes serialised); ingest is quality-gated (FAIL ⇒ no
+register); each acquisition has a **per-acquisition STAC item that renders directly** (store-name =
+item-id, no titiler change); S1D is skipped; backfill ran once on enable; the acceptance soak
+(5 × 14 × ≥95%) passes on staging and a tile opens as a datacube; the blind cron is retired. Prod
+promotion is Phase 7.

--- a/claude-docs/plans/s1_grd_phase6_productionization.md
+++ b/claude-docs/plans/s1_grd_phase6_productionization.md
@@ -39,7 +39,7 @@ merged templates + spec P1–P8
    ├── T2 platform S1A+S1C (render) ──────────────┤
    ├── T3 ensure-dem auto-fetch ──────────────────┤
    ├── T4 datacube ingest (append to per-tile cube + mutex) ─┤   ┐ P8 cube + per-acq items
-   └── T5 per-acquisition catalogue (sel=time; needs I2/opt-2) ┘ (T4 → T5)
+   └── T5 per-acquisition catalogue + notebook validation ────┘ (T4 → T5; render deferred)
                          │
                          ▼
         T6 trigger → Argo (dedup = per-acq item-exists + cube time-present)
@@ -96,8 +96,8 @@ Argo `ensure-dem` step before s1tiling, writing the `s1-dem` PVC. Geoid pre-stag
 **What**: ingest **appends the scene as a new `time` slice into the per-tile cube**
 (`s1-rtc-{tile}.zarr`, `sentinel-1-grd-rtc-staging`) via the existing `ingest_s1tiling_acquisition`
 (`mode=r+`, PoC-validated); **skip a `time` already present**; serialise per-tile writes with an **Argo
-`synchronization` mutex keyed on the tile**. *(Fallback if I2/option 2 stalls: also write a
-per-acquisition single-time store named = item-id for reconstruction-based rendering — dual storage.)*
+`synchronization` mutex keyed on the tile**. Single shared cube (rendering deferred → no per-acquisition
+stores).
 **Verify**: `uv run pytest tests/unit/test_ingest_cube.py` (append into empty/existing cube; duplicate-time skip); cluster: 2 scenes same tile → a 2-time cube; concurrent submit → no corruption.
 **Acceptance**:
 - [ ] A 2nd acquisition appends a `time` slice (cube has N times), unit-tested
@@ -105,18 +105,18 @@ per-acquisition single-time store named = item-id for reconstruction-based rende
 - [ ] Concurrent same-tile writes serialised (mutex) — no corruption
 - [ ] `xr.open_dataset(cube)` exposes all scenes on `time`
 
-### Task 5 — Per-acquisition catalogue (renders via `sel=time`)  <status: blocked by I2/option 2>
-**What**: emit **one STAC item per acquisition** (`s1-rtc-{tile}-{datetime}`, single `datetime`,
-collection `sentinel-1-grd-rtc-acquisitions`) pointing at the **per-tile cube** via asset href, with
-viz/xyz/tilejson links carrying `sel=time=nearest::{datetime}`. **Renders once I2/option 2** (titiler
-resolves the store from the href; platform-deploy `ecde99c`) **is deployed + verified** (re-tested
-2026-06-08: not yet effective). Reuse the phase-5 builder with per-acquisition ids; also (re)register
-the per-tile cube item (`sentinel-1-grd-rtc-staging`) for analysis. No upstream data-model change.
-**Verify**: `uv run pytest tests/unit/test_register_v1_s1_rtc.py` (per-acquisition ids + `sel=time` links); cluster (after option 2 live): each item's XYZ/preview renders its slice (HTTP 200); distinct dates → distinct slices.
+### Task 5 — Per-acquisition catalogue + notebook validation  <status: ready>
+**What**: emit **one queryable STAC item per acquisition** (`s1-rtc-{tile}-{datetime}`, single
+`datetime`, collection `sentinel-1-grd-rtc-acquisitions`) indexing its cube slice (asset href + time);
+also (re)register the per-tile cube item (`sentinel-1-grd-rtc-staging`). Reuse the phase-5 builder with
+per-acquisition ids (no upstream change). **Validate via the `validate_s1_grd_rtc` notebook** (open the
+cube → PASS) + STAC queries. **Explorer rendering deferred (I2/option 2)** — bake `sel=time` links into
+the items now so they render later when option 2 lands, with **no data change**.
+**Verify**: `uv run pytest tests/unit/test_register_v1_s1_rtc.py` (per-acquisition ids); cluster: items queryable in STAC; `validate_s1_grd_rtc` notebook returns PASS against the cube; distinct dates → distinct items.
 **Acceptance**:
-- [ ] One item per acquisition (id `s1-rtc-{tile}-{datetime}`, single `datetime`), `sel=time` links
-- [ ] Per-tile cube item present for analysis; per-acquisition items are the time-series index
-- [ ] Renders 200 **once I2/option 2 is live** (until then: blocked, or dual-storage fallback)
+- [ ] One queryable item per acquisition (id `s1-rtc-{tile}-{datetime}`); per-tile cube item present
+- [ ] `validate_s1_grd_rtc` notebook **PASS** against the tile cube
+- [ ] `sel=time` links baked in (explorer render deferred to I2/option 2; no later data change)
 
 > **CP-A (after T1–T5)**: a single discovered product (any tile, S1A/S1C) is quality-gated and
 > appended to the tile cube (openable as a datacube), and gets a per-acquisition item that renders its
@@ -172,9 +172,29 @@ cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst
 | 2 | Backfill lookback window (days) | T8 | Loïc |
 | 3 | Alerting path (quality-gate FAIL + persistent failures) | T1, T9 | Loïc / infra |
 | 4 | `ensure-dem` discovery (eodag vs direct) + PVC cache layout | T3 | Loïc / me (during T3) |
-| 5 | **I2 / option 2** — deploy + verify titiler resolves the store from the item asset href (platform-deploy `ecde99c` adds `TITILER_EOPF_API_ROOT_URL`; re-tested 2026-06-08 **NOT yet effective**). Blocks per-acquisition rendering; fallback = dual storage. | T5 | Loïc / infra (E. Mathot) |
+| 5 | **Titiler rendering (I2/option 2) — DEFERRED**, tracked in its own follow-up issue (see below). Not a phase-6 blocker; per-acquisition items render later with no data change. | — (deferred) | Loïc / infra |
 
-*(Resolved: P8 = shared per-tile cube + per-acquisition items rendering via `sel=time` (option 2); DEM source = public `copernicus-dem-30m`; Spike 3 = titiler currently reconstructs the store + ignores href, so option 2 (`ecde99c`) must land to enable per-acquisition rendering — dual storage is the fallback.)*
+*(Resolved: P8 = shared per-tile cube + per-acquisition items (queryable index), validated by the `validate_s1_grd_rtc` notebook; explorer/titiler rendering **deferred** off the critical path; DEM source = public `copernicus-dem-30m`; Spike 3 = titiler reconstructs the store + ignores href, so a titiler change (I2/option 2, `ecde99c`) is needed for rendering — tracked separately.)*
+
+---
+
+## Deferred follow-ups (create tracking issues)
+
+### Task D1 — **Create a tracking issue: "S1 GRD RTC — titiler rendering support (I2/option 2)"**  <status: DONE — #228>
+**What**: open a GitHub issue (linked from #226) capturing everything needed to turn on explorer
+rendering of the per-acquisition items, deferred out of phase 6. The issue body should list:
+- **Make titiler resolve the store from the STAC item asset href** (not path reconstruction) — verify
+  whether platform-deploy `ecde99c` (`TITILER_EOPF_API_ROOT_URL`) achieves it once deployed
+  (re-tested 2026-06-08: still reconstructs `…fra/tests-output/{collection}/{item_id}.zarr`); if not,
+  land titiler-eopf I-8 Option A (resolve from `asset_info["href"]`/`alternate`).
+- **Verify `sel=time` slice rendering** end-to-end: a per-acquisition item renders *its* slice of the
+  multi-time cube (HTTP 200, correct slice) — the phase-6 items already bake `sel=time` links.
+- **Per-mission bucket addressing**: confirm titiler can resolve stores across per-mission buckets
+  (the single `TITILER_EOPF_STORE_URL` base can't — this is why href resolution is needed).
+- Re-run `analysis/poc_s1_datacube_hybrid.py` render checks as the acceptance gate.
+**Verify**: issue exists, linked from #226, with the checklist above.
+**Acceptance**:
+- [x] Tracking issue created (#228) + linked from #226; referenced in the spec
 
 ---
 
@@ -183,8 +203,7 @@ cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst
 | Risk | Impact | Mitigation |
 |------|--------|------------|
 | Concurrent same-tile cube writes corrupt the Zarr | **High** | per-tile Argo `synchronization` mutex (T4); region writes; time-present skip |
-| **I2/option 2 (titiler href resolution) not effective** → per-acquisition rendering blocked | **High** (T5) | `ecde99c` adds `TITILER_EOPF_API_ROOT_URL`; deploy + re-verify (re-tested 2026-06-08: still reconstructs). Fallback = dual storage (per-acq stores named = item-id render via reconstruction). Cube + xarray load unaffected |
-| Dual-storage fallback cost (each scene written twice) | Low–Med | only if option 2 stalls; per-acq store is small, cube append incremental |
+| Titiler rendering (I2/option 2) not yet effective | **Low** (deferred) | rendering is out of scope for phase 6 — tracked in Task D1; per-acquisition items pre-bake `sel=time` so they render later with no data change; cube + xarray + notebook validation are unaffected |
 | S1C has an unforeseen RTC issue despite the orbit table | Med | T2 is a live S1C verify gate before relying on it; fall back to S1A-only |
 | s1tiling exits non-zero when off-platform (S1C/S1D) downloads fail, even though target succeeded | Med | tolerate off-platform download failures in the s1tiling step (don't fail the run if the wanted platform produced output) — observed in the PoC scene-2 run |
 | `ensure-dem` swath/tile-name derivation wrong → missing DEM | High (silent bad RTC) | unit-test vs known 31TCH set; s1tiling errors on <100% DEM coverage |
@@ -199,8 +218,8 @@ cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst
 
 CronWorkflow (6 h, data-driven) submits child Workflows only for new S1A/S1C products across the AOI;
 each tile auto-provisions its DEM; ingest **appends each scene to the per-tile cube** (per-tile writes
-serialised); ingest is quality-gated (FAIL ⇒ no register); each acquisition has a **per-acquisition
-STAC item that renders its slice via `sel=time`** once **I2/option 2** (titiler href resolution) is
-live (dual-storage fallback otherwise); a tile opens as a datacube (xarray) regardless; S1D is skipped;
-backfill ran once on enable; the acceptance soak (5 × 14 × ≥95%) passes on staging; the blind cron is
-retired. Prod promotion is Phase 7.
+serialised); ingest is quality-gated (FAIL ⇒ no register); each acquisition has a **queryable
+per-acquisition STAC item**; a tile **opens as a datacube (xarray)** and the **`validate_s1_grd_rtc`
+notebook returns PASS**; S1D is skipped; backfill ran once on enable; the acceptance soak
+(5 × 14 × ≥95%) passes on staging. Explorer/titiler rendering is **deferred** (tracked in Task D1);
+prod promotion is Phase 7. The blind cron is retired.

--- a/claude-docs/plans/s1_grd_phase6_productionization.md
+++ b/claude-docs/plans/s1_grd_phase6_productionization.md
@@ -9,10 +9,10 @@ work *orchestrates*, *gates*, and *accumulates the cube*); path-guard every dest
 per-tile cube writes; tests at each new-code boundary; **staging only** (prod = Phase 7).
 
 > **Repo split**: plan authored here; new **scripts** (`ensure_dem.py`, `validate_s1_rtc.py`, cube
-> time-slice insert, trigger entrypoint) + the **`eopf-geozarr` per-acquisition builder** ship in
-> data-pipeline / the data-model repo; new **Argo manifests** (CronWorkflow, ensure-dem + quality-gate
-> steps, per-tile mutex) ship in **platform-deploy**. Branch off `main` once phase-5 (#186 +
-> platform-deploy #207/#208) is merged.
+> time-slice append, per-acquisition register, trigger entrypoint) ship in **data-pipeline** (reusing
+> the existing `eopf_geozarr` builder with per-acquisition ids — no upstream data-model change); new
+> **Argo manifests** (CronWorkflow, ensure-dem + quality-gate steps, per-tile mutex) ship in
+> **platform-deploy**. Branch off `main` once phase-5 (#186 + platform-deploy #207/#208) is merged.
 
 ---
 
@@ -25,7 +25,7 @@ per-tile cube writes; tests at each new-code boundary; **staging only** (prod = 
 | `s1-dem` PVC (31TCH only, manual) + EGM2008 geoid | ✅ bound; no auto-fetch (T3) |
 | Ingest = **fresh store per run** | ⚠️ → **append scene to per-tile cube** (T4); append validated by PoC |
 | `eopf_geozarr.build_s1_rtc_stac_item` = one item per store | ✅ reuse with **per-acquisition ids** + `sel=time` links (T5; no upstream change) |
-| titiler store resolution | ⚠️ reconstructs + ignores href (Spike 3); **I2/option 2** (`ecde99c`) to fix it — not yet effective; blocks per-acq rendering |
+| titiler store resolution | ⚠️ reconstructs + ignores href (Spike 3); explorer rendering **deferred (#228)** — not a phase blocker (validation is via notebook) |
 | Local watcher query/bbox/dedup logic | ✅ port; dedup → per-acquisition STAC item-exists (T6) |
 | Blind daily cron + sensor (sub-issue 8) | ✅ shipped, suspended — replaced by the data-driven trigger (T6) |
 
@@ -115,12 +115,14 @@ the items now so they render later when option 2 lands, with **no data change**.
 **Verify**: `uv run pytest tests/unit/test_register_v1_s1_rtc.py` (per-acquisition ids); cluster: items queryable in STAC; `validate_s1_grd_rtc` notebook returns PASS against the cube; distinct dates → distinct items.
 **Acceptance**:
 - [ ] One queryable item per acquisition (id `s1-rtc-{tile}-{datetime}`); per-tile cube item present
-- [ ] `validate_s1_grd_rtc` notebook **PASS** against the tile cube
-- [ ] `sel=time` links baked in (explorer render deferred to I2/option 2; no later data change)
+- [ ] **`validate_s1_grd_rtc` confirmed/extended for a *multi-time* cube** (it was written for a
+      single-acquisition store — verify it validates every `time`, or update it) and returns **PASS**
+- [ ] `sel=time` links baked in (explorer render deferred to #228; no later data change)
 
-> **CP-A (after T1–T5)**: a single discovered product (any tile, S1A/S1C) is quality-gated and
-> appended to the tile cube (openable as a datacube), and gets a per-acquisition item that renders its
-> slice via `sel=time` **once I2/option 2 is live** (else dual-storage fallback). Model proven on one product.
+> **CP-A (after T1–T5)**: a single discovered product (any tile, S1A/S1C) is quality-gated, **appended
+> to the tile cube** (which opens as a datacube), and gets a **queryable per-acquisition STAC item**;
+> the `validate_s1_grd_rtc` notebook **PASSes** against the cube. Model proven on one product.
+> (Explorer rendering deferred — #228.)
 
 ### Task 6 — Port the CDSE watcher to an Argo CronWorkflow (data-driven trigger)  <status: blocked by 1–5>
 **What**: trigger entrypoint (reuse `tile_bbox`/`query_cdse`) queries CDSE for a tile+window, filters
@@ -156,10 +158,11 @@ cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst
 
 ### Task 9 — Acceptance soak  <status: blocked by 7,8; OQ #1,#3>
 **What**: run the full system on staging for the soak window; track success rate.
-**Verify**: cluster — ≥14 days × 5 soak tiles; tally success/fail from Argo + STAC; spot-check a tile opens as a multi-time cube.
+**Verify**: cluster — ≥14 days × 5 soak tiles; tally success/fail from Argo + STAC; run `validate_s1_grd_rtc` on each soak tile's cube.
 **Acceptance**:
 - [ ] **5 tiles × 14 days × ≥ 95% success** on staging
-- [ ] Each soak tile opens as a cube with all its scenes; failures alert (OQ #3) + triaged
+- [ ] Each soak tile opens as a cube with all its scenes **and `validate_s1_grd_rtc` PASSes**;
+      failures alert (OQ #3) + triaged
 - [ ] Outcome recorded on #226; phase done (staging)
 
 ---

--- a/claude-docs/plans/s1_grd_phase6_productionization.md
+++ b/claude-docs/plans/s1_grd_phase6_productionization.md
@@ -1,17 +1,18 @@
 # Plan: S1 GRD RTC Productionization — Phase 6 (`claude-docs/specs/s1_grd_phase6_productionization.md`)
 
 **Goal**: an automated, multi-tile, in-cluster S1 GRD RTC service on **staging** — a data-driven
-trigger discovers new CDSE S1A/S1C products, auto-provisions the DEM per tile, and runs
-s1tiling → ingest → quality-gate → register. **Tracked in #226.**
-**Constraint**: keep Script A/B + the merged Argo templates as the single source of pipeline logic
-(new work only *orchestrates* and *gates*); path-guard every destructive op; tests at each new-code
-boundary; **staging only** (prod = Phase 7).
+trigger discovers new CDSE S1A/S1C products, auto-provisions the DEM per tile, runs
+s1tiling → ingest → quality-gate → register, storing each tile as a **multi-temporal datacube** with
+**per-acquisition STAC items** (P8). **Tracked in #226.**
+**Constraint**: keep Script A/B + merged Argo templates as the single source of pipeline logic (new
+work *orchestrates*, *gates*, and *accumulates the cube*); path-guard every destructive op; serialise
+per-tile cube writes; tests at each new-code boundary; **staging only** (prod = Phase 7).
 
-> **Repo split** (as in `subissue_8_cron_sensor.md`): plan authored here (spec lives here); new
-> **scripts** (`ensure_dem.py`, `validate_s1_rtc.py`, trigger entrypoint) ship in **data-pipeline**
-> and bake into the image; new **Argo manifests** (CronWorkflow, ensure-dem step, quality-gate step)
-> ship in **platform-deploy** (`workspaces/devseed-staging/data-pipeline/`). Branch off `main` in each
-> repo *after* the phase-5 PRs (#186 + platform-deploy #207/#208) are merged.
+> **Repo split**: plan authored here; new **scripts** (`ensure_dem.py`, `validate_s1_rtc.py`, cube
+> time-slice insert, trigger entrypoint) + the **`eopf-geozarr` per-acquisition builder** ship in
+> data-pipeline / the data-model repo; new **Argo manifests** (CronWorkflow, ensure-dem + quality-gate
+> steps, per-tile mutex) ship in **platform-deploy**. Branch off `main` once phase-5 (#186 +
+> platform-deploy #207/#208) is merged.
 
 ---
 
@@ -19,150 +20,139 @@ boundary; **staging only** (prod = Phase 7).
 
 | Resource | Status |
 |----------|--------|
-| `eopf-explorer-s1tiling` / `ingest-v1-s1rtc` WorkflowTemplates | ✅ merged (PR#207) — child Workflows for decision B |
-| s1tiling cfg render (tile/orbit/date) in template | ✅ exists; **platform_list not yet parametrized** (Task 2) |
-| `s1-dem` PVC (31TCH swath only, manual) + EGM2008 geoid | ✅ bound; **no auto-fetch** (Task 3) |
-| Local watcher `watch_cdse_and_process.py` (query/bbox/dedup) | ✅ logic to port; dedup is file-based → STAC-existence (Task 4) |
-| `validate_s1_grd_rtc` notebook (PASS/WARN/FAIL checks) | ✅ logic to wrap as a CLI gate (Task 1) |
-| Blind daily cron + webhook sensor (sub-issue 8) | ✅ shipped, **suspended** — replaced by the data-driven trigger (Task 4) |
-| Data-driven trigger / ensure-dem / quality-gate steps | ❌ this plan |
+| `eopf-explorer-s1tiling` / `ingest-v1-s1rtc` WorkflowTemplates | ✅ merged (PR#207) |
+| s1tiling cfg render (tile/orbit/date) | ✅ exists; `platform_list` not parametrized (T2) |
+| `s1-dem` PVC (31TCH only, manual) + EGM2008 geoid | ✅ bound; no auto-fetch (T3) |
+| Ingest = **fresh store per run** | ⚠️ must become **time-slice insert into a per-tile cube** (T4) |
+| `eopf_geozarr.build_s1_rtc_stac_item` = **one item per store (datetime range)** | ⚠️ must emit **one item per `time` slice** (T5, upstream) |
+| titiler-eopf `sel=time` rendering | ✅ verified 0.9.0 (Spike 1) |
+| Local watcher query/bbox/dedup logic | ✅ port; dedup → per-acquisition STAC item-exists (T6) |
+| Blind daily cron + sensor (sub-issue 8) | ✅ shipped, suspended — replaced by the data-driven trigger (T6) |
 
 ---
 
 ## Dependency graph
 
 ```
-merged templates (s1tiling, ingest)            spec decisions (P1–P7)
-        │                                              │
-        ├── Task 1  quality-gate step (ingest)  ───────┐
-        ├── Task 2  platform S1A+S1C (render)   ───────┤
-        ├── Task 3  ensure-dem auto-fetch       ──┐    │
-        │                                         ▼    ▼
-        └── Task 4  trigger → Argo (query→dedup→submit) ──► Task 5  multi-tile AOI ──┐
-                                  │                                                  ├─► Task 7  soak
-                                  └── Task 6  bounded backfill ──────────────────────┘
-        CP-A after T1–T3 (single product, any tile, S1A+S1C, gated)
-        CP-B after T6   (full automated data-driven multi-tile + backfill)
-        CP-C  = Task 7  (acceptance soak → phase done)
+merged templates + spec P1–P8
+   ├── T1 quality-gate step (ingest) ─────────────┐
+   ├── T2 platform S1A+S1C (render) ──────────────┤
+   ├── T3 ensure-dem auto-fetch ──────────────────┤
+   ├── T4 cube ingest (time-slice insert + mutex) ─┤   ┐ P8 datacube
+   └── T5 per-acquisition catalogue (builder PR + sel links) ┘ (T4 ⟂ T5)
+                         │
+                         ▼
+        T6 trigger → Argo (dedup = per-acq item-exists + cube time-present)
+                         │                                   │
+                         ├── T7 multi-tile AOI ──────────────┤
+                         └── T8 bounded backfill ────────────┴──► T9 acceptance soak
+   CP-A after T1–T5 (one acquisition → cube slice + per-acq item, gated, any tile, S1A/S1C)
+   CP-B after T8   (automated multi-tile data-driven trigger + backfill; cube accumulates)
+   CP-C  = T9      (acceptance soak → phase done)
 ```
 
-Build order favours **vertical slices that ship value early**: each of T1–T3 improves the *existing*
-single-tile pipeline independently; T4 adds the trigger; T5/T6 scale it; T7 proves it.
+Vertical slices: T1–T3 improve the existing pipeline independently; **T4+T5 deliver the datacube
+model** (P8); T6 adds the trigger; T7/T8 scale; T9 proves it.
 
 ---
 
 ## Tasks
 
-> Each task: code/manifest + tests; cluster `Verify` steps are run by an operator (no cluster in the
-> dev env). Unit tests for new **scripts** run in CI (`uv run pytest`).
-
 ### Task 1 — Quality-gate step (gate register on validation FAIL)  <status: ready>
-**What**: wrap the `validate_s1_grd_rtc` checks into `scripts/validate_s1_rtc.py` — a CLI taking a
-store URI, exiting **0=PASS / 1=WARN / 2=FAIL** with a structured summary. Add a `quality-gate` step
-to the **ingest template** *between* ingest and register: exit 2 → fail the workflow (no register) +
-alert; exit 1 → register + annotate; exit 0 → register. (Mirrors spec P1; **needs OQ #3** for the
-alert path.)
-**Verify**:
-```bash
-uv run pytest tests/unit/test_validate_s1_rtc.py          # PASS/WARN/FAIL on fixtures
-# cluster: run ingest on a good store (registers) and a corrupted store (fails, no item)
-```
-**Acceptance criteria**:
-- [ ] CLI returns 0/1/2 for PASS/WARN/FAIL, unit-tested on good + corrupted fixtures
-- [ ] FAIL → workflow fails, **no STAC item registered**; PASS → item registered
-- [ ] WARN → item registered with an annotation
-- [ ] FAIL emits an alert via the OQ #3 path
+**What**: `scripts/validate_s1_rtc.py` CLI (wrap the notebook checks) → exit **0=PASS/1=WARN/2=FAIL**.
+Add a `quality-gate` step in the ingest template *between* ingest and register: 2 → fail (no register)
++ alert; 1 → register + annotate; 0 → register. (P1; alert path = OQ #3.)
+**Verify**: `uv run pytest tests/unit/test_validate_s1_rtc.py`; cluster: good store registers, corrupted store fails (no item).
+**Acceptance**:
+- [ ] CLI returns 0/1/2, unit-tested on good + corrupted fixtures
+- [ ] FAIL → no item registered; PASS → registered; WARN → registered + annotated
+- [ ] FAIL alerts via OQ #3
 
 ### Task 2 — Enable S1A + S1C (platform render)  <status: ready>
-**What**: parametrize `platform_list` in the s1tiling template's `sed` render (default `S1A S1C`), so
-s1tiling will process an S1C scene. (Spec §3; spike confirms S1C is in the orbit table, S1D is not.)
-The query-side **S1D skip** lives in the trigger (Task 4) — this task only proves s1tiling itself
-handles S1C, by a direct submit.
-**Verify**:
-```bash
-# cluster: submit s1tiling for a live S1C scene (e.g. 31TCH 2026-06-06) → A→B → item + validation PASS
-```
-**Acceptance criteria**:
-- [ ] An **S1C** scene processes A→B end-to-end; item queryable + `validate_s1_rtc` PASS
-- [ ] `platform_list` is rendered from a param (not hardcoded), default `S1A S1C`
+**What**: parametrize `platform_list` in the s1tiling template `sed` render (default `S1A S1C`); prove
+s1tiling handles S1C by a direct submit. (Query-side S1D skip = T6.)
+**Verify**: cluster — live S1C scene (31TCH 2026-06-06) → A→B → item + `validate_s1_rtc` PASS.
+**Acceptance**:
+- [ ] S1C scene processes A→B end-to-end; item queryable + PASS
+- [ ] `platform_list` rendered from a param (default `S1A S1C`), not hardcoded
 
-### Task 3 — `ensure-dem` auto-fetch step (any tile)  <status: blocked by OQ #4>
-**What**: `scripts/ensure_dem.py` — given a tile, compute the S1 IW **swath** bbox, fetch missing
-GLO-30 COGs from the public **`copernicus-dem-30m`** bucket over HTTPS (anon), rename to the
-`Product10` convention, (re)build `DEM_Union.gpkg`; **idempotent** (skip cached tiles). Add an
-`ensure-dem` step before s1tiling writing to the `s1-dem` PVC. Geoid is pre-staged (not fetched).
-**Verify**:
-```bash
-uv run pytest tests/unit/test_ensure_dem.py     # tile→bbox→tile-name derivation; skip-existing; bad tile rejected
-# cluster: run for a NEW tile (not 31TCH) → DEM tiles appear, s1tiling proceeds; re-run skips
-```
-**Acceptance criteria**:
-- [ ] Tile → swath-bbox → GLO-30 tile-name derivation, unit-tested (incl. malformed tile rejected)
-- [ ] A previously-unprovisioned tile runs end-to-end with **no manual DEM upload**
-- [ ] Idempotent: re-run fetches nothing; `DEM_Union.gpkg` consistent
-- [ ] OQ #4 resolved (discovery method; PVC cache layout) and reflected in the step
+### Task 3 — `ensure-dem` auto-fetch step  <status: blocked by OQ #4>
+**What**: `scripts/ensure_dem.py` — tile → swath bbox → fetch missing GLO-30 COGs from public
+`copernicus-dem-30m` (HTTPS, anon) → rename to `Product10` → rebuild `DEM_Union.gpkg`; idempotent.
+Argo `ensure-dem` step before s1tiling, writing the `s1-dem` PVC. Geoid pre-staged.
+**Verify**: `uv run pytest tests/unit/test_ensure_dem.py` (bbox/tile-name derivation; skip-existing; bad tile rejected); cluster: a NEW tile provisions + processes; re-run skips.
+**Acceptance**:
+- [ ] tile→swath-bbox→tile-name derivation unit-tested (malformed tile rejected)
+- [ ] previously-unprovisioned tile runs end-to-end, no manual DEM upload
+- [ ] idempotent re-run fetches nothing; OQ #4 resolved
 
-> **CP-A (after T1–T3)**: a single discovered product, *any* tile, S1A or S1C, runs end-to-end on
-> staging and is quality-gated. The pipeline is no longer 31TCH/S1A-bound. Smallest shippable phase-6 slice.
+### Task 4 — Datacube ingest: insert acquisition as a `time` slice  <status: blocked by spec P8>
+**What**: change ingest from *fresh store per run* to **inserting the scene as a new `time` slice into
+the per-tile cube** (`s1-grd-rtc-{tile}.zarr`) via a Zarr region/append write; **skip if the time is
+already present** (idempotency). Serialise concurrent writes to the same tile with an **Argo
+`synchronization` mutex keyed on the tile**. (P8 storage; the contamination-fix cleanup logic adapts —
+no wholesale overwrite.)
+**Verify**: `uv run pytest tests/unit/test_ingest_cube_insert.py` (insert into empty/existing cube; duplicate-time skip); cluster: 2 scenes same tile → both time slices present, store opens as a cube; concurrent submit → no corruption.
+**Acceptance**:
+- [ ] A 2nd acquisition appends a `time` slice (cube has N times), unit-tested
+- [ ] Re-ingesting an existing time is a no-op (no duplicate slice)
+- [ ] Concurrent same-tile writes serialised (mutex) — no corruption
+- [ ] `xr.open_dataset(cube)` exposes all scenes on `time`
 
-### Task 4 — Port the CDSE watcher to an Argo CronWorkflow (data-driven trigger)  <status: blocked by 1,2,3>
-**What**: a trigger entrypoint (reuse `tile_bbox`/`query_cdse` from `watch_cdse_and_process.py`) that
-queries CDSE for a tile+window, **filters platform to {S1A,S1C} (skips S1D, logged)**, and emits the
-**new** products — dedup switched from the local JSON state file to a **STAC item-exists check**
-(spec P2). A **CronWorkflow** (every **6 h**) runs the query step and submits one child `Workflow` per
-new product via `workflowTemplateRef` (decision B), **replacing** the suspended blind cron.
-**Verify**:
-```bash
-uv run pytest tests/unit/test_trigger.py        # query→dedup (mocked STAC); new vs already-registered
-# cluster: argo submit --from cronworkflow/... over a data-bearing window → submits only NEW products;
-#          no-data window → submits nothing; immediate re-run → 0 submitted (existence-dedup)
-```
-**Acceptance criteria**:
-- [ ] Submits a child Workflow **only** for products with no existing STAC item (dedup), unit-tested
-- [ ] No-data window submits nothing (zero blind s1tiling runs)
-- [ ] Re-run over the same window submits 0 (idempotent)
-- [ ] S1D products are filtered out at query time with a logged reason (no child Workflow)
-- [ ] The suspended sub-issue-8 cron is retired/replaced (one trigger of record)
+### Task 5 — Per-acquisition catalogue (builder + `sel=time` links)  <status: blocked by OQ #5>
+**What**: (a) **upstream `eopf-geozarr`**: emit **one STAC item per `time` slice**
+(`s1-rtc-{tile}-{datetime}`, `datetime`=scene time, assets → cube) instead of one-per-store; (b)
+`scripts/register_v1.py`: append `&sel=time=nearest::{datetime}` to the S1 viz/xyz/tilejson/thumbnail
+links (~few lines); (c) `register_v1_s1_rtc.py`: upsert the **list** of per-acquisition items. (P8 catalogue.)
+**Verify**: `uv run pytest tests/unit/test_register_v1_s1_rtc.py` (per-acquisition ids + `sel=time` in links); cluster: an item's XYZ/preview renders its slice (`sel=time`), distinct dates → distinct items.
+**Acceptance**:
+- [ ] Builder emits one item per `time` slice (id `s1-rtc-{tile}-{datetime}`, single `datetime`)
+- [ ] Viz/XYZ/tilejson/thumbnail links carry `sel=time=nearest::{datetime}` and render the right slice
+- [ ] Register upserts all per-acquisition items; OQ #5 (data-model PR) landed
 
-### Task 5 — Multi-tile AOI iteration  <status: blocked by 3,4; OQ #1>
-**What**: the CronWorkflow iterates the configured **AOI** tile set; each tile self-provisions its DEM
-(T3) and is queried/deduped/submitted independently (T4). Per-tile failure must not abort the others.
-**Verify**:
-```bash
-# cluster: cron over a ≥2-tile AOI → per-tile child Workflows; a never-seen tile auto-provisions DEM;
-#          one tile failing does not stop the others
-```
-**Acceptance criteria**:
-- [ ] Cron processes every tile in the AOI; per-tile isolation (one failure ≠ whole-run failure)
-- [ ] A new AOI tile auto-provisions its DEM (no manual step)
-- [ ] AOI is config-driven (OQ #1 set)
+> **CP-A (after T1–T5)**: a single discovered product (any tile, S1A/S1C) lands as a `time` slice in
+> the tile cube, is quality-gated, and gets a per-acquisition item that renders via `sel=time`. The
+> datacube model is proven on one product.
 
-### Task 6 — Bounded backfill on enable  <status: blocked by 4; OQ #2>
-**What**: the trigger accepts a **backfill lookback** (distinct from the steady-state 6 h window) used
-once on enable; existence-dedup (P2) prevents reprocessing already-registered items.
-**Verify**:
-```bash
-# cluster: enable with backfill=N days → the historical window is processed once;
-#          subsequent scheduled runs only pick up forward products
-```
-**Acceptance criteria**:
-- [ ] The configured lookback is processed on enable **without duplicating** forward items
-- [ ] Backfill volume respects the concurrency limits (no thundering herd) — semaphore honoured
-- [ ] OQ #2 (window size) set
+### Task 6 — Port the CDSE watcher to an Argo CronWorkflow (data-driven trigger)  <status: blocked by 1–5>
+**What**: trigger entrypoint (reuse `tile_bbox`/`query_cdse`) queries CDSE for a tile+window, filters
+platform to {S1A,S1C} (**skips S1D**, logged), and emits **new** products — dedup = **per-acquisition
+STAC item-exists** + cube time-present (P2). CronWorkflow (**6 h**) submits one child Workflow per new
+product (decision B), **replacing** the suspended blind cron.
+**Verify**: `uv run pytest tests/unit/test_trigger.py` (query→dedup, mocked STAC); cluster: data-bearing window submits only new products; no-data → nothing; re-run → 0.
+**Acceptance**:
+- [ ] Submits only for acquisitions with no existing per-acquisition item (dedup), unit-tested
+- [ ] No-data window → 0 submissions; re-run → 0 (idempotent)
+- [ ] S1D filtered at query time (logged), no child Workflow
+- [ ] Suspended sub-issue-8 cron retired (one trigger of record)
 
-> **CP-B (after T6)**: full automated, data-driven, multi-tile trigger with backfill running on
-> staging. Functionally complete — ready to soak.
+### Task 7 — Multi-tile AOI iteration  <status: blocked by 3,6; OQ #1>
+**What**: CronWorkflow iterates the configured AOI; each tile self-provisions DEM (T3), accumulates its
+own cube (T4), queried/deduped independently (T6); per-tile failure isolation.
+**Verify**: cluster — cron over ≥2-tile AOI → per-tile child Workflows; new tile auto-provisions DEM; one failure ≠ whole-run failure.
+**Acceptance**:
+- [ ] Every AOI tile processed; per-tile isolation
+- [ ] New AOI tile auto-provisions DEM; AOI config-driven (OQ #1)
 
-### Task 7 — Acceptance soak  <status: blocked by 5,6; OQ #1,#3>
-**What**: run the full system on staging for the soak window; track success rate per the spec bar.
-**Verify**:
-```bash
-# cluster: observe ≥ 14 days across the 5 soak tiles; tally workflow success/fail from Argo + STAC
-```
-**Acceptance criteria**:
+### Task 8 — Bounded backfill on enable  <status: blocked by 6; OQ #2>
+**What**: trigger accepts a one-time **backfill lookback** (distinct from the 6 h window); dedup +
+cube time-present prevent reprocessing; per-tile mutex (T4) serialises the burst into each cube.
+**Verify**: cluster — enable with backfill=N days → historical window processed once into the cubes; later runs only forward.
+**Acceptance**:
+- [ ] Configured lookback processed without duplicate items/time slices
+- [ ] Backfill respects the semaphore + per-tile mutex (no thundering herd / no cube corruption)
+- [ ] OQ #2 (window) set
+
+> **CP-B (after T8)**: automated, data-driven, multi-tile trigger + backfill; tile cubes accumulate
+> over time. Functionally complete — ready to soak.
+
+### Task 9 — Acceptance soak  <status: blocked by 7,8; OQ #1,#3>
+**What**: run the full system on staging for the soak window; track success rate.
+**Verify**: cluster — ≥14 days × 5 soak tiles; tally success/fail from Argo + STAC; spot-check a tile opens as a multi-time cube.
+**Acceptance**:
 - [ ] **5 tiles × 14 days × ≥ 95% success** on staging
-- [ ] Failures alert via the OQ #3 path and are triaged (no silent drops)
-- [ ] Outcome recorded on #226; phase declared done (staging)
+- [ ] Each soak tile opens as a cube with all its scenes; failures alert (OQ #3) + triaged
+- [ ] Outcome recorded on #226; phase done (staging)
 
 ---
 
@@ -170,12 +160,13 @@ once on enable; existence-dedup (P2) prevents reprocessing already-registered it
 
 | OQ | Question | Blocks | Owner |
 |----|----------|--------|-------|
-| 1 | AOI tile set (+ the 5 soak tiles) | T5, T7 | Loïc / science |
-| 2 | Backfill lookback window (days) | T6 | Loïc |
-| 3 | Alerting path (quality-gate FAIL + persistent failures) | T1, T7 | Loïc / infra |
-| 4 | `ensure-dem` discovery (eodag earth_search vs direct names) + PVC cache layout | T3 | Loïc / me, during T3 |
+| 1 | AOI tile set (+ 5 soak tiles) | T7, T9 | Loïc / science |
+| 2 | Backfill lookback window (days) | T8 | Loïc |
+| 3 | Alerting path (quality-gate FAIL + persistent failures) | T1, T9 | Loïc / infra |
+| 4 | `ensure-dem` discovery (eodag vs direct) + PVC cache layout | T3 | Loïc / me (during T3) |
+| 5 | **`eopf-geozarr` per-acquisition builder PR** — owner + timeline | T5 | Loïc / data-model |
 
-*(Resolved in spec §7: DEM source = public `copernicus-dem-30m` over HTTPS, no auth.)*
+*(Resolved in spec §7: DEM source = public `copernicus-dem-30m`; Spike 1 titiler `sel=time`; Spike 2 sizing.)*
 
 ---
 
@@ -183,16 +174,22 @@ once on enable; existence-dedup (P2) prevents reprocessing already-registered it
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| S1C has an unforeseen RTC issue despite being in the orbit table | Med — Task 2 stalls | Task 2 is a *live* S1C verify gate before relying on it; fall back to S1A-only if it fails |
-| `ensure-dem` swath-bbox / tile-name derivation wrong → missing DEM coverage | High — silent bad RTC | Unit-test the derivation against the known 31TCH tile set; s1tiling already errors on <100% DEM coverage |
-| STAC-existence dedup races indexing latency → duplicate submit | Low | ingest skip-gate is the backstop; child Workflow self-skips (exit-2 contract) |
-| Backfill thundering herd overwhelms the cluster | Med | honour the `v1-s1rtc`/cron semaphores; cap backfill concurrency (Task 6) |
-| `copernicus-dem-30m` anon HTTPS unavailable/rate-limited in-cluster | Med — Task 3 | retry/backoff in `ensure_dem.py`; cache on the PVC so it's a one-time cost per tile |
-| Cross-repo drift (data-pipeline image vs platform-deploy template pin) | Med | pin `pipeline_image_version` to the merged-`main` SHA; document the bump (per #186 follow-up) |
+| Concurrent same-tile cube writes corrupt the Zarr | **High** | per-tile Argo `synchronization` mutex (T4); region writes; time-present skip |
+| `eopf-geozarr` per-acquisition builder slips (upstream) | **High** — T5 blocks T6 register | land OQ #5 early; interim: a local builder wrapper over the existing geometry/proj logic |
+| S1C has an unforeseen RTC issue despite the orbit table | Med | T2 is a live S1C verify gate before relying on it; fall back to S1A-only |
+| `ensure-dem` swath/tile-name derivation wrong → missing DEM | High (silent bad RTC) | unit-test vs known 31TCH set; s1tiling errors on <100% DEM coverage |
+| STAC-existence dedup races indexing latency | Low | cube time-present check is the backstop |
+| Backfill thundering herd | Med | semaphore + per-tile mutex; cap backfill concurrency (T8) |
+| `copernicus-dem-30m` anon HTTPS unavailable/rate-limited | Med (T3) | retry/backoff; PVC cache = one-time per tile |
+| Cross-repo drift (image SHA vs template pin) | Med | pin `pipeline_image_version` to merged-`main` SHA (#186 follow-up) |
+
+---
 
 ## Done definition
 
 CronWorkflow (6 h, data-driven) submits child Workflows only for new S1A/S1C products across the AOI;
-each tile auto-provisions its DEM; ingest is quality-gated (FAIL ⇒ no register); S1D is skipped;
-backfill ran once on enable; the acceptance soak (5 × 14 × ≥95%) passes on staging; the blind cron is
-retired. Prod promotion is Phase 7.
+each tile auto-provisions its DEM and **accumulates a multi-temporal cube** (one `time` slice per
+acquisition, per-tile writes serialised); ingest is quality-gated (FAIL ⇒ no register); each
+acquisition has a **per-acquisition STAC item** rendering via `sel=time`; S1D is skipped; backfill ran
+once on enable; the acceptance soak (5 × 14 × ≥95%) passes on staging and a tile opens as a cube; the
+blind cron is retired. Prod promotion is Phase 7.

--- a/claude-docs/specs/s1_grd_phase6_productionization.md
+++ b/claude-docs/specs/s1_grd_phase6_productionization.md
@@ -13,9 +13,11 @@ Move the S1 GRD RTC pipeline from the verified **single-tile (31TCH) / S1A** pro
 S1 GRD products, provisions the DEM for any requested tile automatically, and runs
 s1tiling → ingest → register, writing to **staging** (staging→prod promotion is a later phase — P3).
 
-**Hard requirement**: each tile is stored as a **multi-temporal datacube** (one Zarr per tile with a
-`time` axis) so a user can load *all scenes in a tile as a cube*, while the catalogue exposes
-**per-acquisition STAC items** (a time series) that render their slice via TiTiler `sel=time` (P8).
+**Hard requirement**: a user can load *all scenes in a tile as a datacube*. Met via **dual storage**
+(P8): a **per-tile multi-temporal cube** for analysis (xarray), plus **per-acquisition single-time
+stores + STAC items** that render directly in the explorer (titiler reconstructs `store = item-id`, so
+no `sel=time` / titiler change is needed). The PoC proved titiler ignores the asset href, so a single
+shared cube cannot back the per-acquisition rendering — hence dual storage (§7 Spike 3, P8).
 
 **Target users**: the EOPF Explorer platform (STAC catalogue + raster viewer consumers) and the
 devseed operators who run/monitor the pipeline.
@@ -63,10 +65,11 @@ CronWorkflow (data-driven trigger, every 6 h)
        query CDSE STAC (bbox, lookback, orbit, platform∈{S1A,S1C})  ──► new products?
           └─ for each NEW product (not already in STAC):           ──► submit child Workflow:
                ┌──────────────────────────────────────────────────────────────────────┐
-               │ ensure-dem → s1tiling → ingest(insert time slice into tile cube)        │
+               │ ensure-dem → s1tiling → ingest ──┬─ per-acquisition store (renders)     │
+               │                                  └─ append to per-tile cube (analysis)  │
                │            → quality-gate(FAIL⇒stop) → register(per-acquisition item)   │
                └──────────────────────────────────────────────────────────────────────┘
-   (per-tile write serialised by an Argo synchronization mutex keyed on the tile)
+   (cube append serialised by an Argo synchronization mutex keyed on the tile)
 ```
 
 - **Trigger**: the local `watch_cdse_and_process.py` query/dedup logic is ported into a container
@@ -79,14 +82,16 @@ CronWorkflow (data-driven trigger, every 6 h)
   cached). The EGM2008 geoid is a one-time shared asset, not per-tile.
 - **Platform**: cfg render extended to set `platform_list`; trigger filters its CDSE query to
   `S1A, S1C` and explicitly skips S1D with a log line.
-- **Storage (datacube, P8)**: one Zarr **cube per tile** on the S1 **staging** bucket; ingest
-  **inserts the acquisition as a new `time` slice** (region/append write) rather than writing a fresh
-  store. Concurrent writes to the same tile cube are **serialised by an Argo `synchronization` mutex
-  keyed on the tile**; ingest skips a time already present. Prod is out of scope (P3).
-- **Catalogue (P8)**: `register` upserts **one STAC item per acquisition** (`s1-rtc-{tile}-{datetime}`,
-  `datetime` = the scene time), whose assets point at the tile cube and whose viz/XYZ links carry
-  `sel=time=nearest::{datetime}` so TiTiler renders that slice. A user loads the whole tile by opening
-  the cube store directly; the per-acquisition items are the queryable time-series index.
+- **Storage (dual, P8)**: ingest writes **two** artifacts per scene on the S1 **staging** bucket —
+  (1) a **per-acquisition single-time store** named = its item id (`s1-rtc-{tile}-{datetime}.zarr`) for
+  rendering, and (2) an **append of the scene as a new `time` slice into the per-tile cube**
+  (`s1-rtc-{tile}.zarr`) for analysis. The cube append is **serialised by an Argo `synchronization`
+  mutex keyed on the tile**; ingest skips a time already present. Prod is out of scope (P3).
+- **Catalogue (P8)**: `register` upserts **one STAC item per acquisition** (`s1-rtc-{tile}-{datetime}`),
+  pointing at its per-acquisition store → **renders directly** (store-name = item-id matches titiler's
+  reconstruction; no `sel=time`). The per-tile cube is catalogued as the per-tile item for analysis;
+  a user loads the whole tile by opening the cube store (xarray). The per-acquisition items are the
+  queryable time-series index (dedup authority).
 - **Geoid**: the EGM2008 model is assumed pre-staged on the `s1-dem` PVC (as in phase-1); `ensure-dem`
   does not fetch it per run.
 
@@ -99,11 +104,13 @@ CronWorkflow (data-driven trigger, every 6 h)
 - [ ] A **previously-unprocessed tile** runs end-to-end with **no manual DEM upload** (ensure-dem works).
 - [ ] An **S1C** scene processes A→B end-to-end; item queryable + validation PASS.
 - [ ] **S1D** scenes are skipped with a logged reason; no failed workflows.
-- [ ] **Datacube (P8)**: after ≥2 acquisitions for a tile, the tile's Zarr opens as a cube with all
-      scenes on the `time` axis; each acquisition has its own STAC item that renders via `sel=time`.
+- [ ] **Per-acquisition rendering (P8)**: each acquisition has its own single-time store + STAC item
+      that **renders directly** in the explorer (store-name = item-id; no `sel=time`/titiler change).
+- [ ] **Datacube (P8)**: after ≥2 acquisitions for a tile, the per-tile cube opens as a datacube with
+      all scenes on the `time` axis (xarray) — "load all scenes in a tile" works.
 - [ ] **Concurrency**: two scenes for the same tile processed together both land in the cube without
       corruption (per-tile write serialised).
-- [ ] **Idempotent**: re-trigger over the same window creates no duplicate work / items / time slices.
+- [ ] **Idempotent**: re-trigger over the same window creates no duplicate stores / items / time slices.
 - [ ] **Quality gate** blocks a deliberately-corrupted output from being registered (P1).
 - [ ] **Backfill**: the configured lookback window is processed on enable without duplicating
       forward items (P5).
@@ -134,13 +141,23 @@ CronWorkflow (data-driven trigger, every 6 h)
   **overwrites the acquisition's `time` slice in the cube (region write) and upserts its item**; no
   versioning yet. The **automated trigger never reprocesses** (P2). *Force-path UX is a plan detail,
   not required for the soak.*
-- **P8 — Data model & identity** *(decided 2026-06-08; hard requirement)*: **per-tile multi-temporal
-  Zarr cube** (one store per tile, scenes inserted on the `time` axis) + **per-acquisition STAC items**
-  (`s1-rtc-{tile}-{datetime}`) that render their slice via TiTiler `sel=time`. A user can load all
-  scenes in a tile as a cube; STAC is the per-acquisition index (no separate tracking system). De-risked
-  by Spike 1 (titiler `sel`) + Spike 2 (builder sizing) — see §7. **Dependency**: the data-model
-  builder must emit one item per `time` slice (currently one-per-store with a datetime range) — an
-  upstream `eopf-geozarr` change.
+- **P8 — Data model & identity** *(decided 2026-06-08; revised after the PoC; hard requirement)*:
+  **dual storage**, because the PoC proved titiler-eopf reconstructs the store path from
+  `{base}/{collection}/{item_id}.zarr` and **ignores the asset href** (so per-acquisition items
+  *cannot* share one cube for rendering — see §7 Spike 3). Therefore:
+  1. **Per-acquisition stores + items** (rendering path): each acquisition → its own single-time Zarr
+     named = its item id (`s1-rtc-{tile}-{datetime}.zarr`) in a per-acquisition collection, + one STAC
+     item. Renders **directly today** (store-name = item-id matches titiler's reconstruction; **no
+     `sel=time`, no titiler change** — it's the proven phase-5 store pattern with per-acquisition ids).
+  2. **Per-tile cube** (analysis path): scenes also appended to one multi-temporal Zarr per tile
+     (`s1-rtc-{tile}.zarr`, existing `sentinel-1-grd-rtc-staging`) so a user can **load all scenes in a
+     tile as a datacube** (xarray). Catalogued as the per-tile item.
+  STAC is the per-acquisition index (no separate tracking system). **Cost**: each scene is written
+  twice (its own store + appended to the cube); the cube append needs per-tile write serialisation.
+  **Deferred**: a future titiler "resolve store from asset href" change (I-8 Option A) would let the
+  per-acquisition items render *from the shared cube*, collapsing dual storage to single — out of scope
+  here. **Dependency**: per-acquisition item builder (one item per scene) — small (the phase-5 builder
+  already emits per-store items; just per-acquisition ids).
 
 ---
 
@@ -164,20 +181,24 @@ hardcode credentials; blind-run s1tiling on no-data days.
 3. **Alerting path** — where do quality-gate FAILs and persistent workflow failures notify? *Owner: Loïc / infra.*
 4. **ensure-dem sub-choices** — DEM discovery via `eodag earth_search` vs. direct tile-name
    derivation; cache reuse of the existing `s1-dem` PVC. *Owner: Loïc — confirm during planning.*
-5. **Data-model builder PR (P8)** — `eopf-geozarr` must emit one STAC item per `time` slice; who lands
-   the upstream change and on what timeline? Blocks the per-acquisition register step.
-   *Owner: Loïc / data-model.*
+5. **Dual-storage write cost (P8)** — confirm acceptance of writing each scene twice (per-acquisition
+   store + per-tile cube append). *Owner: Loïc — confirmed 2026-06-08 (chose dual storage).*
 
 ### Resolved
-- **Spike 1 — TiTiler time selection (2026-06-08, live)**: deployed **titiler-eopf 0.9.0** exposes
-  `sel` on all render endpoints (`sel=time={value}` or `{method}::{value}`, methods nearest/pad/…).
-  Verified `sel=time=nearest::2026-06-05` → HTTP 200 on `info` + `tilejson`. → the per-acquisition-item
-  + per-tile-cube rendering (P8) works. (Also: 0.9.0 resolves the store from the item href — old I-8
-  blocker shipped.)
-- **Spike 2 — per-acquisition builder sizing (2026-06-08)**: viz/`sel=time` links are a few lines in
-  `scripts/register_v1.py` (ours); the per-acquisition item builder is a **moderate upstream
-  `eopf-geozarr` change** (loop the existing `time` axis; geometry/proj/SAR logic already present);
-  the real cost is the **cube time-slice insert + per-tile write serialisation** in ingest (OQ #5/P8).
+- **Spike 1 — TiTiler `sel` param (2026-06-08)**: titiler-eopf **0.9.0** exposes `sel` on all render
+  endpoints (`sel=time={value}` / `{method}::{value}`). `sel=time=nearest::…` returns 200. *(Caveat:
+  the 200 was against a store sitting at titiler's reconstructed path — it did not prove href
+  resolution; see Spike 3.)*
+- **Spike 2 — per-acquisition builder sizing (2026-06-08)**: the per-acquisition item builder is a
+  **small** change (the phase-5 builder already emits per-store items; just use per-acquisition ids);
+  viz links are a few lines in `scripts/register_v1.py`.
+- **Spike 3 — titiler store resolution (2026-06-08, PoC, decisive)**: the datacube PoC proved
+  titiler-eopf **reconstructs the store path as `s3://esa-zarr-sentinel-explorer-fra/tests-output/
+  {collection}/{item_id}.zarr` and IGNORES the asset href** (`/info` → *"No group found in store …
+  {item_id}.zarr"*); there is **no URL-based render endpoint**. So per-acquisition items **cannot share
+  one cube** for rendering (I-8 not fixed). → drove the **P8 revision to dual storage**: per-acquisition
+  single-time stores (store-name = item-id → render directly today, no titiler change) + a per-tile cube
+  for analysis. The PoC *did* validate the cube **append** works (2 acquisitions → 2-time cube).
 - **DEM source/auth (2026-06-08)** — replicate phase-1: Copernicus DEM **GLO-30** COGs from the
   **public AWS Open Data bucket `s3://copernicus-dem-30m/`** over HTTPS
   (`https://copernicus-dem-30m.s3.amazonaws.com/`), **no credentials / not requester-pays**

--- a/claude-docs/specs/s1_grd_phase6_productionization.md
+++ b/claude-docs/specs/s1_grd_phase6_productionization.md
@@ -14,10 +14,10 @@ S1 GRD products, provisions the DEM for any requested tile automatically, and ru
 s1tiling → ingest → register, writing to **staging** (staging→prod promotion is a later phase — P3).
 
 **Hard requirement**: a user can load *all scenes in a tile as a datacube* — met by a **per-tile
-multi-temporal cube** (xarray). The catalogue exposes **per-acquisition STAC items** that render their
-slice from the cube via TiTiler `sel=time`. This rendering **depends on I2 / option 2** — titiler
-resolving the store from the item's asset href (platform-deploy `ecde99c`; **not yet effective**, §7
-Spike 3, P8). **Dual storage** (per-acquisition stores) is the documented fallback if option 2 stalls.
+multi-temporal cube** (xarray), with **per-acquisition STAC items** as the time-series index.
+**Validation is via Jupyter/xarray + the `validate_s1_grd_rtc` notebook** (read the cube + query STAC).
+**Explorer/TiTiler rendering is deferred** to a follow-up (it needs I2/option 2 — titiler href
+resolution; §7, P8) and is *not* on this phase's critical path.
 
 **Target users**: the EOPF Explorer platform (STAC catalogue + raster viewer consumers) and the
 devseed operators who run/monitor the pipeline.
@@ -50,8 +50,14 @@ devseed operators who run/monitor the pipeline.
   processing (P5).
 - **In-cluster dedup/idempotency** via STAC item-exists check (P2 — replaces the local JSON state).
 - **Quality gate** before register (P1).
+- **Validation via Jupyter/xarray** — the `validate_s1_grd_rtc` notebook reads the cube + STAC items
+  (PASS/WARN/FAIL); this is the phase's acceptance lens, not the explorer.
 
 ### Out of scope (deferred, flagged)
+- **Explorer / TiTiler rendering of per-acquisition items** — deferred; needs I2/option 2 (titiler
+  href resolution; platform-deploy `ecde99c`, not yet effective — §7). The per-acquisition items are
+  registered now (queryable) and will render via `sel=time` once option 2 lands, with no data changes.
+  **Tracked in #228** (plan Task D1).
 - **Staging → prod promotion** — **staging-only this phase** (P3); prod bucket/collection + cutover
   authority deferred to a later phase.
 - **S1D** — no s1tiling version supports it; track an upstream issue. Trigger skips it meanwhile.
@@ -73,7 +79,7 @@ CronWorkflow (data-driven trigger, every 6 h)
                │   item → cube via asset href + sel=time)                                │
                └──────────────────────────────────────────────────────────────────────┘
    (cube append serialised by an Argo synchronization mutex keyed on the tile;
-    per-acquisition rendering depends on titiler href resolution — I2/option 2)
+    validation via the validate_s1_grd_rtc notebook; explorer rendering deferred — I2/option 2)
 ```
 
 - **Trigger**: the local `watch_cdse_and_process.py` query/dedup logic is ported into a container
@@ -89,14 +95,15 @@ CronWorkflow (data-driven trigger, every 6 h)
 - **Storage (P8)**: ingest **appends the scene as a new `time` slice into the per-tile cube**
   (`s1-rtc-{tile}.zarr`, collection `sentinel-1-grd-rtc-staging`) on the S1 **staging** bucket;
   the append is **serialised by an Argo `synchronization` mutex keyed on the tile** and skips a `time`
-  already present. (Fallback only, if I2/option 2 stalls: also write a per-acquisition single-time
-  store named = item-id for reconstruction-based rendering — dual storage.) Prod is out of scope (P3).
+  already present. Single shared cube — no per-acquisition stores (rendering deferred). Prod out of scope (P3).
 - **Catalogue (P8)**: `register` upserts **one STAC item per acquisition**
   (`s1-rtc-{tile}-{datetime}`, collection `sentinel-1-grd-rtc-acquisitions`), pointing at the cube via
-  asset href; TiTiler renders the right slice with `sel=time=nearest::{datetime}` **once I2/option 2
-  (href resolution) is live**. The per-tile cube item (`sentinel-1-grd-rtc-staging`) is the analysis
-  entry — a user loads the whole tile by opening the cube (xarray). The per-acquisition items are the
-  queryable time-series index (dedup authority).
+  asset href (+ time) — the **queryable time-series index** (dedup authority). The per-tile cube item
+  (`sentinel-1-grd-rtc-staging`) is the analysis entry; a user loads the whole tile by opening the cube
+  (xarray). **Explorer rendering of these items is deferred** (I2/option 2); they render via `sel=time`
+  later with no data change.
+- **Validation**: the `validate_s1_grd_rtc` notebook opens the cube (structural/CF/data checks,
+  PASS/WARN/FAIL) and the STAC items are queried — this is the acceptance lens, not the explorer.
 - **Geoid**: the EGM2008 model is assumed pre-staged on the `s1-dem` PVC (as in phase-1); `ensure-dem`
   does not fetch it per run.
 
@@ -109,8 +116,10 @@ CronWorkflow (data-driven trigger, every 6 h)
 - [ ] A **previously-unprocessed tile** runs end-to-end with **no manual DEM upload** (ensure-dem works).
 - [ ] An **S1C** scene processes A→B end-to-end; item queryable + validation PASS.
 - [ ] **S1D** scenes are skipped with a logged reason; no failed workflows.
-- [ ] **Per-acquisition rendering (P8)**: each acquisition has a STAC item that renders its slice from
-      the cube via `sel=time` (depends on **I2/option 2** — titiler href resolution being live).
+- [ ] **Per-acquisition catalogue (P8)**: each acquisition has a **queryable** STAC item indexing its
+      cube slice (explorer rendering deferred — I2/option 2).
+- [ ] **Notebook validation**: the `validate_s1_grd_rtc` notebook returns **PASS** against a tile's
+      cube (CRS, grid_mapping, dtypes, finite data, dB ranges, overviews) — the acceptance lens.
 - [ ] **Datacube (P8)**: after ≥2 acquisitions for a tile, the per-tile cube opens as a datacube with
       all scenes on the `time` axis (xarray) — "load all scenes in a tile" works (independent of titiler).
 - [ ] **Concurrency**: two scenes for the same tile processed together both land in the cube without
@@ -147,21 +156,16 @@ CronWorkflow (data-driven trigger, every 6 h)
   versioning yet. The **automated trigger never reprocesses** (P2). *Force-path UX is a plan detail,
   not required for the soak.*
 - **P8 — Data model & identity** *(decided 2026-06-08; hard requirement)*: a **per-tile multi-temporal
-  Zarr cube** (one store per tile, scenes appended on the `time` axis) backs both access paths:
-  1. **Analysis** — a user loads all scenes in a tile by opening the cube (`s1-rtc-{tile}.zarr`,
-     collection `sentinel-1-grd-rtc-staging`) with xarray. Works regardless of titiler.
-  2. **Rendering** — **per-acquisition STAC items** (`s1-rtc-{tile}-{datetime}`, one per scene,
-     collection `sentinel-1-grd-rtc-acquisitions`) point at the cube via asset href and render their
-     slice via TiTiler `sel=time=nearest::{datetime}`.
-  STAC is the per-acquisition index (no separate tracking system). **Rendering depends on I2 (option 2,
-  chosen 2026-06-08)**: titiler must resolve the store from the STAC item's **asset href** — platform-
-  deploy `ecde99c` adds `TITILER_EOPF_API_ROOT_URL` toward this, but **re-tested 2026-06-08 it is NOT
-  yet effective** (titiler still reconstructs `{base}/{collection}/{item_id}.zarr`, ignores href; §7
-  Spike 3). Per-acquisition **rendering is blocked until option 2 deploys + is verified**; the cube
-  storage/append + xarray load are unaffected.
-  **Fallback** (if option 2 stalls): **dual storage** — also write per-acquisition single-time stores
-  named = item-id, which render via titiler's reconstruction today (cost: each scene written twice +
-  cube-append serialisation). Single shared cube is preferred once option 2 is verified.
+  Zarr cube** (one store per tile, scenes appended on the `time` axis, collection
+  `sentinel-1-grd-rtc-staging`) + **per-acquisition STAC items** (`s1-rtc-{tile}-{datetime}`, one per
+  scene, collection `sentinel-1-grd-rtc-acquisitions`) that index the time series and point at the cube
+  (asset href + time). STAC is the per-acquisition index (no separate tracking system).
+  **Validation is via tools that read the cube/STAC directly — Jupyter/xarray + the `validate_s1_grd_rtc`
+  notebook — not the explorer.** **Explorer/titiler rendering is DEFERRED** (it needs I2/option 2 —
+  titiler resolving the store from the item href; platform-deploy `ecde99c`, not yet effective, §7).
+  Because rendering is deferred, **no per-acquisition stores / dual storage are needed** — a single
+  shared cube suffices; when option 2 lands later, the existing per-acquisition items render via
+  `sel=time` with **no data changes**.
 
 ---
 
@@ -185,12 +189,10 @@ hardcode credentials; blind-run s1tiling on no-data days.
 3. **Alerting path** — where do quality-gate FAILs and persistent workflow failures notify? *Owner: Loïc / infra.*
 4. **ensure-dem sub-choices** — DEM discovery via `eodag earth_search` vs. direct tile-name
    derivation; cache reuse of the existing `s1-dem` PVC. *Owner: Loïc — confirm during planning.*
-5. **I2 / option 2 — titiler href resolution (blocks per-acquisition rendering)**: deploy + verify that
-   titiler resolves the store from the STAC item asset href (platform-deploy `ecde99c` adds
-   `TITILER_EOPF_API_ROOT_URL`; re-tested 2026-06-08 — **not yet effective**). Until verified, fall back
-   to dual storage (per-acquisition stores named = item-id). *Owner: Loïc / infra (E. Mathot).*
-6. **s1tiling off-platform-download tolerance** — make the s1tiling step succeed when the requested
+5. **s1tiling off-platform-download tolerance** — make the s1tiling step succeed when the requested
    platform produced output despite S1D/S1C download failures (PoC finding). *Owner: plan T2.*
+
+*(Deferred, not a phase-6 open question: titiler rendering / I2 option 2 — tracked in **#228**.)*
 
 ### Resolved
 - **Spike 1 — TiTiler `sel` param (2026-06-08)**: titiler-eopf **0.9.0** exposes `sel` on all render
@@ -205,14 +207,14 @@ hardcode credentials; blind-run s1tiling on no-data days.
   {collection}/{item_id}.zarr` and IGNORES the asset href** (`/info` → *"No group found in store …
   {item_id}.zarr"*); there is **no URL-based render endpoint**. The PoC *did* validate the cube
   **append** works (2 acquisitions → 2-time cube).
-- **I2 decision = option 2, in flight (2026-06-08)**: make titiler **resolve the store from the STAC
-  item asset href** so per-acquisition items can render from the shared cube (collapses the dual-storage
-  fallback to a single cube). platform-deploy **`ecde99c`** adds
-  `TITILER_EOPF_API_ROOT_URL: …/stac` toward this. **Re-tested 2026-06-08 — NOT yet effective**: the
-  per-acquisition item still 500s with the reconstructed `fra/tests-output/…` path. → option 2 is a
-  **dependency to deploy + verify** (OQ #5); until then per-acquisition rendering is blocked (cube
-  append + xarray load are fine), and **dual storage** (per-acquisition stores named = item-id) is the
-  fallback that renders via reconstruction today.
+- **I2 = option 2, DEFERRED (2026-06-08)**: explorer rendering needs titiler to **resolve the store
+  from the STAC item asset href** (so per-acquisition items render from the shared cube via `sel=time`).
+  platform-deploy **`ecde99c`** adds `TITILER_EOPF_API_ROOT_URL: …/stac` toward this, but **re-tested
+  2026-06-08 it is NOT yet effective** (per-acquisition item still 500s with the reconstructed
+  `fra/tests-output/…` path). **Rendering is deferred off the phase-6 critical path** — phase 6
+  validates via the `validate_s1_grd_rtc` notebook + STAC queries instead. Rendering work is tracked in
+  **#228** (deploy/verify `ecde99c` or land titiler-eopf I-8 Option A); the per-acquisition items
+  pre-bake `sel=time` links so they render later with no data change.
 - **DEM source/auth (2026-06-08)** — replicate phase-1: Copernicus DEM **GLO-30** COGs from the
   **public AWS Open Data bucket `s3://copernicus-dem-30m/`** over HTTPS
   (`https://copernicus-dem-30m.s3.amazonaws.com/`), **no credentials / not requester-pays**

--- a/claude-docs/specs/s1_grd_phase6_productionization.md
+++ b/claude-docs/specs/s1_grd_phase6_productionization.md
@@ -76,7 +76,7 @@ CronWorkflow (data-driven trigger, every 6 h)
                ┌──────────────────────────────────────────────────────────────────────┐
                │ ensure-dem → s1tiling → ingest(append scene as a time slice to the      │
                │   per-tile cube) → quality-gate(FAIL⇒stop) → register(per-acquisition   │
-               │   item → cube via asset href + sel=time)                                │
+               │   item → cube via href; sel=time links baked, render deferred #228)     │
                └──────────────────────────────────────────────────────────────────────┘
    (cube append serialised by an Argo synchronization mutex keyed on the tile;
     validation via the validate_s1_grd_rtc notebook; explorer rendering deferred — I2/option 2)
@@ -124,7 +124,7 @@ CronWorkflow (data-driven trigger, every 6 h)
       all scenes on the `time` axis (xarray) — "load all scenes in a tile" works (independent of titiler).
 - [ ] **Concurrency**: two scenes for the same tile processed together both land in the cube without
       corruption (per-tile write serialised).
-- [ ] **Idempotent**: re-trigger over the same window creates no duplicate stores / items / time slices.
+- [ ] **Idempotent**: re-trigger over the same window creates no duplicate items / `time` slices.
 - [ ] **Quality gate** blocks a deliberately-corrupted output from being registered (P1).
 - [ ] **Backfill**: the configured lookback window is processed on enable without duplicating
       forward items (P5).

--- a/claude-docs/specs/s1_grd_phase6_productionization.md
+++ b/claude-docs/specs/s1_grd_phase6_productionization.md
@@ -1,6 +1,6 @@
 # Spec: S1 GRD RTC Productionization (Phase 6)
 
-**Status**: Draft (Define stage) — 2026-06-08
+**Status**: Draft (Define stage) — 2026-06-08 · **Tracked in #226**
 **Builds on**: `s1_grd_phase5_subissues.md` (local prototype + Argo templates),
 `s1_grd_STACregisration_and_argo_pipelines.md`, `spike_s1tiling_platform_support.md` (S1C/S1D finding).
 
@@ -11,7 +11,7 @@
 Move the S1 GRD RTC pipeline from the verified **single-tile (31TCH) / S1A** prototype to an
 **automated, multi-tile, in-cluster production service**: a data-driven trigger discovers new CDSE
 S1 GRD products, provisions the DEM for any requested tile automatically, and runs
-s1tiling → ingest → register, promoting outputs along a staging → prod path.
+s1tiling → ingest → register, writing to **staging** (staging→prod promotion is a later phase — P3).
 
 **Target users**: the EOPF Explorer platform (STAC catalogue + raster viewer consumers) and the
 devseed operators who run/monitor the pipeline.
@@ -19,7 +19,7 @@ devseed operators who run/monitor the pipeline.
 ### Resolved decisions (2026-06-08, confirmed with Loïc)
 | # | Decision | Implication |
 |---|----------|-------------|
-| Goal | Productionize S1 GRD RTC in-cluster (automated, multi-tile, staging→prod) | Drives the whole spec |
+| Goal | Productionize S1 GRD RTC in-cluster (automated, multi-tile, **staging-only**; prod deferred) | Drives the whole spec |
 | Platform | **S1A + S1C**, skip **S1D** | S1C enabled config-only; S1D skipped until upstream s1tiling support (no release/dev branch has it — `spike_s1tiling_platform_support.md`) |
 | Trigger | **Port the CDSE watcher into Argo** (data-driven) | A CronWorkflow runs query→dedup→submit; no blind-day s1tiling |
 | Tiles/DEM | **Automated DEM-fetch step** | A pipeline step fetches/builds the Copernicus DEM GLO-30 for any requested MGRS tile; no manual DEM upload |
@@ -37,7 +37,7 @@ devseed operators who run/monitor the pipeline.
 - **Multi-platform**: render `platform_list = "S1A S1C"` into the s1tiling cfg; the trigger skips S1D
   (logged), so daily runs don't attempt-and-fail S1D scenes.
 - **Multi-tile**: trigger iterates a configured tile set (AOI); each tile self-provisions its DEM.
-- **Bounded historical backfill** on enable (configurable lookback — OQ #4), alongside forward
+- **Bounded historical backfill** on enable (configurable lookback — OQ #2), alongside forward
   processing (P5).
 - **In-cluster dedup/idempotency** via STAC item-exists check (P2 — replaces the local JSON state).
 - **Quality gate** before register (P1).
@@ -54,14 +54,14 @@ devseed operators who run/monitor the pipeline.
 ## 3. Architecture (proposed)
 
 ```
-CronWorkflow (data-driven trigger, every N hours)
+CronWorkflow (data-driven trigger, every 6 h)
   └─ for each tile in AOI:
        query CDSE STAC (bbox, lookback, orbit, platform∈{S1A,S1C})  ──► new products?
           └─ for each NEW product (not already in STAC):           ──► submit child Workflow:
-               ┌─────────────────────────────────────────────────────────────┐
-               │ ensure-dem (fetch GLO-30 for tile)  →  s1tiling  →  ingest  →  register │
-               │                                                     └─ quality gate ┘   │
-               └─────────────────────────────────────────────────────────────┘
+               ┌──────────────────────────────────────────────────────────────────────┐
+               │ ensure-dem  →  s1tiling  →  ingest  →  quality-gate  →  register       │
+               │                                         (FAIL ⇒ stop, no register)     │
+               └──────────────────────────────────────────────────────────────────────┘
 ```
 
 - **Trigger**: the local `watch_cdse_and_process.py` query/dedup logic is ported into a container
@@ -74,11 +74,14 @@ CronWorkflow (data-driven trigger, every N hours)
   cached). The EGM2008 geoid is a one-time shared asset, not per-tile.
 - **Platform**: cfg render extended to set `platform_list`; trigger filters its CDSE query to
   `S1A, S1C` and explicitly skips S1D with a log line.
-- **Storage**: GeoTIFFs + Zarr to the S1 staging bucket; prod promotion path per P3.
+- **Storage**: GeoTIFFs + Zarr to the S1 **staging** bucket/collection only; prod promotion is out
+  of scope this phase (P3).
+- **Geoid**: the EGM2008 model is assumed pre-staged on the `s1-dem` PVC (as in phase-1); `ensure-dem`
+  does not fetch it per run.
 
 ---
 
-## 4. Success criteria (proposed — review)
+## 4. Success criteria (agreed)
 
 - [ ] Data-driven trigger submits a child Workflow **only** for genuinely new CDSE products
       (zero s1tiling runs on no-data days).
@@ -99,18 +102,23 @@ CronWorkflow (data-driven trigger, every N hours)
 - **P1 — Quality gate**: run the `validate_s1_grd_rtc` checks (CRS, grid_mapping, NaN fraction, dB
   ranges) as an automated **post-ingest gate**. **FAIL → do not register, fail the workflow + alert;
   WARN → register with an annotation.**
-- **P2 — Dedup**: **STAC "does this item exist?" check** (+ the ingest's own skip gate) is the dedup
-  authority — no persistent PVC/ConfigMap state. *Risk: STAC indexing latency could allow a brief
-  re-submit window; acceptable, mitigated by the ingest skip-gate.*
+- **P2 — Dedup**: the **automated trigger** skips a product whose STAC item already exists (+ the
+  ingest's own skip gate); no persistent PVC/ConfigMap state. *Risk: STAC indexing latency could
+  allow a brief re-submit window; acceptable, mitigated by the ingest skip-gate.*
+  → **Interaction with P7**: existence-dedup means the trigger **never reprocesses** an already-
+  registered product. Reprocessing is therefore an **explicit, out-of-band path** (see P7), not
+  something the daily trigger does.
 - **P3 — Promotion**: **staging only this phase.** Register to the S1 staging bucket/collection;
   **prod bucket/collection + cutover are out of scope** (deferred to a later phase). The §4 soak is
   the phase acceptance bar, not a prod gate.
 - **P4 — Acceptance soak**: **5 tiles × 14 days × ≥ 95% success** on staging.
 - **P5 — Temporal**: **forward + bounded backfill.** Process new acquisitions *and* a configurable
-  historical lookback window on enable. Backfill window size = **OQ #4**.
+  historical lookback window on enable. Backfill window size = **OQ #2**.
 - **P6 — Cadence**: trigger **every 6 h**.
-- **P7 — Reprocessing**: **overwrite (upsert)** on reprocess (orbit/DEM/data-model change); no item
-  versioning yet (revisit only if a consumer needs history).
+- **P7 — Reprocessing**: an explicit/manual path (e.g. a `force` flag or a one-off submit that
+  bypasses the P2 existence check) **overwrites (upsert)** the item; no item versioning yet (revisit
+  only if a consumer needs history). The **automated trigger never reprocesses** (P2). *Scope note:
+  the force path's UX is a plan-level detail, not required for the soak.*
 
 ---
 
@@ -147,6 +155,7 @@ hardcode credentials; blind-run s1tiling on no-data days.
 
 ## 8. Done definition (Define stage)
 
-Objectives, scope, and success criteria are unambiguous and agreed; P1–P7 defaults are confirmed or
-amended; open questions §7 have owners. Then proceed to a Plan (`claude-docs/plans/`) breaking this
-into atomic tasks (trigger port, ensure-dem, platform render, quality gate, promotion, soak).
+Objectives, scope, and success criteria are unambiguous and agreed; P1–P7 confirmed (§5); open
+questions §7 have owners. Then proceed to a Plan (`claude-docs/plans/`) breaking this into atomic
+tasks (trigger port, ensure-dem, platform render S1A+S1C, multi-tile AOI, quality gate, backfill,
+acceptance soak).

--- a/claude-docs/specs/s1_grd_phase6_productionization.md
+++ b/claude-docs/specs/s1_grd_phase6_productionization.md
@@ -13,6 +13,10 @@ Move the S1 GRD RTC pipeline from the verified **single-tile (31TCH) / S1A** pro
 S1 GRD products, provisions the DEM for any requested tile automatically, and runs
 s1tiling → ingest → register, writing to **staging** (staging→prod promotion is a later phase — P3).
 
+**Hard requirement**: each tile is stored as a **multi-temporal datacube** (one Zarr per tile with a
+`time` axis) so a user can load *all scenes in a tile as a cube*, while the catalogue exposes
+**per-acquisition STAC items** (a time series) that render their slice via TiTiler `sel=time` (P8).
+
 **Target users**: the EOPF Explorer platform (STAC catalogue + raster viewer consumers) and the
 devseed operators who run/monitor the pipeline.
 
@@ -59,9 +63,10 @@ CronWorkflow (data-driven trigger, every 6 h)
        query CDSE STAC (bbox, lookback, orbit, platform∈{S1A,S1C})  ──► new products?
           └─ for each NEW product (not already in STAC):           ──► submit child Workflow:
                ┌──────────────────────────────────────────────────────────────────────┐
-               │ ensure-dem  →  s1tiling  →  ingest  →  quality-gate  →  register       │
-               │                                         (FAIL ⇒ stop, no register)     │
+               │ ensure-dem → s1tiling → ingest(insert time slice into tile cube)        │
+               │            → quality-gate(FAIL⇒stop) → register(per-acquisition item)   │
                └──────────────────────────────────────────────────────────────────────┘
+   (per-tile write serialised by an Argo synchronization mutex keyed on the tile)
 ```
 
 - **Trigger**: the local `watch_cdse_and_process.py` query/dedup logic is ported into a container
@@ -74,8 +79,14 @@ CronWorkflow (data-driven trigger, every 6 h)
   cached). The EGM2008 geoid is a one-time shared asset, not per-tile.
 - **Platform**: cfg render extended to set `platform_list`; trigger filters its CDSE query to
   `S1A, S1C` and explicitly skips S1D with a log line.
-- **Storage**: GeoTIFFs + Zarr to the S1 **staging** bucket/collection only; prod promotion is out
-  of scope this phase (P3).
+- **Storage (datacube, P8)**: one Zarr **cube per tile** on the S1 **staging** bucket; ingest
+  **inserts the acquisition as a new `time` slice** (region/append write) rather than writing a fresh
+  store. Concurrent writes to the same tile cube are **serialised by an Argo `synchronization` mutex
+  keyed on the tile**; ingest skips a time already present. Prod is out of scope (P3).
+- **Catalogue (P8)**: `register` upserts **one STAC item per acquisition** (`s1-rtc-{tile}-{datetime}`,
+  `datetime` = the scene time), whose assets point at the tile cube and whose viz/XYZ links carry
+  `sel=time=nearest::{datetime}` so TiTiler renders that slice. A user loads the whole tile by opening
+  the cube store directly; the per-acquisition items are the queryable time-series index.
 - **Geoid**: the EGM2008 model is assumed pre-staged on the `s1-dem` PVC (as in phase-1); `ensure-dem`
   does not fetch it per run.
 
@@ -88,7 +99,11 @@ CronWorkflow (data-driven trigger, every 6 h)
 - [ ] A **previously-unprocessed tile** runs end-to-end with **no manual DEM upload** (ensure-dem works).
 - [ ] An **S1C** scene processes A→B end-to-end; item queryable + validation PASS.
 - [ ] **S1D** scenes are skipped with a logged reason; no failed workflows.
-- [ ] **Idempotent**: re-trigger over the same window creates no duplicate work / items.
+- [ ] **Datacube (P8)**: after ≥2 acquisitions for a tile, the tile's Zarr opens as a cube with all
+      scenes on the `time` axis; each acquisition has its own STAC item that renders via `sel=time`.
+- [ ] **Concurrency**: two scenes for the same tile processed together both land in the cube without
+      corruption (per-tile write serialised).
+- [ ] **Idempotent**: re-trigger over the same window creates no duplicate work / items / time slices.
 - [ ] **Quality gate** blocks a deliberately-corrupted output from being registered (P1).
 - [ ] **Backfill**: the configured lookback window is processed on enable without duplicating
       forward items (P5).
@@ -102,12 +117,12 @@ CronWorkflow (data-driven trigger, every 6 h)
 - **P1 — Quality gate**: run the `validate_s1_grd_rtc` checks (CRS, grid_mapping, NaN fraction, dB
   ranges) as an automated **post-ingest gate**. **FAIL → do not register, fail the workflow + alert;
   WARN → register with an annotation.**
-- **P2 — Dedup**: the **automated trigger** skips a product whose STAC item already exists (+ the
-  ingest's own skip gate); no persistent PVC/ConfigMap state. *Risk: STAC indexing latency could
-  allow a brief re-submit window; acceptable, mitigated by the ingest skip-gate.*
+- **P2 — Dedup**: the **automated trigger** skips a product whose **per-acquisition STAC item**
+  (`s1-rtc-{tile}-{datetime}`) already exists; the ingest also skips a `time` already present in the
+  cube. No persistent PVC/ConfigMap state — STAC is the index (P8). *Risk: STAC indexing latency could
+  allow a brief re-submit window; acceptable, mitigated by the cube time-present check.*
   → **Interaction with P7**: existence-dedup means the trigger **never reprocesses** an already-
-  registered product. Reprocessing is therefore an **explicit, out-of-band path** (see P7), not
-  something the daily trigger does.
+  registered acquisition. Reprocessing is an **explicit, out-of-band path** (see P7).
 - **P3 — Promotion**: **staging only this phase.** Register to the S1 staging bucket/collection;
   **prod bucket/collection + cutover are out of scope** (deferred to a later phase). The §4 soak is
   the phase acceptance bar, not a prod gate.
@@ -115,10 +130,17 @@ CronWorkflow (data-driven trigger, every 6 h)
 - **P5 — Temporal**: **forward + bounded backfill.** Process new acquisitions *and* a configurable
   historical lookback window on enable. Backfill window size = **OQ #2**.
 - **P6 — Cadence**: trigger **every 6 h**.
-- **P7 — Reprocessing**: an explicit/manual path (e.g. a `force` flag or a one-off submit that
-  bypasses the P2 existence check) **overwrites (upsert)** the item; no item versioning yet (revisit
-  only if a consumer needs history). The **automated trigger never reprocesses** (P2). *Scope note:
-  the force path's UX is a plan-level detail, not required for the soak.*
+- **P7 — Reprocessing**: an explicit/manual path (e.g. a `force` flag bypassing the P2 check)
+  **overwrites the acquisition's `time` slice in the cube (region write) and upserts its item**; no
+  versioning yet. The **automated trigger never reprocesses** (P2). *Force-path UX is a plan detail,
+  not required for the soak.*
+- **P8 — Data model & identity** *(decided 2026-06-08; hard requirement)*: **per-tile multi-temporal
+  Zarr cube** (one store per tile, scenes inserted on the `time` axis) + **per-acquisition STAC items**
+  (`s1-rtc-{tile}-{datetime}`) that render their slice via TiTiler `sel=time`. A user can load all
+  scenes in a tile as a cube; STAC is the per-acquisition index (no separate tracking system). De-risked
+  by Spike 1 (titiler `sel`) + Spike 2 (builder sizing) — see §7. **Dependency**: the data-model
+  builder must emit one item per `time` slice (currently one-per-store with a datetime range) — an
+  upstream `eopf-geozarr` change.
 
 ---
 
@@ -142,8 +164,20 @@ hardcode credentials; blind-run s1tiling on no-data days.
 3. **Alerting path** — where do quality-gate FAILs and persistent workflow failures notify? *Owner: Loïc / infra.*
 4. **ensure-dem sub-choices** — DEM discovery via `eodag earth_search` vs. direct tile-name
    derivation; cache reuse of the existing `s1-dem` PVC. *Owner: Loïc — confirm during planning.*
+5. **Data-model builder PR (P8)** — `eopf-geozarr` must emit one STAC item per `time` slice; who lands
+   the upstream change and on what timeline? Blocks the per-acquisition register step.
+   *Owner: Loïc / data-model.*
 
 ### Resolved
+- **Spike 1 — TiTiler time selection (2026-06-08, live)**: deployed **titiler-eopf 0.9.0** exposes
+  `sel` on all render endpoints (`sel=time={value}` or `{method}::{value}`, methods nearest/pad/…).
+  Verified `sel=time=nearest::2026-06-05` → HTTP 200 on `info` + `tilejson`. → the per-acquisition-item
+  + per-tile-cube rendering (P8) works. (Also: 0.9.0 resolves the store from the item href — old I-8
+  blocker shipped.)
+- **Spike 2 — per-acquisition builder sizing (2026-06-08)**: viz/`sel=time` links are a few lines in
+  `scripts/register_v1.py` (ours); the per-acquisition item builder is a **moderate upstream
+  `eopf-geozarr` change** (loop the existing `time` axis; geometry/proj/SAR logic already present);
+  the real cost is the **cube time-slice insert + per-tile write serialisation** in ingest (OQ #5/P8).
 - **DEM source/auth (2026-06-08)** — replicate phase-1: Copernicus DEM **GLO-30** COGs from the
   **public AWS Open Data bucket `s3://copernicus-dem-30m/`** over HTTPS
   (`https://copernicus-dem-30m.s3.amazonaws.com/`), **no credentials / not requester-pays**

--- a/claude-docs/specs/s1_grd_phase6_productionization.md
+++ b/claude-docs/specs/s1_grd_phase6_productionization.md
@@ -13,11 +13,11 @@ Move the S1 GRD RTC pipeline from the verified **single-tile (31TCH) / S1A** pro
 S1 GRD products, provisions the DEM for any requested tile automatically, and runs
 s1tiling → ingest → register, writing to **staging** (staging→prod promotion is a later phase — P3).
 
-**Hard requirement**: a user can load *all scenes in a tile as a datacube*. Met via **dual storage**
-(P8): a **per-tile multi-temporal cube** for analysis (xarray), plus **per-acquisition single-time
-stores + STAC items** that render directly in the explorer (titiler reconstructs `store = item-id`, so
-no `sel=time` / titiler change is needed). The PoC proved titiler ignores the asset href, so a single
-shared cube cannot back the per-acquisition rendering — hence dual storage (§7 Spike 3, P8).
+**Hard requirement**: a user can load *all scenes in a tile as a datacube* — met by a **per-tile
+multi-temporal cube** (xarray). The catalogue exposes **per-acquisition STAC items** that render their
+slice from the cube via TiTiler `sel=time`. This rendering **depends on I2 / option 2** — titiler
+resolving the store from the item's asset href (platform-deploy `ecde99c`; **not yet effective**, §7
+Spike 3, P8). **Dual storage** (per-acquisition stores) is the documented fallback if option 2 stalls.
 
 **Target users**: the EOPF Explorer platform (STAC catalogue + raster viewer consumers) and the
 devseed operators who run/monitor the pipeline.
@@ -40,8 +40,11 @@ devseed operators who run/monitor the pipeline.
   decision B (child `Workflow`s via `workflowTemplateRef`).
 - **Automated DEM-fetch**: a template/step that ensures the DEM swath + `dem_db` for the requested
   tile exists before s1tiling (fetches Copernicus DEM GLO-30 tiles intersecting the MGRS square).
-- **Multi-platform**: render `platform_list = "S1A S1C"` into the s1tiling cfg; the trigger skips S1D
-  (logged), so daily runs don't attempt-and-fail S1D scenes.
+- **Multi-platform**: render `platform_list = "S1A S1C"` into the s1tiling cfg; the trigger skips
+  submitting S1D-targeted workflows (logged). **Note (PoC finding)**: s1tiling downloads *all*
+  platforms in the window (filter applies at processing, not download) and exits non-zero if an
+  off-platform (S1D/S1C) download fails — so the s1tiling step must **tolerate off-platform download
+  failures** (succeed when the requested platform produced output). See §7 + plan T2.
 - **Multi-tile**: trigger iterates a configured tile set (AOI); each tile self-provisions its DEM.
 - **Bounded historical backfill** on enable (configurable lookback — OQ #2), alongside forward
   processing (P5).
@@ -65,11 +68,12 @@ CronWorkflow (data-driven trigger, every 6 h)
        query CDSE STAC (bbox, lookback, orbit, platform∈{S1A,S1C})  ──► new products?
           └─ for each NEW product (not already in STAC):           ──► submit child Workflow:
                ┌──────────────────────────────────────────────────────────────────────┐
-               │ ensure-dem → s1tiling → ingest ──┬─ per-acquisition store (renders)     │
-               │                                  └─ append to per-tile cube (analysis)  │
-               │            → quality-gate(FAIL⇒stop) → register(per-acquisition item)   │
+               │ ensure-dem → s1tiling → ingest(append scene as a time slice to the      │
+               │   per-tile cube) → quality-gate(FAIL⇒stop) → register(per-acquisition   │
+               │   item → cube via asset href + sel=time)                                │
                └──────────────────────────────────────────────────────────────────────┘
-   (cube append serialised by an Argo synchronization mutex keyed on the tile)
+   (cube append serialised by an Argo synchronization mutex keyed on the tile;
+    per-acquisition rendering depends on titiler href resolution — I2/option 2)
 ```
 
 - **Trigger**: the local `watch_cdse_and_process.py` query/dedup logic is ported into a container
@@ -82,15 +86,16 @@ CronWorkflow (data-driven trigger, every 6 h)
   cached). The EGM2008 geoid is a one-time shared asset, not per-tile.
 - **Platform**: cfg render extended to set `platform_list`; trigger filters its CDSE query to
   `S1A, S1C` and explicitly skips S1D with a log line.
-- **Storage (dual, P8)**: ingest writes **two** artifacts per scene on the S1 **staging** bucket —
-  (1) a **per-acquisition single-time store** named = its item id (`s1-rtc-{tile}-{datetime}.zarr`) for
-  rendering, and (2) an **append of the scene as a new `time` slice into the per-tile cube**
-  (`s1-rtc-{tile}.zarr`) for analysis. The cube append is **serialised by an Argo `synchronization`
-  mutex keyed on the tile**; ingest skips a time already present. Prod is out of scope (P3).
-- **Catalogue (P8)**: `register` upserts **one STAC item per acquisition** (`s1-rtc-{tile}-{datetime}`),
-  pointing at its per-acquisition store → **renders directly** (store-name = item-id matches titiler's
-  reconstruction; no `sel=time`). The per-tile cube is catalogued as the per-tile item for analysis;
-  a user loads the whole tile by opening the cube store (xarray). The per-acquisition items are the
+- **Storage (P8)**: ingest **appends the scene as a new `time` slice into the per-tile cube**
+  (`s1-rtc-{tile}.zarr`, collection `sentinel-1-grd-rtc-staging`) on the S1 **staging** bucket;
+  the append is **serialised by an Argo `synchronization` mutex keyed on the tile** and skips a `time`
+  already present. (Fallback only, if I2/option 2 stalls: also write a per-acquisition single-time
+  store named = item-id for reconstruction-based rendering — dual storage.) Prod is out of scope (P3).
+- **Catalogue (P8)**: `register` upserts **one STAC item per acquisition**
+  (`s1-rtc-{tile}-{datetime}`, collection `sentinel-1-grd-rtc-acquisitions`), pointing at the cube via
+  asset href; TiTiler renders the right slice with `sel=time=nearest::{datetime}` **once I2/option 2
+  (href resolution) is live**. The per-tile cube item (`sentinel-1-grd-rtc-staging`) is the analysis
+  entry — a user loads the whole tile by opening the cube (xarray). The per-acquisition items are the
   queryable time-series index (dedup authority).
 - **Geoid**: the EGM2008 model is assumed pre-staged on the `s1-dem` PVC (as in phase-1); `ensure-dem`
   does not fetch it per run.
@@ -104,10 +109,10 @@ CronWorkflow (data-driven trigger, every 6 h)
 - [ ] A **previously-unprocessed tile** runs end-to-end with **no manual DEM upload** (ensure-dem works).
 - [ ] An **S1C** scene processes A→B end-to-end; item queryable + validation PASS.
 - [ ] **S1D** scenes are skipped with a logged reason; no failed workflows.
-- [ ] **Per-acquisition rendering (P8)**: each acquisition has its own single-time store + STAC item
-      that **renders directly** in the explorer (store-name = item-id; no `sel=time`/titiler change).
+- [ ] **Per-acquisition rendering (P8)**: each acquisition has a STAC item that renders its slice from
+      the cube via `sel=time` (depends on **I2/option 2** — titiler href resolution being live).
 - [ ] **Datacube (P8)**: after ≥2 acquisitions for a tile, the per-tile cube opens as a datacube with
-      all scenes on the `time` axis (xarray) — "load all scenes in a tile" works.
+      all scenes on the `time` axis (xarray) — "load all scenes in a tile" works (independent of titiler).
 - [ ] **Concurrency**: two scenes for the same tile processed together both land in the cube without
       corruption (per-tile write serialised).
 - [ ] **Idempotent**: re-trigger over the same window creates no duplicate stores / items / time slices.
@@ -141,23 +146,22 @@ CronWorkflow (data-driven trigger, every 6 h)
   **overwrites the acquisition's `time` slice in the cube (region write) and upserts its item**; no
   versioning yet. The **automated trigger never reprocesses** (P2). *Force-path UX is a plan detail,
   not required for the soak.*
-- **P8 — Data model & identity** *(decided 2026-06-08; revised after the PoC; hard requirement)*:
-  **dual storage**, because the PoC proved titiler-eopf reconstructs the store path from
-  `{base}/{collection}/{item_id}.zarr` and **ignores the asset href** (so per-acquisition items
-  *cannot* share one cube for rendering — see §7 Spike 3). Therefore:
-  1. **Per-acquisition stores + items** (rendering path): each acquisition → its own single-time Zarr
-     named = its item id (`s1-rtc-{tile}-{datetime}.zarr`) in a per-acquisition collection, + one STAC
-     item. Renders **directly today** (store-name = item-id matches titiler's reconstruction; **no
-     `sel=time`, no titiler change** — it's the proven phase-5 store pattern with per-acquisition ids).
-  2. **Per-tile cube** (analysis path): scenes also appended to one multi-temporal Zarr per tile
-     (`s1-rtc-{tile}.zarr`, existing `sentinel-1-grd-rtc-staging`) so a user can **load all scenes in a
-     tile as a datacube** (xarray). Catalogued as the per-tile item.
-  STAC is the per-acquisition index (no separate tracking system). **Cost**: each scene is written
-  twice (its own store + appended to the cube); the cube append needs per-tile write serialisation.
-  **Deferred**: a future titiler "resolve store from asset href" change (I-8 Option A) would let the
-  per-acquisition items render *from the shared cube*, collapsing dual storage to single — out of scope
-  here. **Dependency**: per-acquisition item builder (one item per scene) — small (the phase-5 builder
-  already emits per-store items; just per-acquisition ids).
+- **P8 — Data model & identity** *(decided 2026-06-08; hard requirement)*: a **per-tile multi-temporal
+  Zarr cube** (one store per tile, scenes appended on the `time` axis) backs both access paths:
+  1. **Analysis** — a user loads all scenes in a tile by opening the cube (`s1-rtc-{tile}.zarr`,
+     collection `sentinel-1-grd-rtc-staging`) with xarray. Works regardless of titiler.
+  2. **Rendering** — **per-acquisition STAC items** (`s1-rtc-{tile}-{datetime}`, one per scene,
+     collection `sentinel-1-grd-rtc-acquisitions`) point at the cube via asset href and render their
+     slice via TiTiler `sel=time=nearest::{datetime}`.
+  STAC is the per-acquisition index (no separate tracking system). **Rendering depends on I2 (option 2,
+  chosen 2026-06-08)**: titiler must resolve the store from the STAC item's **asset href** — platform-
+  deploy `ecde99c` adds `TITILER_EOPF_API_ROOT_URL` toward this, but **re-tested 2026-06-08 it is NOT
+  yet effective** (titiler still reconstructs `{base}/{collection}/{item_id}.zarr`, ignores href; §7
+  Spike 3). Per-acquisition **rendering is blocked until option 2 deploys + is verified**; the cube
+  storage/append + xarray load are unaffected.
+  **Fallback** (if option 2 stalls): **dual storage** — also write per-acquisition single-time stores
+  named = item-id, which render via titiler's reconstruction today (cost: each scene written twice +
+  cube-append serialisation). Single shared cube is preferred once option 2 is verified.
 
 ---
 
@@ -181,8 +185,12 @@ hardcode credentials; blind-run s1tiling on no-data days.
 3. **Alerting path** — where do quality-gate FAILs and persistent workflow failures notify? *Owner: Loïc / infra.*
 4. **ensure-dem sub-choices** — DEM discovery via `eodag earth_search` vs. direct tile-name
    derivation; cache reuse of the existing `s1-dem` PVC. *Owner: Loïc — confirm during planning.*
-5. **Dual-storage write cost (P8)** — confirm acceptance of writing each scene twice (per-acquisition
-   store + per-tile cube append). *Owner: Loïc — confirmed 2026-06-08 (chose dual storage).*
+5. **I2 / option 2 — titiler href resolution (blocks per-acquisition rendering)**: deploy + verify that
+   titiler resolves the store from the STAC item asset href (platform-deploy `ecde99c` adds
+   `TITILER_EOPF_API_ROOT_URL`; re-tested 2026-06-08 — **not yet effective**). Until verified, fall back
+   to dual storage (per-acquisition stores named = item-id). *Owner: Loïc / infra (E. Mathot).*
+6. **s1tiling off-platform-download tolerance** — make the s1tiling step succeed when the requested
+   platform produced output despite S1D/S1C download failures (PoC finding). *Owner: plan T2.*
 
 ### Resolved
 - **Spike 1 — TiTiler `sel` param (2026-06-08)**: titiler-eopf **0.9.0** exposes `sel` on all render
@@ -195,22 +203,28 @@ hardcode credentials; blind-run s1tiling on no-data days.
 - **Spike 3 — titiler store resolution (2026-06-08, PoC, decisive)**: the datacube PoC proved
   titiler-eopf **reconstructs the store path as `s3://esa-zarr-sentinel-explorer-fra/tests-output/
   {collection}/{item_id}.zarr` and IGNORES the asset href** (`/info` → *"No group found in store …
-  {item_id}.zarr"*); there is **no URL-based render endpoint**. So per-acquisition items **cannot share
-  one cube** for rendering (I-8 not fixed). → drove the **P8 revision to dual storage**: per-acquisition
-  single-time stores (store-name = item-id → render directly today, no titiler change) + a per-tile cube
-  for analysis. The PoC *did* validate the cube **append** works (2 acquisitions → 2-time cube).
+  {item_id}.zarr"*); there is **no URL-based render endpoint**. The PoC *did* validate the cube
+  **append** works (2 acquisitions → 2-time cube).
+- **I2 decision = option 2, in flight (2026-06-08)**: make titiler **resolve the store from the STAC
+  item asset href** so per-acquisition items can render from the shared cube (collapses the dual-storage
+  fallback to a single cube). platform-deploy **`ecde99c`** adds
+  `TITILER_EOPF_API_ROOT_URL: …/stac` toward this. **Re-tested 2026-06-08 — NOT yet effective**: the
+  per-acquisition item still 500s with the reconstructed `fra/tests-output/…` path. → option 2 is a
+  **dependency to deploy + verify** (OQ #5); until then per-acquisition rendering is blocked (cube
+  append + xarray load are fine), and **dual storage** (per-acquisition stores named = item-id) is the
+  fallback that renders via reconstruction today.
 - **DEM source/auth (2026-06-08)** — replicate phase-1: Copernicus DEM **GLO-30** COGs from the
   **public AWS Open Data bucket `s3://copernicus-dem-30m/`** over HTTPS
   (`https://copernicus-dem-30m.s3.amazonaws.com/`), **no credentials / not requester-pays**
   (`s1_grd_phase5_subissues.md:169-242`). NOT CDSE (`cop_dataspace` lacks the collection / is
   auth'd-requester-pays). This makes the automated DEM-fetch viable; cache on the `s1-dem` PVC.
-- **P1–P7** — see §5. Prod cutover authority deferred with the prod path (P3).
+- **P1–P8** — see §5. Prod cutover authority deferred with the prod path (P3).
 
 ---
 
 ## 8. Done definition (Define stage)
 
-Objectives, scope, and success criteria are unambiguous and agreed; P1–P7 confirmed (§5); open
-questions §7 have owners. Then proceed to a Plan (`claude-docs/plans/`) breaking this into atomic
-tasks (trigger port, ensure-dem, platform render S1A+S1C, multi-tile AOI, quality gate, backfill,
-acceptance soak).
+Objectives, scope, and success criteria are unambiguous and agreed; P1–P8 confirmed (§5); open
+questions §7 have owners. Then proceed to the Plan (`claude-docs/plans/s1_grd_phase6_productionization.md`),
+which breaks this into atomic tasks (quality gate, platform render S1A+S1C, ensure-dem, **datacube
+ingest/append**, **per-acquisition catalogue**, trigger port, multi-tile AOI, backfill, acceptance soak).

--- a/claude-docs/specs/s1_grd_phase6_productionization.md
+++ b/claude-docs/specs/s1_grd_phase6_productionization.md
@@ -1,0 +1,152 @@
+# Spec: S1 GRD RTC Productionization (Phase 6)
+
+**Status**: Draft (Define stage) — 2026-06-08
+**Builds on**: `s1_grd_phase5_subissues.md` (local prototype + Argo templates),
+`s1_grd_STACregisration_and_argo_pipelines.md`, `spike_s1tiling_platform_support.md` (S1C/S1D finding).
+
+---
+
+## 1. Objective
+
+Move the S1 GRD RTC pipeline from the verified **single-tile (31TCH) / S1A** prototype to an
+**automated, multi-tile, in-cluster production service**: a data-driven trigger discovers new CDSE
+S1 GRD products, provisions the DEM for any requested tile automatically, and runs
+s1tiling → ingest → register, promoting outputs along a staging → prod path.
+
+**Target users**: the EOPF Explorer platform (STAC catalogue + raster viewer consumers) and the
+devseed operators who run/monitor the pipeline.
+
+### Resolved decisions (2026-06-08, confirmed with Loïc)
+| # | Decision | Implication |
+|---|----------|-------------|
+| Goal | Productionize S1 GRD RTC in-cluster (automated, multi-tile, staging→prod) | Drives the whole spec |
+| Platform | **S1A + S1C**, skip **S1D** | S1C enabled config-only; S1D skipped until upstream s1tiling support (no release/dev branch has it — `spike_s1tiling_platform_support.md`) |
+| Trigger | **Port the CDSE watcher into Argo** (data-driven) | A CronWorkflow runs query→dedup→submit; no blind-day s1tiling |
+| Tiles/DEM | **Automated DEM-fetch step** | A pipeline step fetches/builds the Copernicus DEM GLO-30 for any requested MGRS tile; no manual DEM upload |
+
+---
+
+## 2. Scope
+
+### In scope
+- **Data-driven trigger in Argo**: a CronWorkflow that runs the watcher logic (per-tile bbox → CDSE
+  STAC query → dedup → submit a child Workflow per *new* product). Reuses sub-issue 8's composition
+  decision B (child `Workflow`s via `workflowTemplateRef`).
+- **Automated DEM-fetch**: a template/step that ensures the DEM swath + `dem_db` for the requested
+  tile exists before s1tiling (fetches Copernicus DEM GLO-30 tiles intersecting the MGRS square).
+- **Multi-platform**: render `platform_list = "S1A S1C"` into the s1tiling cfg; the trigger skips S1D
+  (logged), so daily runs don't attempt-and-fail S1D scenes.
+- **Multi-tile**: trigger iterates a configured tile set (AOI); each tile self-provisions its DEM.
+- **Bounded historical backfill** on enable (configurable lookback — OQ #4), alongside forward
+  processing (P5).
+- **In-cluster dedup/idempotency** via STAC item-exists check (P2 — replaces the local JSON state).
+- **Quality gate** before register (P1).
+
+### Out of scope (deferred, flagged)
+- **Staging → prod promotion** — **staging-only this phase** (P3); prod bucket/collection + cutover
+  authority deferred to a later phase.
+- **S1D** — no s1tiling version supports it; track an upstream issue. Trigger skips it meanwhile.
+- **Other missions (S2/S3/S4)** — generalizing the trigger/ingest pattern is a separate effort;
+  design with reuse in mind but do not build it here.
+
+---
+
+## 3. Architecture (proposed)
+
+```
+CronWorkflow (data-driven trigger, every N hours)
+  └─ for each tile in AOI:
+       query CDSE STAC (bbox, lookback, orbit, platform∈{S1A,S1C})  ──► new products?
+          └─ for each NEW product (not already in STAC):           ──► submit child Workflow:
+               ┌─────────────────────────────────────────────────────────────┐
+               │ ensure-dem (fetch GLO-30 for tile)  →  s1tiling  →  ingest  →  register │
+               │                                                     └─ quality gate ┘   │
+               └─────────────────────────────────────────────────────────────┘
+```
+
+- **Trigger**: the local `watch_cdse_and_process.py` query/dedup logic is ported into a container
+  step the CronWorkflow runs; it submits child Workflows rather than calling subprocesses. The blind
+  daily cron (sub-issue 8) is retired/replaced once this is live.
+- **ensure-dem step**: automates the phase-1 DEM recipe per tile — compute the S1 IW **swath** bbox
+  for the MGRS tile, fetch the GLO-30 COGs from the **public AWS Open Data bucket
+  `s3://copernicus-dem-30m/`** over HTTPS (no auth — see §7 Resolved), rename to the `Product10`
+  convention, rebuild `DEM_Union.gpkg`, and cache on the `s1-dem` PVC (idempotent: skip tiles already
+  cached). The EGM2008 geoid is a one-time shared asset, not per-tile.
+- **Platform**: cfg render extended to set `platform_list`; trigger filters its CDSE query to
+  `S1A, S1C` and explicitly skips S1D with a log line.
+- **Storage**: GeoTIFFs + Zarr to the S1 staging bucket; prod promotion path per P3.
+
+---
+
+## 4. Success criteria (proposed — review)
+
+- [ ] Data-driven trigger submits a child Workflow **only** for genuinely new CDSE products
+      (zero s1tiling runs on no-data days).
+- [ ] A **previously-unprocessed tile** runs end-to-end with **no manual DEM upload** (ensure-dem works).
+- [ ] An **S1C** scene processes A→B end-to-end; item queryable + validation PASS.
+- [ ] **S1D** scenes are skipped with a logged reason; no failed workflows.
+- [ ] **Idempotent**: re-trigger over the same window creates no duplicate work / items.
+- [ ] **Quality gate** blocks a deliberately-corrupted output from being registered (P1).
+- [ ] **Backfill**: the configured lookback window is processed on enable without duplicating
+      forward items (P5).
+- [ ] **Phase acceptance soak**: **5 tiles × 14 days × ≥ 95% success** on staging (no prod cutover
+      this phase — P3, P4).
+
+---
+
+## 5. Resolved operational decisions (2026-06-08, confirmed with Loïc)
+
+- **P1 — Quality gate**: run the `validate_s1_grd_rtc` checks (CRS, grid_mapping, NaN fraction, dB
+  ranges) as an automated **post-ingest gate**. **FAIL → do not register, fail the workflow + alert;
+  WARN → register with an annotation.**
+- **P2 — Dedup**: **STAC "does this item exist?" check** (+ the ingest's own skip gate) is the dedup
+  authority — no persistent PVC/ConfigMap state. *Risk: STAC indexing latency could allow a brief
+  re-submit window; acceptable, mitigated by the ingest skip-gate.*
+- **P3 — Promotion**: **staging only this phase.** Register to the S1 staging bucket/collection;
+  **prod bucket/collection + cutover are out of scope** (deferred to a later phase). The §4 soak is
+  the phase acceptance bar, not a prod gate.
+- **P4 — Acceptance soak**: **5 tiles × 14 days × ≥ 95% success** on staging.
+- **P5 — Temporal**: **forward + bounded backfill.** Process new acquisitions *and* a configurable
+  historical lookback window on enable. Backfill window size = **OQ #4**.
+- **P6 — Cadence**: trigger **every 6 h**.
+- **P7 — Reprocessing**: **overwrite (upsert)** on reprocess (orbit/DEM/data-model change); no item
+  versioning yet (revisit only if a consumer needs history).
+
+---
+
+## 6. Boundaries
+
+**Always**: keep Script A/B and the Argo templates as the single source of pipeline logic (trigger
+only orchestrates); path-guard any destructive op; validate before register (P1); use per-mission
+buckets.
+**Ask first**: enabling **prod** writes; changing the STAC collection schema (consumer contract);
+any S1D work; cross-repo changes to the merged s1tiling/ingest templates.
+**Never**: register an item that failed the quality gate; process S1D until upstream support lands;
+hardcode credentials; blind-run s1tiling on no-data days.
+
+---
+
+## 7. Open questions (owner)
+
+1. **AOI definition** — the concrete tile set (and the 5 soak tiles). *Owner: Loïc / science.*
+2. **Backfill window** (P5) — how far back on enable (e.g. 30 / 90 days)? Sizes throughput + cost.
+   *Owner: Loïc.*
+3. **Alerting path** — where do quality-gate FAILs and persistent workflow failures notify? *Owner: Loïc / infra.*
+4. **ensure-dem sub-choices** — DEM discovery via `eodag earth_search` vs. direct tile-name
+   derivation; cache reuse of the existing `s1-dem` PVC. *Owner: Loïc — confirm during planning.*
+
+### Resolved
+- **DEM source/auth (2026-06-08)** — replicate phase-1: Copernicus DEM **GLO-30** COGs from the
+  **public AWS Open Data bucket `s3://copernicus-dem-30m/`** over HTTPS
+  (`https://copernicus-dem-30m.s3.amazonaws.com/`), **no credentials / not requester-pays**
+  (`s1_grd_phase5_subissues.md:169-242`). NOT CDSE (`cop_dataspace` lacks the collection / is
+  auth'd-requester-pays). This makes the automated DEM-fetch viable; cache on the `s1-dem` PVC.
+- **P1–P7** — see §5. Prod cutover authority deferred with the prod path (P3).
+
+---
+
+## 8. Done definition (Define stage)
+
+Objectives, scope, and success criteria are unambiguous and agreed; P1–P7 defaults are confirmed or
+amended; open questions §7 have owners. Then proceed to a Plan (`claude-docs/plans/`) breaking this
+into atomic tasks (trigger port, ensure-dem, platform render, quality gate, promotion, soak).


### PR DESCRIPTION
Define-stage spec for the **next phase**: automated, multi-tile, in-cluster S1 GRD RTC. Builds on the phase-5 prototype (#186).

## Decisions locked (confirmed with Loïc, 2026-06-08)
- **Goal**: productionize in-cluster (automated, multi-tile, staging→prod)
- **Platform**: S1A + S1C; **skip S1D** (no s1tiling release/dev branch supports it — see #223)
- **Trigger**: port the CDSE watcher into Argo (data-driven CronWorkflow)
- **DEM**: automated DEM-fetch from the **public AWS Open Data `copernicus-dem-30m`** bucket (no auth)
- **P1–P8**: quality gate on FAIL · STAC-existence dedup · staging-only (prod deferred) · soak 5 tiles × 14 d × ≥95% · forward + bounded backfill · 6 h cadence · overwrite-on-reprocess · **P8** data model = per-tile datacube + per-acquisition items (rendering deferred, #228)

## Open questions (owner-assigned, pinned during planning)
AOI/soak tiles · backfill window · alerting path · ensure-dem sub-choices (discovery method, PVC cache).

Base is `feat--s1_grd_phase5` (stacked; `claude-docs/specs/` only exists there until #186 merges). Retarget to `main` after #186 lands. Next stage: a Plan breaking this into atomic tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
