### PR TITLE
chore: pin data-model to v0.10.1 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.1",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@5be1f10ec87938c49c06c04fb6a722d33e2b94fe",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@v0.10.1",
     "requests==2.34.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -831,7 +831,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.1" },
     { name = "click", specifier = "==8.3.3" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=5be1f10ec87938c49c06c04fb6a722d33e2b94fe" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=v0.10.1" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "morecantile", specifier = "==7.0.3" },
     { name = "pystac", specifier = "==1.14.3" },
@@ -950,8 +950,8 @@ wheels = [
 
 [[package]]
 name = "eopf-geozarr"
-version = "0.9.0"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=5be1f10ec87938c49c06c04fb6a722d33e2b94fe#5be1f10ec87938c49c06c04fb6a722d33e2b94fe" }
+version = "0.10.1"
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=v0.10.1#49f18e77f54d2d0dbb89d25f7f5b4b206ede3988" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
## Summary

Release branch pinning **eopf-geozarr** to the data-model **v0.10.1** release tag (`49f18e7`).

- Branched off `main`, which already includes the merged scale-offset codec work (#189): `zarr[cast-value-rs]>=3.2.0` and the experimental scale-offset flag.
- Bumps the data-model pin to the official `@v0.10.1` tag (a descendant of v0.10.0 / 5be1f10e, so the cast-value-rs codec work is retained).
- `uv.lock` regenerated.

## Verification

- `uv lock` resolves `eopf-geozarr==0.10.1` (`49f18e77f54d2d0dbb89d25f7f5b4b206ede3988`).
- Full test suite: **305 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)