### PR TITLE
feat(s1-phase6): quality-gate CLI + per-acquisition register (T1, T5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,5 +178,5 @@ module = "notebooks.*"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = ["boto3.*", "botocore.*", "mgrs.*"]
+module = ["boto3.*", "botocore.*", "mgrs.*", "eopf_geozarr.*", "rioxarray.*"]
 ignore_missing_imports = true

--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -1,0 +1,155 @@
+"""Register one STAC item per acquisition from a per-tile S1 GRD RTC datacube (plan T5).
+
+The cube (`s1-rtc-{tile}.zarr`, collection `sentinel-1-grd-rtc-staging`) holds all acquisitions on a
+`time` axis. This emits **one queryable STAC item per `time` slice** (`s1-rtc-{tile}-{datetime}`,
+single `datetime`) into the `sentinel-1-grd-rtc-acquisitions` collection, each pointing at the cube
+via asset href with a `sel=time` tilejson link baked in. Explorer rendering is deferred (see #228);
+the links render once titiler resolves the store from the item href — no later data change.
+
+Usage:
+    uv run python scripts/register_per_acquisition.py --store <cube-uri> --tile-id 31TCH \
+      --orbit-direction descending --stac-api-url <url> --raster-api-url <url>
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import datetime as dt
+import urllib.parse
+from typing import Any
+
+DEFAULT_ACQ_COLLECTION = "sentinel-1-grd-rtc-acquisitions"
+
+
+def acquisition_id(tile_id: str, when: dt.datetime) -> str:
+    """Per-acquisition item id, e.g. ``s1-rtc-31TCH-20260607t055248``."""
+    return f"s1-rtc-{tile_id}-{when.strftime('%Y%m%dt%H%M%S')}"
+
+
+def sel_time_tilejson(
+    raster_api: str,
+    collection: str,
+    item_id: str,
+    when: dt.datetime,
+    orbit: str,
+    *,
+    var: str = "vh",
+) -> str:
+    """TiTiler tilejson URL that renders this acquisition's slice of the cube (``sel=time``)."""
+    sel = urllib.parse.quote(f"time=nearest::{when.isoformat()}", safe="")
+    variables = urllib.parse.quote(f"/{orbit}:{var}", safe="")
+    return (
+        f"{raster_api}/collections/{collection}/items/{item_id}"
+        f"/WebMercatorQuad/tilejson.json?variables={variables}&bidx=1&rescale=0%2C219"
+        f"&assets={var}&sel={sel}"
+    )
+
+
+def per_acquisition_items(
+    base_item: dict,
+    times_ns: list[int],
+    *,
+    tile_id: str,
+    orbit: str,
+    collection: str,
+    raster_api: str,
+) -> list[dict]:
+    """Clone the per-tile ``base_item`` into one item per `time` slice.
+
+    Each clone keeps the base geometry/assets/SAR+proj properties, sets a single ``datetime`` (drops
+    the start/end range), targets ``collection``, and carries a ``sel=time`` tilejson link. The input
+    ``base_item`` is not mutated.
+    """
+    items: list[dict] = []
+    for t_ns in times_ns:
+        when = dt.datetime.fromtimestamp(t_ns / 1e9, tz=dt.UTC)
+        item_id = acquisition_id(tile_id, when)
+        item = copy.deepcopy(base_item)
+        item["id"] = item_id
+        item["collection"] = collection
+        props = {
+            k: v
+            for k, v in item.get("properties", {}).items()
+            if k not in ("start_datetime", "end_datetime")
+        }
+        props["datetime"] = when.isoformat()
+        item["properties"] = props
+        item["links"] = [
+            {
+                "rel": "tilejson",
+                "type": "application/json",
+                "href": sel_time_tilejson(raster_api, collection, item_id, when, orbit),
+                "title": "tilejson (sel=time)",
+            }
+        ]
+        items.append(item)
+    return items
+
+
+# --- store I/O + registration (integration; exercised in main) --------------
+
+
+def _open_root(store: str) -> Any:
+    import zarr
+
+    if "://" in store:
+        from zarr.storage import FsspecStore
+
+        return zarr.open_group(FsspecStore.from_url(store), mode="r")
+    return zarr.open_group(store, mode="r", zarr_format=3)
+
+
+def read_times_ns(store: str, orbit: str) -> list[int]:
+    """Sorted `time` values (ns since epoch) from the cube's native (r10m) level."""
+    import numpy as np
+
+    root = _open_root(store)
+    times = np.asarray(root[orbit]["r10m"]["time"]).astype("datetime64[ns]").astype("int64")
+    return sorted(int(t) for t in times)
+
+
+def _upsert_items(stac_api_url: str, collection: str, items: list[dict]) -> None:
+    """DELETE-then-POST each item (pgstac has no item PUT), mirroring register_v1.upsert_item."""
+    from pystac_client import Client
+
+    client = Client.open(stac_api_url)
+    io = client._stac_io
+    assert io is not None  # noqa: S101 -- pystac-client always sets this after open()
+    base = str(client.self_href).rstrip("/")
+    for item in items:
+        item_id = item["id"]
+        io.session.delete(f"{base}/collections/{collection}/items/{item_id}", timeout=30)
+        resp = io.session.post(f"{base}/collections/{collection}/items", json=item, timeout=30)
+        resp.raise_for_status()
+        print(f"registered {item_id} (datetime {item['properties']['datetime']})")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--store", required=True, help="per-tile cube URI (https/s3)")
+    ap.add_argument("--tile-id", required=True)
+    ap.add_argument("--orbit-direction", required=True, choices=["descending", "ascending"])
+    ap.add_argument("--collection", default=DEFAULT_ACQ_COLLECTION)
+    ap.add_argument("--stac-api-url", required=True)
+    ap.add_argument("--raster-api-url", required=True)
+    args = ap.parse_args()
+
+    from eopf_geozarr.stac.s1_rtc import build_s1_rtc_stac_item
+
+    base = build_s1_rtc_stac_item(args.store, args.collection).to_dict()
+    times = read_times_ns(args.store, args.orbit_direction)
+    items = per_acquisition_items(
+        base,
+        times,
+        tile_id=args.tile_id,
+        orbit=args.orbit_direction,
+        collection=args.collection,
+        raster_api=args.raster_api_url,
+    )
+    _upsert_items(args.stac_api_url, args.collection, items)
+    print(f"registered {len(items)} per-acquisition item(s) in {args.collection}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_s1_rtc.py
+++ b/scripts/validate_s1_rtc.py
@@ -100,20 +100,33 @@ def check_db_range(
     return Check(Level.PASS, f"{name} dB range", detail)
 
 
-def validate_dataset(ds: xr.Dataset) -> list[Check]:
-    """Run the per-level (r10m) data checks over an opened dataset."""
-    checks = [
+def validate_schema(ds: xr.Dataset) -> list[Check]:
+    """Cheap (metadata-only) checks: dtype/dims + CRS. Run on the native resolution."""
+    return [
         check_dtype_dims(ds, "vv", "float32"),
         check_dtype_dims(ds, "vh", "float32"),
         check_dtype_dims(ds, "border_mask", "uint8"),
         check_crs(ds),
     ]
+
+
+def validate_data(ds: xr.Dataset) -> list[Check]:
+    """Data-sanity checks (finite fraction, dB range) over vv/vh of the given dataset.
+
+    Pass a coarse overview (cheap) and/or a single ``time`` slice (gate the new acquisition).
+    """
+    checks: list[Check] = []
     for var in ("vv", "vh"):
         if var in ds:
             arr = np.asarray(ds[var].values)
             checks.append(check_finite(var, arr))
             checks.append(check_db_range(var, arr))
     return checks
+
+
+def validate_dataset(ds: xr.Dataset) -> list[Check]:
+    """Schema + data checks over one opened dataset (used by tests / simple single-level runs)."""
+    return validate_schema(ds) + validate_data(ds)
 
 
 # --- store I/O + structural check (integration; exercised in main) ----------
@@ -159,11 +172,30 @@ def _open_level(store: str, orbit: str, res: str) -> xr.Dataset:
     return ds
 
 
+def time_index(native: xr.Dataset, when: str) -> int:
+    """Nearest `time` index for `when` (ISO) from the native level's time coordinate.
+
+    Overview levels carry the `time` dimension but not always its coordinate/index, so we resolve
+    the position on the native level and `isel` it positionally on the overview.
+    """
+    tvals = np.asarray(native["time"].values).astype("datetime64[ns]")
+    target = np.datetime64(when).astype("datetime64[ns]")
+    return int(np.argmin(np.abs(tvals - target)))
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--store", required=True, help="Zarr store URI (local path or https/s3)")
     ap.add_argument("--orbit", default=None, help="orbit group (default: auto-detect)")
-    ap.add_argument("--res", default="r10m")
+    ap.add_argument("--res", default="r10m", help="native resolution level for schema checks")
+    ap.add_argument(
+        "--data-res", default="r60m", help="coarse overview for data checks (avoids loading r10m)"
+    )
+    ap.add_argument(
+        "--time",
+        default=None,
+        help="acquisition datetime to gate (ISO); default validates all times in the cube",
+    )
     args = ap.parse_args()
 
     root = _open_root(args.store)
@@ -173,12 +205,21 @@ def main() -> None:
         print(f"[FAIL] orbit group — none of ascending/descending in {members}")
         sys.exit(int(Level.FAIL))
 
-    checks = [check_structural(root), *validate_dataset(_open_level(args.store, orbit, args.res))]
+    # Schema (cheap) on native; data sanity on a coarse overview, optionally one acquisition slice.
+    native = _open_level(args.store, orbit, args.res)
+    checks = [check_structural(root), *validate_schema(native)]
+    data_ds = _open_level(args.store, orbit, args.data_res)
+    if args.time is not None:
+        data_ds = data_ds.isel(time=time_index(native, args.time))
+    checks += validate_data(data_ds)
 
     worst = overall(checks)
     for c in checks:
         print(f"[{c.level.name}] {c.label} — {c.detail}")
-    print(f"OVERALL: {worst.name}  (orbit={orbit}, res={args.res})")
+    scope = f"time={args.time}" if args.time else "all times"
+    print(
+        f"OVERALL: {worst.name}  (orbit={orbit}, schema={args.res}, data={args.data_res}, {scope})"
+    )
     sys.exit(int(worst))
 
 

--- a/scripts/validate_s1_rtc.py
+++ b/scripts/validate_s1_rtc.py
@@ -1,0 +1,186 @@
+"""S1 GRD RTC quality gate — validate a GeoZarr store/cube; exit 0=PASS / 1=WARN / 2=FAIL.
+
+Wraps the `validate_s1_grd_rtc` notebook's checks as a CLI for the Argo quality-gate step
+(plan T1) and as the notebook-validation core (plan T5). The pure check functions are unit-tested;
+`main()` opens the store (structural `S1RtcRoot` check + per-level data checks) and exits with the
+worst severity found.
+
+Usage:
+    uv run python scripts/validate_s1_rtc.py --store <zarr-uri> [--orbit descending] [--res r10m]
+exit code = 0 PASS · 1 WARN · 2 FAIL
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any
+
+import numpy as np
+import rioxarray  # noqa: F401  -- registers the .rio accessor used by check_crs
+import xarray as xr
+
+
+class Level(IntEnum):
+    PASS = 0
+    WARN = 1
+    FAIL = 2
+
+
+@dataclass
+class Check:
+    level: Level
+    label: str
+    detail: str
+
+
+def overall(checks: list[Check]) -> Level:
+    """Worst severity across checks (PASS if none)."""
+    return max((c.level for c in checks), default=Level.PASS)
+
+
+# --- pure checks (unit-tested) ----------------------------------------------
+
+
+def check_finite(
+    name: str, arr: np.ndarray, *, fail_below: float = 0.5, warn_below: float = 0.99
+) -> Check:
+    """Fraction of finite samples: < fail_below → FAIL, < warn_below → WARN, else PASS."""
+    a = np.asarray(arr)
+    finite = float(np.isfinite(a).mean()) if a.size else 0.0
+    detail = f"{finite * 100:.1f}% finite"
+    if finite < fail_below:
+        return Check(Level.FAIL, f"{name} finite data", detail)
+    if finite < warn_below:
+        return Check(Level.WARN, f"{name} finite data", detail)
+    return Check(Level.PASS, f"{name} finite data", detail)
+
+
+def check_dtype_dims(
+    ds: xr.Dataset, var: str, want_dtype: str, want_dims: tuple[str, ...] = ("time", "y", "x")
+) -> Check:
+    """Variable present with the expected dtype and dimension order."""
+    if var not in ds:
+        return Check(Level.FAIL, f"{var} present", "missing")
+    got_dtype = str(ds[var].dtype)
+    if got_dtype != want_dtype:
+        return Check(Level.FAIL, f"{var} dtype", f"{got_dtype} (want {want_dtype})")
+    got_dims = tuple(ds[var].dims)
+    if got_dims != want_dims:
+        return Check(Level.FAIL, f"{var} dims", f"{got_dims} (want {want_dims})")
+    return Check(Level.PASS, f"{var} dtype/dims", f"{got_dtype} {got_dims}")
+
+
+def check_crs(ds: xr.Dataset) -> Check:
+    """A resolvable CRS via rioxarray (CF grid_mapping wired) — WARN if absent."""
+    try:
+        crs = ds["vv"].rio.crs if "vv" in ds else ds.rio.crs
+    except Exception:  # noqa: BLE001 -- rioxarray raises various errors when no CRS is resolvable
+        crs = None
+    if crs is None:
+        return Check(Level.WARN, "grid_mapping wired (.rio.crs)", "no CRS — needs CF grid_mapping")
+    return Check(Level.PASS, "grid_mapping wired (.rio.crs)", str(crs))
+
+
+def check_db_range(
+    name: str, arr_linear: np.ndarray, *, lo_db: float = -40.0, hi_db: float = 10.0
+) -> Check:
+    """p2..p98 of the backscatter in dB should sit within plausible bounds (else WARN)."""
+    a = np.asarray(arr_linear, dtype="float64")
+    a = a[np.isfinite(a) & (a > 0)]
+    if a.size == 0:
+        return Check(Level.WARN, f"{name} dB range", "no positive finite samples")
+    db = 10.0 * np.log10(a)
+    p2, p98 = (float(v) for v in np.percentile(db, [2, 98]))
+    detail = f"p2..p98 = [{p2:.1f}, {p98:.1f}] dB"
+    if p2 < lo_db or p98 > hi_db:
+        return Check(Level.WARN, f"{name} dB range", f"{detail} outside [{lo_db}, {hi_db}]")
+    return Check(Level.PASS, f"{name} dB range", detail)
+
+
+def validate_dataset(ds: xr.Dataset) -> list[Check]:
+    """Run the per-level (r10m) data checks over an opened dataset."""
+    checks = [
+        check_dtype_dims(ds, "vv", "float32"),
+        check_dtype_dims(ds, "vh", "float32"),
+        check_dtype_dims(ds, "border_mask", "uint8"),
+        check_crs(ds),
+    ]
+    for var in ("vv", "vh"):
+        if var in ds:
+            arr = np.asarray(ds[var].values)
+            checks.append(check_finite(var, arr))
+            checks.append(check_db_range(var, arr))
+    return checks
+
+
+# --- store I/O + structural check (integration; exercised in main) ----------
+
+
+def check_structural(root: Any) -> Check:
+    """Validate a store root against the S1RtcRoot model; known x/y/spatial_ref drift → WARN."""
+    try:
+        from eopf_geozarr.data_api.s1_rtc import S1RtcRoot
+        from pydantic import ValidationError
+    except Exception as exc:  # noqa: BLE001  -- optional dep; degrade to WARN
+        return Check(Level.WARN, "Strict schema (S1RtcRoot)", f"unavailable: {exc}")
+    try:
+        S1RtcRoot.from_zarr(root)
+        return Check(Level.PASS, "Strict schema (S1RtcRoot)", "validates")
+    except ValidationError as exc:
+        known = ("x", "y", "spatial_ref")
+        errs = exc.errors()
+        drift = [
+            e for e in errs if e["type"] == "extra_forbidden" and e["loc"] and e["loc"][-1] in known
+        ]
+        real = [e for e in errs if e not in drift]
+        if real:
+            detail = "; ".join("/".join(map(str, e["loc"])) for e in real[:5])
+            return Check(Level.FAIL, "Strict schema (S1RtcRoot)", f"{len(real)} error(s): {detail}")
+        return Check(Level.WARN, "Strict schema (S1RtcRoot)", f"known coord drift ({len(drift)})")
+
+
+def _open_root(store: str) -> Any:
+    import zarr
+
+    if "://" in store:
+        from zarr.storage import FsspecStore
+
+        return zarr.open_group(FsspecStore.from_url(store), mode="r")
+    return zarr.open_group(store, mode="r", zarr_format=3)
+
+
+def _open_level(store: str, orbit: str, res: str) -> xr.Dataset:
+    ds: xr.Dataset = xr.open_zarr(
+        store, group=f"{orbit}/{res}", decode_coords="all", consolidated=True
+    )
+    return ds
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--store", required=True, help="Zarr store URI (local path or https/s3)")
+    ap.add_argument("--orbit", default=None, help="orbit group (default: auto-detect)")
+    ap.add_argument("--res", default="r10m")
+    args = ap.parse_args()
+
+    root = _open_root(args.store)
+    members = list(root)
+    orbit = args.orbit or next((o for o in ("ascending", "descending") if o in members), None)
+    if orbit is None:
+        print(f"[FAIL] orbit group — none of ascending/descending in {members}")
+        sys.exit(int(Level.FAIL))
+
+    checks = [check_structural(root), *validate_dataset(_open_level(args.store, orbit, args.res))]
+
+    worst = overall(checks)
+    for c in checks:
+        print(f"[{c.level.name}] {c.label} — {c.detail}")
+    print(f"OVERALL: {worst.name}  (orbit={orbit}, res={args.res})")
+    sys.exit(int(worst))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -1,0 +1,124 @@
+"""Unit tests for scripts/register_per_acquisition.py — per-acquisition STAC items (plan T5).
+
+One STAC item per cube `time` slice, id `s1-rtc-{tile}-{datetime}`, with `sel=time` viz links
+baked (explorer rendering deferred to #228). Pure builders tested here; store I/O + upsert in main().
+"""
+
+import datetime as dt
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "register_per_acquisition.py"
+
+
+def _mod():
+    sys.path.insert(0, str(SCRIPT.parent))
+    import register_per_acquisition
+
+    return register_per_acquisition
+
+
+def _base_item() -> dict:
+    """A per-tile base item (as build_s1_rtc_stac_item would emit) to clone per acquisition."""
+    return {
+        "type": "Feature",
+        "stac_version": "1.0.0",
+        "id": "s1-rtc-31TCH",
+        "collection": "sentinel-1-grd-rtc-staging",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[0, 42], [2, 42], [2, 43], [0, 43], [0, 42]]],
+        },
+        "bbox": [0, 42, 2, 43],
+        "properties": {
+            "start_datetime": "2026-06-05T06:09:07Z",
+            "end_datetime": "2026-06-07T05:52:48Z",
+            "sar:product_type": "GRD",
+            "proj:code": "EPSG:32631",
+        },
+        "assets": {
+            "vh": {"href": "https://gw/.../s1-rtc-31TCH.zarr/descending", "roles": ["data"]},
+            "zarr-store": {"href": "https://gw/.../s1-rtc-31TCH.zarr", "roles": ["data"]},
+        },
+        "links": [],
+    }
+
+
+# two acquisitions on the cube's time axis (ns since epoch)
+_T0 = int(dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC).timestamp() * 1e9)
+_T1 = int(dt.datetime(2026, 6, 7, 5, 52, 48, tzinfo=dt.UTC).timestamp() * 1e9)
+RASTER = "https://api.explorer.eopf.copernicus.eu/raster"
+ACQ = "sentinel-1-grd-rtc-acquisitions"
+
+
+# --- acquisition_id ----------------------------------------------------------
+
+
+def test_acquisition_id_format():
+    m = _mod()
+    when = dt.datetime(2026, 6, 7, 5, 52, 48, tzinfo=dt.UTC)
+    assert m.acquisition_id("31TCH", when) == "s1-rtc-31TCH-20260607t055248"
+
+
+# --- sel_time_tilejson -------------------------------------------------------
+
+
+def test_sel_time_tilejson_carries_sel_and_item():
+    m = _mod()
+    when = dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC)
+    url = m.sel_time_tilejson(RASTER, ACQ, "s1-rtc-31TCH-20260605t060907", when, "descending")
+    assert ACQ in url and "s1-rtc-31TCH-20260605t060907" in url
+    assert "sel=" in url and "time%3Dnearest" in url  # url-encoded "time=nearest"
+    assert "tilejson.json" in url
+
+
+# --- per_acquisition_items ---------------------------------------------------
+
+
+def test_per_acquisition_items_one_per_time():
+    m = _mod()
+    items = m.per_acquisition_items(
+        _base_item(),
+        [_T0, _T1],
+        tile_id="31TCH",
+        orbit="descending",
+        collection=ACQ,
+        raster_api=RASTER,
+    )
+    assert [i["id"] for i in items] == [
+        "s1-rtc-31TCH-20260605t060907",
+        "s1-rtc-31TCH-20260607t055248",
+    ]
+
+
+def test_per_acquisition_items_single_datetime_no_range():
+    m = _mod()
+    items = m.per_acquisition_items(
+        _base_item(), [_T0], tile_id="31TCH", orbit="descending", collection=ACQ, raster_api=RASTER
+    )
+    props = items[0]["properties"]
+    assert props["datetime"] == "2026-06-05T06:09:07+00:00"
+    assert "start_datetime" not in props and "end_datetime" not in props
+    assert props["sar:product_type"] == "GRD"  # base properties preserved
+
+
+def test_per_acquisition_items_collection_and_sel_link():
+    m = _mod()
+    items = m.per_acquisition_items(
+        _base_item(), [_T0], tile_id="31TCH", orbit="descending", collection=ACQ, raster_api=RASTER
+    )
+    item = items[0]
+    assert item["collection"] == ACQ
+    tilejson = [link for link in item["links"] if link["rel"] == "tilejson"]
+    assert len(tilejson) == 1
+    assert "sel=" in tilejson[0]["href"] and item["id"] in tilejson[0]["href"]
+
+
+def test_per_acquisition_items_does_not_mutate_base():
+    m = _mod()
+    base = _base_item()
+    m.per_acquisition_items(
+        base, [_T0, _T1], tile_id="31TCH", orbit="descending", collection=ACQ, raster_api=RASTER
+    )
+    assert base["id"] == "s1-rtc-31TCH"  # base untouched
+    assert "start_datetime" in base["properties"]

--- a/tests/unit/test_validate_s1_rtc.py
+++ b/tests/unit/test_validate_s1_rtc.py
@@ -145,3 +145,27 @@ def test_validate_dataset_corrupt_fails():
     m = _mod()
     bad = _r10m(vv=np.full((1, 4, 4), np.nan, dtype="float32"), with_crs=False)  # all-NaN vv
     assert m.overall(m.validate_dataset(bad)) == m.Level.FAIL
+
+
+def test_validate_schema_is_metadata_only():
+    """Schema checks (dtype/dims/crs) don't include the finite/dB data checks."""
+    m = _mod()
+    labels = [c.label for c in m.validate_schema(_r10m())]
+    assert any("dtype/dims" in label for label in labels)
+    assert not any("finite" in label or "dB" in label for label in labels)
+
+
+def test_validate_data_catches_bad_slice():
+    """validate_data on a single corrupt acquisition slice FAILs (the per-time gate path)."""
+    m = _mod()
+    bad = _r10m(vv=np.full((1, 4, 4), np.nan, dtype="float32"))
+    assert m.overall(m.validate_data(bad)) == m.Level.FAIL
+
+
+def test_time_index_picks_nearest():
+    """time_index resolves the nearest acquisition position from the native time coord."""
+    m = _mod()
+    times = np.array(["2026-06-05T06:09:07", "2026-06-07T05:52:48"], dtype="datetime64[ns]")
+    native = xr.Dataset(coords={"time": ("time", times)})
+    assert m.time_index(native, "2026-06-07") == 1
+    assert m.time_index(native, "2026-06-05T06:09:07") == 0

--- a/tests/unit/test_validate_s1_rtc.py
+++ b/tests/unit/test_validate_s1_rtc.py
@@ -1,0 +1,147 @@
+"""Unit tests for scripts/validate_s1_rtc.py — the S1 GRD RTC quality-gate checks.
+
+Mirrors the validate_s1_grd_rtc notebook's checks as pure functions (testable with tiny
+synthetic inputs); the structural S1RtcRoot check + store I/O live in main() (integration).
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "validate_s1_rtc.py"
+
+
+def _mod():
+    sys.path.insert(0, str(SCRIPT.parent))
+    import validate_s1_rtc
+
+    return validate_s1_rtc
+
+
+def _r10m(vv=None, vh=None, *, vv_dtype="float32", with_crs=True, ntime=1, n=4):
+    """Build a minimal r10m-level dataset (vv/vh/border_mask, dims time,y,x)."""
+    shape = (ntime, n, n)
+    vv = np.ones(shape, dtype=vv_dtype) if vv is None else vv.astype(vv_dtype)
+    vh = np.ones(shape, dtype="float32") if vh is None else vh
+    ds = xr.Dataset(
+        {
+            "vv": (("time", "y", "x"), vv),
+            "vh": (("time", "y", "x"), vh.astype("float32")),
+            "border_mask": (("time", "y", "x"), np.ones(shape, dtype="uint8")),
+        },
+        coords={"time": np.arange(ntime), "y": np.arange(n), "x": np.arange(n)},
+    )
+    if with_crs:
+        import rioxarray  # noqa: F401
+
+        ds = ds.rio.write_crs("EPSG:32631")
+    return ds
+
+
+# --- Level / aggregation -----------------------------------------------------
+
+
+def test_level_ordering_and_exit_codes():
+    m = _mod()
+    assert int(m.Level.PASS) == 0
+    assert int(m.Level.WARN) == 1
+    assert int(m.Level.FAIL) == 2
+
+
+def test_overall_is_worst_level():
+    m = _mod()
+    checks = [
+        m.Check(m.Level.PASS, "a", ""),
+        m.Check(m.Level.WARN, "b", ""),
+        m.Check(m.Level.PASS, "c", ""),
+    ]
+    assert m.overall(checks) == m.Level.WARN
+    checks.append(m.Check(m.Level.FAIL, "d", ""))
+    assert m.overall(checks) == m.Level.FAIL
+
+
+def test_overall_empty_is_pass():
+    m = _mod()
+    assert m.overall([]) == m.Level.PASS
+
+
+# --- check_finite ------------------------------------------------------------
+
+
+def test_check_finite_all_finite_passes():
+    m = _mod()
+    assert m.check_finite("vv", np.ones((4, 4), dtype="float32")).level == m.Level.PASS
+
+
+def test_check_finite_mostly_nan_fails():
+    m = _mod()
+    arr = np.full((10, 10), np.nan, dtype="float32")
+    arr[0, :] = 1.0  # 10% finite
+    assert m.check_finite("vv", arr).level == m.Level.FAIL
+
+
+# --- check_dtype_dims --------------------------------------------------------
+
+
+def test_check_dtype_dims_correct_passes():
+    m = _mod()
+    ds = _r10m()
+    assert m.check_dtype_dims(ds, "vv", "float32").level == m.Level.PASS
+
+
+def test_check_dtype_dims_wrong_dtype_fails():
+    m = _mod()
+    ds = _r10m(vv_dtype="float64")
+    assert m.check_dtype_dims(ds, "vv", "float32").level == m.Level.FAIL
+
+
+def test_check_dtype_dims_missing_var_fails():
+    m = _mod()
+    ds = _r10m().drop_vars("vv")
+    assert m.check_dtype_dims(ds, "vv", "float32").level == m.Level.FAIL
+
+
+# --- check_crs ---------------------------------------------------------------
+
+
+def test_check_crs_present_passes():
+    m = _mod()
+    assert m.check_crs(_r10m(with_crs=True)).level == m.Level.PASS
+
+
+def test_check_crs_absent_warns():
+    m = _mod()
+    assert m.check_crs(_r10m(with_crs=False)).level == m.Level.WARN
+
+
+# --- check_db_range ----------------------------------------------------------
+
+
+def test_check_db_range_plausible_passes():
+    m = _mod()
+    # gamma0 ~ 0.05 linear -> ~ -13 dB, well within bounds
+    arr = np.full((20, 20), 0.05, dtype="float32")
+    assert m.check_db_range("vv", arr).level == m.Level.PASS
+
+
+def test_check_db_range_absurd_warns_or_fails():
+    m = _mod()
+    arr = np.full((20, 20), 1e6, dtype="float32")  # ~ +60 dB, absurd
+    assert m.check_db_range("vv", arr).level >= m.Level.WARN
+
+
+# --- validate_dataset (orchestration over a level) ---------------------------
+
+
+def test_validate_dataset_good_all_pass():
+    m = _mod()
+    checks = m.validate_dataset(_r10m(ntime=1, n=8))
+    assert m.overall(checks) == m.Level.PASS, [(c.label, c.detail) for c in checks]
+
+
+def test_validate_dataset_corrupt_fails():
+    m = _mod()
+    bad = _r10m(vv=np.full((1, 4, 4), np.nan, dtype="float32"), with_crs=False)  # all-NaN vv
+    assert m.overall(m.validate_dataset(bad)) == m.Level.FAIL


### PR DESCRIPTION
First two Phase-6 vertical slices (#226), both TDD'd and live-verified. Data-only — **no titiler dependency** (rendering deferred to #228); validation is via these tools + notebooks.

## T1 — `scripts/validate_s1_rtc.py` (quality gate + notebook-validation core)
CLI returning **exit 0=PASS / 1=WARN / 2=FAIL**. Pure check functions (finite fraction, dtype/dims, CRS/grid_mapping, dB range) + structural via `eopf_geozarr.S1RtcRoot`. Gates a **single acquisition** (`--time`, positional `isel` from the native time coord) and runs data checks at a **coarse overview** (`--data-res r60m`) to avoid loading the full r10m cube. **17 unit tests.**
- Live: staging cube → all data checks PASS (EPSG:32631, 100% finite, plausible dB), OVERALL WARN (benign S1RtcRoot coord drift, same as the notebook).

## T5 — `scripts/register_per_acquisition.py`
Emits **one queryable STAC item per cube `time` slice** (`s1-rtc-{tile}-{datetime}`, single datetime) into `sentinel-1-grd-rtc-acquisitions`, cloned from the phase-5 builder with `sel=time` links baked (render later, no data change). **6 unit tests.**
- Live: registered 2 items (2026-06-05, 2026-06-07) from the staging cube.

## Verification
Full unit suite **365 passed**; ruff + mypy clean. Both verified live against staging.

Base `feat--s1_grd_phase5` (stacked; reuses phase-5 builder/data-api). Remaining T-tasks (ensure-dem, cube append, trigger, multi-tile, backfill, soak) and the Argo wiring of T1/T5 are tracked in the plan (PR #224) / #226. Also remaining: confirm/extend `validate_s1_grd_rtc` for a *multi-time* cube (T5 acceptance, plan P-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
