### PR TITLE
feat(s1-phase6): platform_list param + s1tiling success contract (T2)

### DIFF
--- a/scripts/run_s1tiling.py
+++ b/scripts/run_s1tiling.py
@@ -47,12 +47,19 @@ def _safe_clean(target: Path, data_dir: Path, dry_run: bool) -> None:
 
 
 def _render_cfg(
-    src: Path, dst: Path, tile_id: str, orbit_direction: str, date_start: str, date_end: str
+    src: Path,
+    dst: Path,
+    tile_id: str,
+    orbit_direction: str,
+    date_start: str,
+    date_end: str,
+    platform_list: str,
 ) -> None:
     """Render a per-run S1Tiling cfg from the committed base, patching only the run-specific keys.
 
     Mirrors the Argo eopf-explorer-s1tiling template: without this, S1Processor would use the
-    base cfg's static first_date/last_date and ignore the requested window.
+    base cfg's static first_date/last_date and ignore the requested window. ``platform_list``
+    (e.g. ``S1A S1C``) is rendered too so the enabled platforms aren't hardcoded in the base cfg.
     """
     oc = "DES" if orbit_direction == "descending" else "ASC"
     subs = {
@@ -61,6 +68,7 @@ def _render_cfg(
         "orbit_direction": oc,
         "first_date": date_start,
         "last_date": date_end,
+        "platform_list": platform_list,
     }
     text = src.read_text()
     for key, val in subs.items():
@@ -68,12 +76,37 @@ def _render_cfg(
     dst.write_text(text)
 
 
-def _run(cmd: list[str], dry_run: bool) -> None:
+_GAMMA_PLATFORM_RE = re.compile(r"^(s1[abc])_", re.IGNORECASE)  # platform prefix of an output tif
+
+
+def _requested_platform_outputs_present(tile_out_dir: Path, platforms: list[str]) -> bool:
+    """True if ``data_out/{tile}`` holds a GammaNaughtRTC GeoTIFF for a requested platform.
+
+    s1tiling downloads *every* platform in the window and exits non-zero if an off-platform
+    download (e.g. S1D) fails, even when the requested platform produced output. The run is a
+    success when the requested platform's GeoTIFFs are present, regardless of that exit code.
+    """
+    if not tile_out_dir.is_dir():
+        return False
+    wanted = {p.lower() for p in platforms}
+    for tif in tile_out_dir.glob("*GammaNaughtRTC.tif"):
+        m = _GAMMA_PLATFORM_RE.match(tif.name)
+        if m and m.group(1).lower() in wanted:
+            return True
+    return False
+
+
+def _run(cmd: list[str], dry_run: bool, *, check: bool = True) -> int:
+    """Print and run ``cmd``; return its exit code. With ``check`` (default), a non-zero exit aborts
+    the script (used for the aws steps). Pass ``check=False`` to inspect the code instead — the
+    s1tiling step does this to apply its own success contract."""
     print(" \\\n  ".join(str(c) for c in cmd))
-    if not dry_run:
-        result = subprocess.run(cmd)  # noqa: S603
-        if result.returncode != 0:
-            sys.exit(result.returncode)
+    if dry_run:
+        return 0
+    result = subprocess.run(cmd)  # noqa: S603
+    if check and result.returncode != 0:
+        sys.exit(result.returncode)
+    return result.returncode
 
 
 def main() -> None:
@@ -89,6 +122,11 @@ def main() -> None:
     ap.add_argument("--dem-dir", required=True, type=Path)
     ap.add_argument("--data-dir", required=True, type=Path)
     ap.add_argument("--cfg", required=True, type=Path)
+    ap.add_argument(
+        "--platform-list",
+        default="S1A S1C",
+        help="space-separated S1Tiling platform_list (default: S1A S1C; S1D unsupported)",
+    )
     ap.add_argument(
         "--keep-output",
         action="store_true",
@@ -127,7 +165,13 @@ def main() -> None:
     workdir_cfg = data_dir / "config" / "S1GRD_RTC.cfg"
     workdir_cfg.parent.mkdir(parents=True, exist_ok=True)
     _render_cfg(
-        abs_cfg, workdir_cfg, args.tile_id, args.orbit_direction, args.date_start, args.date_end
+        abs_cfg,
+        workdir_cfg,
+        args.tile_id,
+        args.orbit_direction,
+        args.date_start,
+        args.date_end,
+        args.platform_list,
     )
 
     # Step 1b: clean prior-run outputs so only this window's products get synced. The prototype
@@ -142,8 +186,11 @@ def main() -> None:
     if args.prune_raw:
         _safe_clean(data_dir / "data_raw", data_dir, args.dry_run)
 
-    # Step 2: docker run
-    _run(
+    # Step 2: docker run. Apply the success contract: S1Processor downloads every platform in the
+    # window and exits non-zero if an off-platform (e.g. S1D) download fails, even when the requested
+    # platform produced output. So we don't fail the run on a non-zero exit alone — only if the
+    # requested-platform GeoTIFFs are absent from data_out/{tile}.
+    rc = _run(
         [
             "docker",
             "run",
@@ -169,7 +216,17 @@ def main() -> None:
             "python3 /patch/s1tiling_eodag4_patch.py && S1Processor /data/config/S1GRD_RTC.cfg",
         ],
         args.dry_run,
+        check=False,
     )
+    if rc:
+        tile_out = data_dir / "data_out" / args.tile_id
+        if _requested_platform_outputs_present(tile_out, args.platform_list.split()):
+            print(
+                f"WARN: S1Processor exited {rc}, but requested-platform output is present in "
+                f"{tile_out}; continuing (off-platform download failures tolerated)"
+            )
+        else:
+            sys.exit(rc)
 
     # Step 3: purge the destination prefix, then sync GeoTIFFs + GAMMA_AREA into it. Purging first
     # makes the sync authoritative (a re-run of the same window self-heals); --delete is unusable

--- a/tests/unit/test_run_s1tiling.py
+++ b/tests/unit/test_run_s1tiling.py
@@ -202,6 +202,7 @@ def _render(tmp_path: Path, **kwargs) -> str:
         kwargs.get("orbit_direction", "ascending"),
         kwargs.get("date_start", "2026-06-04"),
         kwargs.get("date_end", "2026-06-06"),
+        kwargs.get("platform_list", "S1A S1C"),
     )
     return dst.read_text()
 
@@ -227,10 +228,16 @@ def test_render_cfg_descending_maps_to_des(tmp_path):
     assert "orbit_direction : DES" in out
 
 
-def test_render_cfg_leaves_platform_untouched(tmp_path):
-    """platform_list is not a run-specific key (S1A-only pipeline) — must be preserved."""
+def test_render_cfg_injects_platform(tmp_path):
+    """platform_list is now run-specific (T2): default S1A S1C, overwriting the base cfg value."""
     out = _render(tmp_path)
+    assert "platform_list : S1A S1C" in out
+
+
+def test_render_cfg_platform_list_configurable(tmp_path):
+    out = _render(tmp_path, platform_list="S1A")
     assert "platform_list : S1A" in out
+    assert "platform_list : S1A S1C" not in out
 
 
 # ---------------------------------------------------------------------------
@@ -325,9 +332,10 @@ def test_safe_clean_refuses_absolute_escape(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _invoke_main(tmp_path, monkeypatch, extra_args=None):
-    """Run run_s1tiling.main() with the docker/aws boundary (_run) stubbed to a no-op.
+def _invoke_main(tmp_path, monkeypatch, extra_args=None, run_stub=None):
+    """Run run_s1tiling.main() with the docker/aws boundary (_run) stubbed.
 
+    Defaults to a no-op stub; pass ``run_stub`` to simulate docker exit codes / output.
     Returns the workdir data_dir so callers can assert on-disk cleanup effects.
     """
     mod = _import_script()
@@ -371,7 +379,7 @@ def _invoke_main(tmp_path, monkeypatch, extra_args=None):
         *(extra_args or []),
     ]
     monkeypatch.setattr(sys, "argv", argv)
-    monkeypatch.setattr(mod, "_run", lambda *a, **k: None)  # stub docker + aws
+    monkeypatch.setattr(mod, "_run", run_stub or (lambda *a, **k: None))  # stub docker + aws
     mod.main()
     return data_dir
 
@@ -498,3 +506,63 @@ def test_s3_sync_not_attempted_after_docker_failure(tmp_path, monkeypatch):
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)  # noqa: S603
     assert result.returncode != 0, "Expected non-zero exit when Docker fails"
     assert "aws" not in result.stdout, "S3 sync should not be attempted after Docker failure"
+
+
+# ---------------------------------------------------------------------------
+# T2: platform-render success contract — tolerate off-platform download failures
+# ---------------------------------------------------------------------------
+
+
+def test_requested_platform_outputs_present_true_for_requested(tmp_path):
+    mod = _import_script()
+    out = tmp_path / "data_out" / "31TCH"
+    out.mkdir(parents=True)
+    (out / "s1a_31TCH_vv_DES_037_20250210t060920_GammaNaughtRTC.tif").write_text("x")
+    assert mod._requested_platform_outputs_present(out, ["S1A", "S1C"]) is True
+
+
+def test_requested_platform_outputs_present_false_for_other_platform(tmp_path):
+    """Only an off-platform (S1B) GeoTIFF present while S1A/S1C were requested -> not a success."""
+    mod = _import_script()
+    out = tmp_path / "data_out" / "31TCH"
+    out.mkdir(parents=True)
+    (out / "s1b_31TCH_vv_DES_037_20250210t060920_GammaNaughtRTC.tif").write_text("x")
+    assert mod._requested_platform_outputs_present(out, ["S1A", "S1C"]) is False
+
+
+def test_requested_platform_outputs_present_false_when_absent(tmp_path):
+    mod = _import_script()
+    assert mod._requested_platform_outputs_present(tmp_path / "nope", ["S1A", "S1C"]) is False
+
+
+def test_main_tolerates_nonzero_docker_when_output_present(tmp_path, monkeypatch):
+    """S1Processor exits non-zero (off-platform download failed) but the requested platform
+    produced output -> the run continues and the aws sync is attempted (T2 success contract)."""
+    data_dir = tmp_path / "workdir"
+    calls = []
+
+    def fake_run(cmd, dry_run, *, check=True):
+        calls.append(cmd)
+        if cmd[0] == "docker":
+            out = data_dir / "data_out" / "31TCH"
+            out.mkdir(parents=True, exist_ok=True)
+            (out / "s1a_31TCH_vv_DES_037_20250210t060920_GammaNaughtRTC.tif").write_text("x")
+            return 2  # off-platform (e.g. S1D) download failed
+        return 0
+
+    _invoke_main(tmp_path, monkeypatch, run_stub=fake_run)
+    assert any(c[0] == "aws" and "sync" in c for c in calls), "sync should proceed despite rc=2"
+
+
+def test_main_exits_when_docker_fails_and_no_output(tmp_path, monkeypatch):
+    """Non-zero docker exit with no requested-platform output -> hard failure, no sync."""
+    calls = []
+
+    def fake_run(cmd, dry_run, *, check=True):
+        calls.append(cmd)
+        return 2 if cmd[0] == "docker" else 0
+
+    with pytest.raises(SystemExit) as exc:
+        _invoke_main(tmp_path, monkeypatch, run_stub=fake_run)
+    assert exc.value.code == 2
+    assert not any(c[0] == "aws" and "sync" in c for c in calls), "no sync after a true failure"


### PR DESCRIPTION
Plan T2 (in-repo half), tracker #226. The cluster S1C end-to-end verify stays platform-deploy/cluster-pending.

## What (`scripts/run_s1tiling.py`)
- **`--platform-list`** (default `S1A S1C`; S1D unsupported per #223) — `_render_cfg` now renders `platform_list` instead of inheriting the base cfg's hardcoded value.
- **Success contract** — S1Processor downloads *every* platform in the window and exits non-zero if an off-platform (e.g. S1D) download fails even when the requested platform produced output (seen in the PoC). The step now succeeds when requested-platform `*GammaNaughtRTC.tif` are present in `data_out/{tile}`, not on exit 0 alone; a true failure (non-zero exit **and** no requested output) still aborts before the S3 sync. `_run` gained `check=False` for this; aws steps keep `check=True`.

## Tests
`uv run pytest tests/unit/test_run_s1tiling.py` — platform render + configurability, the output-presence predicate (requested / off-platform-only / absent), and main() both tolerating rc≠0 with output present and hard-failing without it. 387 unit tests green overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)