### PR TITLE
feat(s1-phase6): ensure_dem.py — auto-fetch GLO-30 DEM per tile swath (T3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,5 +178,5 @@ module = "notebooks.*"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = ["boto3.*", "botocore.*", "mgrs.*"]
+module = ["boto3.*", "botocore.*", "mgrs.*", "eotile.*"]
 ignore_missing_imports = true

--- a/scripts/ensure_dem.py
+++ b/scripts/ensure_dem.py
@@ -1,0 +1,171 @@
+"""Auto-provision the Copernicus GLO-30 DEM for an MGRS tile's S1 swath (plan T3).
+
+s1tiling needs, per tile, the DEM cells covering the **whole SAR swath** (not just the tile —
+phase-5 showed 31TCH's swath reaching N44/W002), plus the static `eotile` `DEM_Union.gpkg` index
+that maps cell geometries to a `Product10` filename stem. This derives the integer GLO-30 cells for
+the tile's swath bbox (lon±4°/lat±1.5° margin), keeps only the land cells the gpkg knows about
+(ocean cells simply don't exist in GLO-30), skips cells already on disk, and downloads the rest from
+the public anon `copernicus-dem-30m` bucket — renaming each COG to the `Product10` stem s1tiling
+matches. Idempotent: a re-run with the tiles present fetches nothing.
+
+Usage:
+    uv run python scripts/ensure_dem.py --tile-id 31TCH \
+      --dem-dir $WORKDIR/DEM/COP_DEM_GLO30 --gpkg $WORKDIR/DEM/dem_db/DEM_Union.gpkg
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import shutil
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+DEM_BUCKET = "copernicus-dem-30m"  # AWS Open Data, anonymous
+DEM_REGION = "eu-central-1"
+MARGIN_LON = 4.0  # SAR (IW) swath reaches ~3° E/W of the tile at mid-latitudes
+MARGIN_LAT = 1.5  # ~1.5° N/S (phase-5: 31TCH swath needed N44, tile tops out ~43.3)
+
+
+def product10_stem(lat: int, lon: int) -> str:
+    """s1tiling/`eotile` `Product10` filename stem for an integer 1°×1° cell (its SW corner)."""
+    ns, ew = ("N" if lat >= 0 else "S"), ("E" if lon >= 0 else "W")
+    return f"Copernicus_DSM_10_{ns}{abs(lat):02d}_00_{ew}{abs(lon):03d}_00"
+
+
+def cog_key(lat: int, lon: int) -> str:
+    """Object key in `copernicus-dem-30m` (`<dir>/<dir>.tif`, the COG/`_DEM` naming variant)."""
+    d = f"Copernicus_DSM_COG_10_{'N' if lat >= 0 else 'S'}{abs(lat):02d}_00_"
+    d += f"{'E' if lon >= 0 else 'W'}{abs(lon):03d}_00_DEM"
+    return f"{d}/{d}.tif"
+
+
+def tiles_for_bbox(
+    bbox: list[float], *, margin_lon: float = MARGIN_LON, margin_lat: float = MARGIN_LAT
+) -> list[tuple[int, int]]:
+    """Integer (lat, lon) SW corners of the 1°×1° cells covering ``bbox`` grown by the margin.
+
+    Returns them in ascending (lat, lon) order — deterministic regardless of input.
+    """
+    lon0, lat0, lon1, lat1 = bbox
+    lats = range(math.floor(lat0 - margin_lat), math.floor(lat1 + margin_lat) + 1)
+    lons = range(math.floor(lon0 - margin_lon), math.floor(lon1 + margin_lon) + 1)
+    return [(la, lo) for la in lats for lo in lons]
+
+
+def read_gpkg_product10(gpkg_path: Path) -> set[str]:
+    """Read the set of `Product10` stems from the `eotile` `DEM_Union.gpkg` (stdlib sqlite, no GDAL)."""
+    con = sqlite3.connect(str(gpkg_path))
+    try:
+        tables = [r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+        table = next(
+            (
+                t
+                for t in tables
+                if any(c[1] == "Product10" for c in con.execute(f"PRAGMA table_info({t})"))
+            ),
+            None,
+        )
+        if table is None:
+            raise ValueError(f"no table with a Product10 column in {gpkg_path}")
+        return {r[0] for r in con.execute(f"SELECT Product10 FROM {table}") if r[0]}  # noqa: S608
+    finally:
+        con.close()
+
+
+def tiles_to_fetch(
+    tile_id: str,
+    gpkg_products: set[str],
+    present_stems: set[str],
+    *,
+    margin_lon: float = MARGIN_LON,
+    margin_lat: float = MARGIN_LAT,
+) -> list[tuple[int, int]]:
+    """Cells to download: (swath cells ∩ gpkg land tiles) − tiles already on disk.
+
+    Raises ``ValueError`` for a malformed/unknown tile id (via ``tile_bbox``).
+    """
+    from watch_cdse_and_process import tile_bbox
+
+    bbox = tile_bbox(tile_id)
+    out: list[tuple[int, int]] = []
+    for lat, lon in tiles_for_bbox(bbox, margin_lon=margin_lon, margin_lat=margin_lat):
+        stem = product10_stem(lat, lon)
+        if stem in gpkg_products and stem not in present_stems:
+            out.append((lat, lon))
+    return out
+
+
+# --- gpkg + anon download (integration; exercised in main / on cluster) ------
+
+
+def ensure_gpkg(gpkg_path: Path) -> None:
+    """Stage the static global `DEM_Union.gpkg` from the `eotile` package if it isn't present."""
+    if gpkg_path.exists():
+        return
+    try:
+        import eotile
+    except ImportError as exc:  # eotile is data-only; not a runtime dep of the pure core
+        raise SystemExit(
+            f"{gpkg_path} missing and eotile not installed — `uv pip install eotile --no-deps` "
+            "or stage the gpkg on the PVC"
+        ) from exc
+    src = next(Path(eotile.__file__).parent.rglob("DEM_Union.gpkg"), None)
+    if src is None:
+        raise SystemExit("eotile installed but bundled DEM_Union.gpkg not found")
+    gpkg_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(src, gpkg_path)
+    print(f"staged DEM_Union.gpkg from eotile: {src}")
+
+
+def _anon_s3(region: str) -> Any:
+    import boto3
+    from botocore import UNSIGNED
+    from botocore.config import Config
+
+    return boto3.client("s3", region_name=region, config=Config(signature_version=UNSIGNED))
+
+
+def _download(s3: Any, bucket: str, key: str, dest: Path) -> None:
+    """Download to a temp sibling then rename, so a failure never leaves a partial Product10 .tif."""
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    s3.download_file(bucket, key, str(tmp))
+    tmp.replace(dest)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--tile-id", required=True)
+    ap.add_argument(
+        "--dem-dir", required=True, type=Path, help="COP_DEM_GLO30 dir (Product10 .tif)"
+    )
+    ap.add_argument("--gpkg", required=True, type=Path, help="dem_db/DEM_Union.gpkg (eotile index)")
+    ap.add_argument("--margin-lon", type=float, default=MARGIN_LON)
+    ap.add_argument("--margin-lat", type=float, default=MARGIN_LAT)
+    ap.add_argument("--bucket", default=DEM_BUCKET)
+    ap.add_argument("--region", default=DEM_REGION)
+    args = ap.parse_args()
+
+    ensure_gpkg(args.gpkg)
+    products = read_gpkg_product10(args.gpkg)
+    args.dem_dir.mkdir(parents=True, exist_ok=True)
+    present = {p.stem for p in args.dem_dir.glob("Copernicus_DSM_10_*.tif")}
+    fetch = tiles_to_fetch(
+        args.tile_id, products, present, margin_lon=args.margin_lon, margin_lat=args.margin_lat
+    )
+    if not fetch:
+        print(f"DEM already complete for {args.tile_id}: {len(present)} tile(s) present")
+        return
+    s3 = _anon_s3(args.region)
+    for lat, lon in fetch:
+        dest = args.dem_dir / f"{product10_stem(lat, lon)}.tif"
+        _download(s3, args.bucket, cog_key(lat, lon), dest)
+        print(f"fetched {dest.name}")
+    print(
+        f"ensured DEM for {args.tile_id}: +{len(fetch)} tile(s) ({len(present) + len(fetch)} total)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_ensure_dem.py
+++ b/tests/unit/test_ensure_dem.py
@@ -1,0 +1,121 @@
+"""Unit tests for scripts/ensure_dem.py — Copernicus GLO-30 DEM auto-fetch (plan T3).
+
+Covers the pure derivation core: tile → swath bbox → integer GLO-30 cells → `Product10` stems /
+public-bucket COG keys, plus the idempotent + ocean-skip fetch list (candidates ∩ gpkg − present).
+The anon-S3 download + COG→Product10 rename + eotile gpkg copy live in main() (integration; cluster).
+
+Naming + the 31TCH expectations below are ground-truthed against the real `eotile` `DEM_Union.gpkg`:
+a lon±4°/lat±1.5° swath margin around 31TCH yields 50 integer cells, of which 41 are real land
+tiles (incl. N44W001/N44W002, observed needed in phase-5) and 9 are absent ocean cells.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "ensure_dem.py"
+
+
+def _mod():
+    sys.path.insert(0, str(SCRIPT.parent))
+    import ensure_dem
+
+    return ensure_dem
+
+
+# --- product10_stem / cog_key (naming) --------------------------------------
+
+
+def test_product10_stem_north_east():
+    m = _mod()
+    assert m.product10_stem(42, 1) == "Copernicus_DSM_10_N42_00_E001_00"
+
+
+def test_product10_stem_north_west_zero_pads():
+    m = _mod()
+    assert m.product10_stem(44, -1) == "Copernicus_DSM_10_N44_00_W001_00"
+    assert m.product10_stem(9, 0) == "Copernicus_DSM_10_N09_00_E000_00"
+
+
+def test_product10_stem_southern_hemisphere():
+    m = _mod()
+    assert m.product10_stem(-34, -59) == "Copernicus_DSM_10_S34_00_W059_00"
+
+
+def test_cog_key_matches_public_bucket_layout():
+    """Public `copernicus-dem-30m` stores each tile as <dir>/<dir>.tif with the COG/_DEM variant."""
+    m = _mod()
+    key = m.cog_key(44, -1)
+    assert key == (
+        "Copernicus_DSM_COG_10_N44_00_W001_00_DEM/Copernicus_DSM_COG_10_N44_00_W001_00_DEM.tif"
+    )
+
+
+# --- tiles_for_bbox (swath margin → integer cells) ---------------------------
+
+
+def test_tiles_for_bbox_covers_margin_and_observed_needed_cells():
+    m = _mod()
+    bbox = [0.533, 42.427, 1.784, 43.346]  # 31TCH
+    cells = m.tiles_for_bbox(bbox)  # default margin lon±4, lat±1.5
+    assert len(cells) == 50  # lon -4..5 (10) × lat 40..44 (5)
+    assert (44, -1) in cells and (44, -2) in cells  # phase-5: swath needed these
+    assert (40, -4) in cells and (44, 5) in cells  # corners
+    assert cells == sorted(cells)  # deterministic order
+
+
+def test_tiles_for_bbox_margin_is_configurable():
+    m = _mod()
+    cells = m.tiles_for_bbox([0.5, 42.4, 0.6, 42.6], margin_lon=0.0, margin_lat=0.0)
+    assert cells == [(42, 0)]  # single cell, no margin
+
+
+# --- read_gpkg_product10 (sqlite, no GDAL) -----------------------------------
+
+
+def test_read_gpkg_product10_reads_the_product10_column(tmp_path):
+    m = _mod()
+    gpkg = tmp_path / "DEM_Union.gpkg"
+    con = sqlite3.connect(gpkg)
+    con.execute("CREATE TABLE dem (id INTEGER, Product10 TEXT)")
+    con.executemany(
+        "INSERT INTO dem VALUES (?, ?)",
+        [(1, "Copernicus_DSM_10_N42_00_E001_00"), (2, "Copernicus_DSM_10_N44_00_W001_00")],
+    )
+    con.commit()
+    con.close()
+    prods = m.read_gpkg_product10(gpkg)
+    assert prods == {
+        "Copernicus_DSM_10_N42_00_E001_00",
+        "Copernicus_DSM_10_N44_00_W001_00",
+    }
+
+
+# --- tiles_to_fetch (idempotent + ocean-skip orchestration) ------------------
+
+
+def test_tiles_to_fetch_skips_ocean_and_already_present():
+    """Fetch list = (swath cells ∩ gpkg land tiles) − tiles already on disk."""
+    m = _mod()
+    s = m.product10_stem
+    gpkg_products = {s(42, 1), s(43, 1), s(44, -1)}  # land tiles known to the gpkg
+    present = {s(42, 1)}  # already downloaded
+    fetch = m.tiles_to_fetch("31TCH", gpkg_products, present)
+    # (42,1) present → skipped; everything not in gpkg (ocean / nonexistent) → skipped
+    assert fetch == [(43, 1), (44, -1)]
+
+
+def test_tiles_to_fetch_idempotent_when_all_present():
+    m = _mod()
+    s = m.product10_stem
+    gpkg_products = {s(42, 1), s(43, 1)}
+    present = {s(42, 1), s(43, 1)}
+    assert m.tiles_to_fetch("31TCH", gpkg_products, present) == []
+
+
+def test_tiles_to_fetch_rejects_malformed_tile():
+    m = _mod()
+    import pytest
+
+    with pytest.raises(ValueError):
+        m.tiles_to_fetch("not-a-tile", set(), set())


### PR DESCRIPTION
Plan T3 (`claude-docs/plans/s1_grd_phase6_productionization.md`), tracker #226. Auto-provisions the Copernicus GLO-30 DEM for any MGRS tile so a new tile no longer needs a manual DEM upload — the gate that unblocks running the chain on a different tile (CP-A).

## What
`scripts/ensure_dem.py`:
- **Pure core (unit-tested):** tile → swath bbox (lon±4°/lat±1.5° margin) → integer GLO-30 cells → `Product10` stems / public-bucket COG keys; fetch list = (swath cells ∩ gpkg land tiles) − tiles already on disk (idempotent; ocean cells absent from GLO-30 are skipped).
- **main() (cluster-exercised):** stage the static `eotile` `DEM_Union.gpkg` if absent, anon-download missing COGs from `copernicus-dem-30m`, rename COG→Product10.

## Verification
- `uv run pytest tests/unit/test_ensure_dem.py` — 10 tests.
- Convention **ground-truthed against the real `eotile` gpkg**: 31TCH → 50 candidate cells, **41 land** (incl. `N44W001`/`N44W002`, the cells phase-5 saw the swath need), 9 ocean — matching the ≥31-tile 31TCH PVC.
- Anon **HEAD** on `copernicus-dem-30m` confirmed key/region resolve a real object (42.6 MB tiff).
- Resolves OQ #4 (script-side): direct anon HTTPS + static eotile gpkg (no eodag) + configurable margin + skip-existing.

## Out of scope (cluster / platform-deploy)
The Argo `ensure-dem` step writing the `s1-dem` PVC, the PVC cache layout, and a live new-tile provision run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)