### PR TITLE
feat(s1-phase6): append scenes to the per-tile cube, idempotently (T4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,5 +178,5 @@ module = "notebooks.*"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = ["boto3.*", "botocore.*", "mgrs.*"]
+module = ["boto3.*", "botocore.*", "mgrs.*", "s3fs.*"]
 ignore_missing_imports = true

--- a/scripts/ingest_v1_s1_rtc.py
+++ b/scripts/ingest_v1_s1_rtc.py
@@ -14,8 +14,10 @@ import os
 import shutil
 import sys
 import tempfile
+from pathlib import Path
 from typing import Any
 
+import numpy as np
 import zarr
 from eopf_geozarr.conversion.s1_ingest import (
     consolidate_s1_store,
@@ -78,10 +80,46 @@ def _patch_cf_grid_mapping(store_path: str, orbit_direction: str) -> list[str]:
     return patched
 
 
-def ingest_all(s3_geotiff_prefix: str, store_path: str, orbit_direction: str) -> int:
-    """Run the 5-step S1 ingest pipeline.
+def acq_time_ns(acq_stamp: str) -> int:
+    """ns-since-epoch for an S1Tiling ``acq_stamp`` (``YYYYMMDDtHHMMSS``).
 
-    Returns exit code: 0 = success, 1 = ingest error, 2 = no acquisitions.
+    Matches how the cube stores ``time``: ``eopf_geozarr`` writes
+    ``np.datetime64(<ACQUISITION_DATETIME tag>)`` — the same instant the stamp encodes — so this is
+    the idempotency key for "is this acquisition already a slice in the cube?".
+    """
+    s = acq_stamp
+    iso = f"{s[0:4]}-{s[4:6]}-{s[6:8]}T{s[9:11]}:{s[11:13]}:{s[13:15]}"
+    return int(np.datetime64(iso).astype("datetime64[ns]").astype("int64"))
+
+
+def store_times_ns(store_path: str, orbit_direction: str) -> set[int]:
+    """`time` values (ns) already present in the cube's r10m level; empty if the store, the orbit
+    group, or its r10m/time are absent (a fresh tile has none)."""
+    if not Path(store_path).exists():
+        return set()
+    root = zarr.open_group(str(store_path), mode="r", zarr_format=3)
+    if orbit_direction not in root:
+        return set()
+    orbit: Any = root[orbit_direction]
+    if "r10m" not in orbit or "time" not in orbit["r10m"]:
+        return set()
+    times = np.asarray(orbit["r10m"]["time"]).astype("datetime64[ns]").astype("int64")
+    return {int(t) for t in times}
+
+
+def new_acquisitions(acquisitions: list[dict], present_ns: set[int]) -> list[dict]:
+    """Acquisitions whose ``time`` is not already a slice in the cube (idempotent re-ingest)."""
+    return [a for a in acquisitions if acq_time_ns(a["acq_stamp"]) not in present_ns]
+
+
+def ingest_all(s3_geotiff_prefix: str, store_path: str, orbit_direction: str) -> int:
+    """Run the 5-step S1 ingest pipeline, appending new acquisitions to the per-tile cube.
+
+    Each new acquisition is appended as a ``time`` slice (``ingest_s1tiling_acquisition`` opens the
+    store ``mode=r+``); acquisitions whose ``time`` is already in the cube are skipped, so a re-run
+    is a no-op (T4 idempotency).
+
+    Returns exit code: 0 = success (or nothing new to ingest), 1 = ingest error, 2 = no acquisitions.
     """
     # Step 1 -- discover acquisitions
     acquisitions = discover_s1tiling_acquisitions(s3_geotiff_prefix)
@@ -89,8 +127,21 @@ def ingest_all(s3_geotiff_prefix: str, store_path: str, orbit_direction: str) ->
         log.warning("No acquisitions found in %s", s3_geotiff_prefix)
         return 2
 
-    # Step 2 -- ingest each acquisition (abort on first error)
-    for acq in acquisitions:
+    # Step 1b -- drop acquisitions already present in the cube (idempotent append)
+    present = store_times_ns(store_path, orbit_direction)
+    acquisitions_to_ingest = new_acquisitions(acquisitions, present)
+    skipped = len(acquisitions) - len(acquisitions_to_ingest)
+    if skipped:
+        log.info("Skipping %d acquisition(s) already present in the cube", skipped)
+    if not acquisitions_to_ingest:
+        log.info(
+            "All %d discovered acquisition(s) already in the cube; nothing to ingest",
+            len(acquisitions),
+        )
+        return 0
+
+    # Step 2 -- ingest each new acquisition (abort on first error)
+    for acq in acquisitions_to_ingest:
         try:
             ingest_s1tiling_acquisition(
                 vv_path=acq["vv"],
@@ -166,12 +217,41 @@ def _put_tree(fs: Any, local_store: str, dest: str) -> None:
             fs.put_file(lpath, rpath)
 
 
+def _get_tree(fs: Any, src: str, local_store: str) -> None:
+    """Download every object under ``src`` to ``local_store/<relpath>`` (mirror of ``_put_tree``)."""
+    for key in fs.find(src):
+        rel = key[len(src) :].lstrip("/")
+        lpath = os.path.join(local_store, rel.replace("/", os.sep))
+        os.makedirs(os.path.dirname(lpath), exist_ok=True)
+        fs.get_file(key, lpath)
+
+
+def _fetch_store_from_s3(s3_uri: str, local_store: str) -> None:
+    """Download an existing cube from S3 into ``local_store`` so new scenes **append** to it.
+
+    No-op if the destination cube doesn't exist yet (the first acquisition for a tile). This is what
+    turns the pipeline from "fresh store per run" into a per-tile datacube that accumulates over runs
+    (T4); concurrent same-tile writes are serialised by the Argo per-tile mutex.
+    """
+    import s3fs
+
+    endpoint = os.environ.get("AWS_ENDPOINT_URL")
+    fs = s3fs.S3FileSystem(client_kwargs={"endpoint_url": endpoint} if endpoint else None)
+    src = s3_uri[len("s3://") :].rstrip("/")
+    if not fs.exists(src):
+        return
+    log.info("Fetching existing cube %s -> %s (append mode)", s3_uri, local_store)
+    _get_tree(fs, src, local_store)
+
+
 def _upload_store_to_s3(local_store: str, s3_uri: str) -> None:
     """Upload a local Zarr store directory to an ``s3://`` URI via s3fs.
 
     The endpoint is taken from ``AWS_ENDPOINT_URL`` (OVH S3 is not AWS-default);
     credentials come from the ambient ``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY``.
-    Any existing store at the destination is removed first so re-runs are clean.
+    The destination is removed first, then re-uploaded; for an appended cube the local store is the
+    full superset (existing slices fetched by ``_fetch_store_from_s3`` + the new one), so this writes
+    the accumulated cube, not a fresh single-acquisition store.
     """
     import s3fs
 
@@ -187,8 +267,9 @@ def run_ingest(s3_geotiff_prefix: str, store: str, orbit_direction: str) -> int:
     """Ingest into ``store``, handling ``s3://`` destinations.
 
     eopf_geozarr writes the store via ``pathlib.Path``, which collapses ``s3://``
-    to a local path. So for an ``s3://`` destination we ingest into a local temp
-    store and upload the result with s3fs. Local destinations pass straight through.
+    to a local path. So for an ``s3://`` destination we fetch any existing cube into a local temp
+    store, append the new acquisition(s), and upload the result with s3fs. Local destinations pass
+    straight through.
     """
     if not store.startswith("s3://"):
         return ingest_all(s3_geotiff_prefix, store, orbit_direction)
@@ -196,6 +277,7 @@ def run_ingest(s3_geotiff_prefix: str, store: str, orbit_direction: str) -> int:
     tmp_dir = tempfile.mkdtemp(prefix="s1-ingest-")
     local_store = os.path.join(tmp_dir, os.path.basename(store.rstrip("/")))
     try:
+        _fetch_store_from_s3(store, local_store)  # append to the existing per-tile cube (T4)
         rc = ingest_all(s3_geotiff_prefix, local_store, orbit_direction)
         if rc != 0:
             return rc

--- a/tests/unit/test_ingest_v1_s1_rtc.py
+++ b/tests/unit/test_ingest_v1_s1_rtc.py
@@ -14,8 +14,11 @@ sys.path.insert(0, str(scripts_dir))
 from ingest_v1_s1_rtc import (  # noqa: E402
     _patch_cf_grid_mapping,
     _put_tree,
+    acq_time_ns,
     ingest_all,
+    new_acquisitions,
     run_ingest,
+    store_times_ns,
 )
 
 # ---------------------------------------------------------------------------
@@ -208,6 +211,7 @@ def test_run_ingest_s3_uploads_on_success() -> None:
     """An s3:// store ingests into a local temp store, then uploads it to S3."""
     s3_store = "s3://out-bucket/sentinel-1-grd-rtc-staging/s1-grd-rtc-31TCH.zarr"
     with (
+        patch(f"{_MOD}._fetch_store_from_s3") as mock_fetch,
         patch(f"{_MOD}.ingest_all", return_value=0) as mock_ingest,
         patch(f"{_MOD}._upload_store_to_s3") as mock_upload,
     ):
@@ -217,6 +221,9 @@ def test_run_ingest_s3_uploads_on_success() -> None:
     local_store = mock_ingest.call_args.args[1]
     assert local_store.endswith("s1-grd-rtc-31TCH.zarr")
     assert not local_store.startswith("s3://")
+    # the existing cube is fetched into the temp store BEFORE ingest, so a new
+    # acquisition appends instead of replacing (cross-run cube accumulation, T4)
+    mock_fetch.assert_called_once_with(s3_store, local_store)
     mock_upload.assert_called_once_with(local_store, s3_store)
 
 
@@ -225,6 +232,7 @@ def test_run_ingest_s3_skips_upload_on_failure() -> None:
     s3_store = "s3://out-bucket/coll/s1-grd-rtc-31TCH.zarr"
     for code in (1, 2):
         with (
+            patch(f"{_MOD}._fetch_store_from_s3"),
             patch(f"{_MOD}.ingest_all", return_value=code),
             patch(f"{_MOD}._upload_store_to_s3") as mock_upload,
         ):
@@ -251,3 +259,92 @@ def test_put_tree_lands_at_dest_without_nesting(tmp_path) -> None:
     assert (dest_root / "descending" / "r10m" / "c" / "0.0").is_file()
     # the basename must NOT be nested a second time under dest
     assert not (dest_root / "s1-grd-rtc-31TCH.zarr").exists()
+
+
+# ---------------------------------------------------------------------------
+# T4 -- datacube append + idempotency (skip a `time` already in the cube)
+# ---------------------------------------------------------------------------
+
+
+def _store_with_times(store_path: str, times_ns: list[int], orbit: str = "descending") -> None:
+    """Minimal cube whose r10m level carries the given `time` values (ns since epoch)."""
+    import numpy as np
+
+    root = zarr.open_group(store_path, mode="w-", zarr_format=3)
+    r10m = root.create_group(orbit).create_group("r10m")
+    t = r10m.create_array("time", shape=(len(times_ns),), dtype="int64", dimension_names=("time",))
+    t[...] = np.asarray(times_ns, dtype="int64")
+
+
+def test_acq_time_ns_matches_cube_datetime_encoding() -> None:
+    """`acq_stamp` -> ns equals how the cube stores `time` (np.datetime64 of the ISO datetime)."""
+    import numpy as np
+
+    # acq_stamp 'YYYYMMDDtHHMMSS' is the same instant the GeoTIFF ACQUISITION_DATETIME tag carries
+    expected = int(np.datetime64("2023-01-15T06:12:34").astype("datetime64[ns]").astype("int64"))
+    assert acq_time_ns("20230115t061234") == expected
+
+
+def test_store_times_ns_reads_existing_and_handles_absent(tmp_path) -> None:
+    t0 = acq_time_ns("20230115t061234")
+    t1 = acq_time_ns("20230127t061230")
+    store = str(tmp_path / "cube.zarr")
+    _store_with_times(store, [t0, t1])
+    assert store_times_ns(store, "descending") == {t0, t1}
+    # absent store / absent orbit group -> empty (no crash)
+    assert store_times_ns(str(tmp_path / "missing.zarr"), "descending") == set()
+    assert store_times_ns(store, "ascending") == set()
+
+
+def test_new_acquisitions_filters_present_times() -> None:
+    a0 = {**_ACQ, "acq_stamp": "20230115t061234"}
+    a1 = {**_ACQ, "acq_stamp": "20230127t061230"}
+    present = {acq_time_ns("20230115t061234")}
+    assert new_acquisitions([a0, a1], present) == [a1]  # a0 already in cube -> dropped
+
+
+def test_ingest_all_skips_acquisition_already_in_cube(tmp_path) -> None:
+    """Re-ingesting an acquisition whose `time` is already present is a no-op (exit 0, no ingest)."""
+    store = str(tmp_path / "cube.zarr")
+    _store_with_times(store, [acq_time_ns(_ACQ["acq_stamp"])])  # _ACQ already present
+    with (
+        patch(f"{_MOD}.discover_s1tiling_acquisitions", return_value=[_ACQ]),
+        patch(f"{_MOD}.ingest_s1tiling_acquisition") as mock_ing,
+        patch(f"{_MOD}.discover_s1tiling_conditions", return_value=[]),
+        patch(f"{_MOD}.consolidate_s1_store") as mock_cons,
+        patch(f"{_MOD}._patch_cf_grid_mapping"),
+    ):
+        rc = ingest_all("/input", store, "descending")
+    assert rc == 0
+    mock_ing.assert_not_called()  # nothing to append
+    mock_cons.assert_not_called()  # no write, no consolidation
+
+
+def test_ingest_all_appends_only_new_acquisition(tmp_path) -> None:
+    """A 2nd, distinct acquisition appends (ingest called once for the new time only)."""
+    store = str(tmp_path / "cube.zarr")
+    _store_with_times(store, [acq_time_ns("20230115t061234")])  # one existing time
+    present_acq = {**_ACQ, "acq_stamp": "20230115t061234"}
+    new_acq = {**_ACQ, "acq_stamp": "20230127t061230"}
+    with (
+        patch(f"{_MOD}.discover_s1tiling_acquisitions", return_value=[present_acq, new_acq]),
+        patch(f"{_MOD}.ingest_s1tiling_acquisition", return_value=1) as mock_ing,
+        patch(f"{_MOD}.discover_s1tiling_conditions", return_value=[]),
+        patch(f"{_MOD}.consolidate_s1_store"),
+        patch(f"{_MOD}._patch_cf_grid_mapping"),
+    ):
+        rc = ingest_all("/input", store, "descending")
+    assert rc == 0
+    mock_ing.assert_called_once()  # only the new acquisition is appended
+    assert mock_ing.call_args.kwargs["vh_path"] == new_acq["vh"]
+
+
+def test_run_ingest_local_does_not_fetch(tmp_path) -> None:
+    """The cross-run fetch is an S3-only concern; a local destination never fetches."""
+    local_store = str(tmp_path / "cube.zarr")
+    with (
+        patch(f"{_MOD}._fetch_store_from_s3") as mock_fetch,
+        patch(f"{_MOD}.ingest_all", return_value=0),
+    ):
+        run_ingest("/input", local_store, "descending")
+    mock_fetch.assert_not_called()


### PR DESCRIPTION
Plan T4 (`claude-docs/plans/s1_grd_phase6_productionization.md`), tracker #226. Turns ingest from "fresh store per run" into a per-tile **datacube** that accumulates acquisitions on the `time` axis — the multi-time half of CP-A.

## What
`scripts/ingest_v1_s1_rtc.py`:
- `acq_time_ns` / `store_times_ns` / `new_acquisitions` — derive an acquisition's `time` (ns) from its `acq_stamp` the **same way `eopf_geozarr` encodes the cube's `time`** (the idempotency key), read the cube's existing times, and drop acquisitions already present.
- `ingest_all` — skip already-present times so a re-run is a no-op; append only new scenes (`ingest_s1tiling_acquisition` already opens `mode=r+`).
- `run_ingest` (`s3://`) — `_fetch_store_from_s3` pulls the existing cube into the temp store **before** ingest so new scenes append rather than replace; upload then writes the accumulated superset.

## Verification
- `uv run pytest tests/unit/test_ingest_v1_s1_rtc.py` — 16 tests (6 new): idempotent skip (no ingest, no consolidation), append-only-new, `acq_stamp`→ns matches the cube's encoding, and the s3 fetch-before-ingest routing. Existing s3 tests updated to mock the new fetch step.

## Out of scope (cluster / platform-deploy)
The per-tile write **mutex** (Argo `synchronization` — concurrent-write serialisation) and a real multi-time S3 cube opened with `xr.open_dataset`. Note: cross-run append currently does download-existing → append → upload-superset (correct + mutex-safe); region-write-only is a possible perf follow-up requiring upstream support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)