### PR TITLE
feat(register): honor STAC render extension for S1 RGB previews

### DIFF
--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -169,10 +169,97 @@ def add_projection_from_zarr(item: Item) -> None:
                 logger.debug(f"Could not read zarr projection: {e}")
 
 
+# Render names preferred when an item declares the STAC `render` extension,
+# in priority order. The first match wins; otherwise the first render is used.
+_PREFERRED_RENDERS = ("rgb", "visual", "thumbnail", "default")
+
+
+def _select_render(item: Item) -> dict | None:
+    """Return the preferred render config from a render-extension ``renders`` dict.
+
+    Items built with the render extension carry ``properties.renders`` mapping a
+    render name to a config (expression/variables, rescale, bidx, ...). This lets
+    the data producer own the visualization rather than hardcoding it here.
+    Returns ``None`` when no usable renders are present.
+    """
+    renders = item.properties.get("renders")
+    if not isinstance(renders, dict) or not renders:
+        return None
+    for name in _PREFERRED_RENDERS:
+        if isinstance(renders.get(name), dict):
+            return renders[name]
+    first = next(iter(renders.values()))
+    return first if isinstance(first, dict) else None
+
+
+def _render_to_query(render: dict, *, include_tilesize: bool) -> str:
+    """Convert a render-extension config into a titiler query string.
+
+    Mirrors titiler's parameter names. ``rescale`` may be a list of ``[min, max]``
+    pairs (one per band) or a single pair; identical pairs are collapsed to one
+    ``rescale`` param (titiler then applies it to every band). ``tilesize`` is
+    only meaningful for the tiles/tilejson endpoints, not ``/preview``.
+    """
+    q = urllib.parse.quote
+    parts: list[str] = []
+    for var in render.get("variables") or []:
+        parts.append(f"variables={q(str(var), safe='')}")
+    if expression := render.get("expression"):
+        parts.append(f"expression={q(str(expression), safe='')}")
+    for asset in render.get("assets") or []:
+        parts.append(f"assets={q(str(asset), safe='')}")
+    bidx = render.get("bidx")
+    if bidx is not None:
+        for b in bidx if isinstance(bidx, list) else [bidx]:
+            parts.append(f"bidx={b}")
+    rescale = render.get("rescale")
+    if rescale:
+        pairs = rescale if isinstance(rescale[0], (list, tuple)) else [rescale]
+        if len({tuple(p) for p in pairs}) == 1:
+            pairs = [pairs[0]]
+        for mn, mx in pairs:
+            parts.append(f"rescale={q(f'{mn},{mx}', safe='')}")
+    if color_formula := render.get("color_formula"):
+        parts.append(f"color_formula={q(str(color_formula), safe='')}")
+    if colormap_name := render.get("colormap_name"):
+        parts.append(f"colormap_name={q(str(colormap_name), safe='')}")
+    if (nodata := render.get("nodata")) is not None:
+        parts.append(f"nodata={q(str(nodata), safe='')}")
+    if resampling := render.get("resampling"):
+        parts.append(f"resampling={q(str(resampling), safe='')}")
+    if include_tilesize and (tilesize := render.get("tilesize")):
+        parts.append(f"tilesize={tilesize}")
+    return "&".join(parts)
+
+
 def add_visualization_links(item: Item, raster_base: str, collection_id: str) -> None:
     """Add viewer/xyz/tilejson links for TiTiler visualization."""
     base_url = f"{raster_base}/collections/{collection_id}/items/{item.id}"
     item.add_link(Link("viewer", f"{base_url}/viewer", "text/html", f"Viewer for {item.id}"))
+
+    # Prefer a producer-declared render config (STAC render extension) over the
+    # hardcoded mission defaults below.
+    if render := _select_render(item):
+        query = _render_to_query(render, include_tilesize=True)
+        title = render.get("title") or f"Visualization for {item.id}"
+        item.add_link(
+            Link(
+                "xyz",
+                f"{base_url}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{query}",
+                "image/png",
+                title,
+            )
+        )
+        item.add_link(
+            Link(
+                "tilejson",
+                f"{base_url}/WebMercatorQuad/tilejson.json?{query}",
+                "application/json",
+                f"TileJSON for {item.id}",
+            )
+        )
+        _add_explorer_link(item, collection_id)
+        return
 
     # Mission-specific tile configurations
     coll_lower = collection_id.lower()
@@ -221,7 +308,11 @@ def add_visualization_links(item: Item, raster_base: str, collection_id: str) ->
             )
         )
 
-    # Add EOPF Explorer link
+    _add_explorer_link(item, collection_id)
+
+
+def _add_explorer_link(item: Item, collection_id: str) -> None:
+    """Add the EOPF Explorer ``via`` link for the item."""
     item.add_link(
         Link(
             "via",
@@ -238,6 +329,22 @@ def add_thumbnail_asset(item: Item, raster_base: str, collection_id: str) -> Non
 
     base_url = f"{raster_base}/collections/{collection_id}/items/{item.id}"
     coll_lower = collection_id.lower()
+
+    # Prefer a producer-declared render config (STAC render extension).
+    if render := _select_render(item):
+        params = "format=png&" + _render_to_query(render, include_tilesize=False)
+        title = render.get("title") or f"{item.id} preview"
+        item.add_asset(
+            "thumbnail",
+            Asset(
+                href=f"{base_url}/preview?{params}",
+                media_type="image/png",
+                roles=["thumbnail"],
+                title=title,
+            ),
+        )
+        logger.debug(f"Added thumbnail asset from render config: {title}")
+        return
 
     # Mission-specific thumbnail parameters
     if coll_lower.startswith(("sentinel-2", "sentinel2")):

--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -185,11 +185,12 @@ def _select_render(item: Item) -> dict | None:
     renders = item.properties.get("renders")
     if not isinstance(renders, dict) or not renders:
         return None
-    for name in _PREFERRED_RENDERS:
-        if isinstance(renders.get(name), dict):
-            return renders[name]
-    first = next(iter(renders.values()))
-    return first if isinstance(first, dict) else None
+    candidates = [renders.get(name) for name in _PREFERRED_RENDERS]
+    candidates.append(next(iter(renders.values())))
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            return candidate
+    return None
 
 
 def _render_to_query(render: dict, *, include_tilesize: bool) -> str:
@@ -214,7 +215,7 @@ def _render_to_query(render: dict, *, include_tilesize: bool) -> str:
             parts.append(f"bidx={b}")
     rescale = render.get("rescale")
     if rescale:
-        pairs = rescale if isinstance(rescale[0], (list, tuple)) else [rescale]
+        pairs = rescale if isinstance(rescale[0], list | tuple) else [rescale]
         if len({tuple(p) for p in pairs}) == 1:
             pairs = [pairs[0]]
         for mn, mx in pairs:

--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -196,38 +196,17 @@ def _select_render(item: Item) -> dict | None:
 def _render_to_query(render: dict, *, include_tilesize: bool) -> str:
     """Convert a render-extension config into a titiler query string.
 
-    Mirrors titiler's parameter names. ``rescale`` may be a list of ``[min, max]``
-    pairs (one per band) or a single pair; identical pairs are collapsed to one
-    ``rescale`` param (titiler then applies it to every band). ``tilesize`` is
-    only meaningful for the tiles/tilejson endpoints, not ``/preview``.
+    Serializes the fields S1 RTC renders use: ``expression``, ``rescale`` (a
+    list of ``[min, max]`` pairs — a single pair applies to all bands) and
+    ``bidx``. ``tilesize`` is only valid on the tiles/tilejson endpoints, not
+    ``/preview``.
     """
     q = urllib.parse.quote
-    parts: list[str] = []
-    for var in render.get("variables") or []:
-        parts.append(f"variables={q(str(var), safe='')}")
-    if expression := render.get("expression"):
-        parts.append(f"expression={q(str(expression), safe='')}")
-    for asset in render.get("assets") or []:
-        parts.append(f"assets={q(str(asset), safe='')}")
-    bidx = render.get("bidx")
-    if bidx is not None:
-        for b in bidx if isinstance(bidx, list) else [bidx]:
-            parts.append(f"bidx={b}")
-    rescale = render.get("rescale")
-    if rescale:
-        pairs = rescale if isinstance(rescale[0], list | tuple) else [rescale]
-        if len({tuple(p) for p in pairs}) == 1:
-            pairs = [pairs[0]]
-        for mn, mx in pairs:
-            parts.append(f"rescale={q(f'{mn},{mx}', safe='')}")
-    if color_formula := render.get("color_formula"):
-        parts.append(f"color_formula={q(str(color_formula), safe='')}")
-    if colormap_name := render.get("colormap_name"):
-        parts.append(f"colormap_name={q(str(colormap_name), safe='')}")
-    if (nodata := render.get("nodata")) is not None:
-        parts.append(f"nodata={q(str(nodata), safe='')}")
-    if resampling := render.get("resampling"):
-        parts.append(f"resampling={q(str(resampling), safe='')}")
+    parts = [f"expression={q(render['expression'], safe='')}"]
+    for mn, mx in render.get("rescale", []):
+        parts.append(f"rescale={q(f'{mn},{mx}', safe='')}")
+    for b in render.get("bidx", []):
+        parts.append(f"bidx={b}")
     if include_tilesize and (tilesize := render.get("tilesize")):
         parts.append(f"tilesize={tilesize}")
     return "&".join(parts)

--- a/tests/unit/test_register_v1.py
+++ b/tests/unit/test_register_v1.py
@@ -12,7 +12,13 @@ import requests
 scripts_dir = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(scripts_dir))
 
-from register_v1 import upsert_item  # noqa: E402
+from register_v1 import (  # noqa: E402
+    _render_to_query,
+    _select_render,
+    add_thumbnail_asset,
+    add_visualization_links,
+    upsert_item,
+)
 
 
 def _make_client(item_exists: bool, base_url: str = "https://stac.example.com") -> MagicMock:
@@ -138,3 +144,110 @@ class TestUpsertItemNewItem:
 
         with pytest.raises(requests.HTTPError):
             upsert_item(client, "my-collection", _make_item())
+
+
+# =============================================================================
+# Render-extension visualization
+# =============================================================================
+
+import datetime as _dt  # noqa: E402
+
+from pystac import Asset, Item  # noqa: E402
+
+RASTER_BASE = "https://api.example.com/raster"
+S1_RGB_EXPR = "/descending:vv;/descending:vh;(/descending:vv)/(/descending:vh)"
+
+
+def _real_item(renders: dict | None = None) -> Item:
+    """A real pystac Item with vv/vh assets and an optional renders property."""
+    props: dict = {}
+    if renders is not None:
+        props["renders"] = renders
+    item = Item(
+        id="s1-rtc-31TCH",
+        geometry=None,
+        bbox=None,
+        datetime=_dt.datetime(2026, 6, 7, tzinfo=_dt.UTC),
+        properties=props,
+    )
+    href = "s3://bucket/s1-grd-rtc-31TCH.zarr/descending"
+    for pol in ("vv", "vh"):
+        item.add_asset(pol, Asset(href=href, roles=["data"]))
+    return item
+
+
+def _s1_rgb_renders() -> dict:
+    return {
+        "rgb": {
+            "title": "VV, VH, VV/VH composite",
+            "expression": S1_RGB_EXPR,
+            "rescale": [[0.0, 0.1], [0.0, 0.1], [0.0, 0.1]],
+            "bidx": [1],
+            "tilesize": 256,
+        }
+    }
+
+
+class TestSelectRender:
+    def test_returns_none_without_renders(self):
+        assert _select_render(_real_item()) is None
+
+    def test_prefers_rgb_name(self):
+        renders = {"other": {"expression": "x"}, "rgb": {"expression": "y"}}
+        assert _select_render(_real_item(renders))["expression"] == "y"
+
+    def test_falls_back_to_first_render(self):
+        renders = {"only": {"expression": "z"}}
+        assert _select_render(_real_item(renders))["expression"] == "z"
+
+
+class TestRenderToQuery:
+    def test_collapses_identical_rescale_pairs(self):
+        q = _render_to_query(_s1_rgb_renders()["rgb"], include_tilesize=True)
+        # identical [0,0.1] pairs collapse to a single rescale param
+        assert q.count("rescale=") == 1
+        assert "rescale=0.0%2C0.1" in q
+        assert "bidx=1" in q
+        assert "tilesize=256" in q
+        assert "expression=" in q
+
+    def test_tilesize_excluded_when_requested(self):
+        q = _render_to_query(_s1_rgb_renders()["rgb"], include_tilesize=False)
+        assert "tilesize" not in q
+
+    def test_per_band_rescale_preserved_when_differing(self):
+        render = {"expression": "a;b", "rescale": [[0, 1], [0, 2]]}
+        q = _render_to_query(render, include_tilesize=False)
+        assert q.count("rescale=") == 2
+
+
+class TestVisualizationFromRenders:
+    def test_xyz_and_tilejson_use_render_expression(self):
+        item = _real_item(_s1_rgb_renders())
+        add_visualization_links(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
+
+        xyz = next(link for link in item.links if link.rel == "xyz")
+        tilejson = next(link for link in item.links if link.rel == "tilejson")
+        # render expression is used, NOT the old VH-grayscale rescale=0,219
+        for link in (xyz, tilejson):
+            assert "expression=" in link.href
+            assert "rescale=0%2C219" not in link.href
+            assert "0.1" in link.href
+        assert "/tiles/WebMercatorQuad/{z}/{x}/{y}.png" in xyz.href
+        assert "tilejson.json" in tilejson.href
+
+    def test_thumbnail_uses_render_expression(self):
+        item = _real_item(_s1_rgb_renders())
+        add_thumbnail_asset(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
+
+        thumb = item.assets["thumbnail"]
+        assert "expression=" in thumb.href
+        assert "rescale=0%2C219" not in thumb.href
+        assert "tilesize" not in thumb.href  # not valid on /preview
+        assert thumb.href.startswith(f"{RASTER_BASE}/collections/")
+
+    def test_falls_back_to_mission_default_without_renders(self):
+        item = _real_item()  # no renders property
+        add_thumbnail_asset(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
+        # legacy VH grayscale path still applies when no render config present
+        assert "thumbnail" in item.assets

--- a/tests/unit/test_register_v1.py
+++ b/tests/unit/test_register_v1.py
@@ -181,7 +181,7 @@ def _s1_rgb_renders() -> dict:
         "rgb": {
             "title": "VV, VH, VV/VH composite",
             "expression": S1_RGB_EXPR,
-            "rescale": [[0.0, 0.1], [0.0, 0.1], [0.0, 0.1]],
+            "rescale": [[0.0, 0.1]],
             "bidx": [1],
             "tilesize": 256,
         }
@@ -202,9 +202,8 @@ class TestSelectRender:
 
 
 class TestRenderToQuery:
-    def test_collapses_identical_rescale_pairs(self):
+    def test_serializes_render_fields(self):
         q = _render_to_query(_s1_rgb_renders()["rgb"], include_tilesize=True)
-        # identical [0,0.1] pairs collapse to a single rescale param
         assert q.count("rescale=") == 1
         assert "rescale=0.0%2C0.1" in q
         assert "bidx=1" in q
@@ -215,7 +214,7 @@ class TestRenderToQuery:
         q = _render_to_query(_s1_rgb_renders()["rgb"], include_tilesize=False)
         assert "tilesize" not in q
 
-    def test_per_band_rescale_preserved_when_differing(self):
+    def test_one_rescale_param_per_pair(self):
         render = {"expression": "a;b", "rescale": [[0, 1], [0, 2]]}
         q = _render_to_query(render, include_tilesize=False)
         assert q.count("rescale=") == 2


### PR DESCRIPTION
> **Stacked on #186** (`feat--s1_grd_phase5`) — base retargeted from `main`. This is the preview half of the S1 GRD RTC pipeline; it builds on #186's `register_v1_s1_rtc.py`, which calls the `add_visualization_links`/`add_thumbnail_asset` functions changed here.

## Summary

The registrar rendered the Sentinel-1 preview as a **single VH band** with `rescale=0,219`, producing a near-black grayscale thumbnail unsuited to linear gamma0 RTC values (real range ~0–0.1).

This makes `add_visualization_links` and `add_thumbnail_asset` **prefer a producer-declared `renders` config** (STAC [render extension](https://github.com/stac-extensions/render)) when present, falling back to #186's per-mission `/{orbit}:vh` defaults otherwise.

- `_select_render(item)` — picks the preferred render by name (`rgb` → `visual` → `thumbnail` → `default`, else first)
- `_render_to_query(render, include_tilesize=...)` — serializes the fields S1 renders use (`expression`, `rescale`, `bidx`, `tilesize`); `tilesize` is omitted on `/preview`

## Why

Paired with **EOPF-Explorer/data-model#180**, whose `build_s1_rtc_stac_item` (used by #186's `register_v1_s1_rtc.py`) now emits a `renders.rgb` dual-pol composite (R=VV, G=VH, B=VV/VH ratio, `rescale=0,0.1`, `bidx=1`, `tilesize=256`). With both in place, S1 previews/tiles/tilejson render the correct RGB composite — the data producer owns the visualization.

Generated query reproduces the manually-verified working URL:
```
.../tiles/WebMercatorQuad/{z}/{x}/{y}.png?expression=/descending:vv;/descending:vh;(/descending:vv)/(/descending:vh)&rescale=0,0.1&bidx=1&tilesize=256
```
Verified live: upserting the corrected `s1-rtc-31TCH` item produced a real 469 KB RGB composite thumbnail (previously a near-black 3.5 KB grayscale).

## Test plan

- [x] `pytest tests/unit/test_register_v1.py` — 22 passed (renders selection, query serialization, S1 xyz/tilejson/thumbnail from renders, fallback when absent; plus #186's existing tests)
- [x] `pre-commit` (ruff v0.8.4, mypy v1.11.2) — clean
- [x] RGB tile/preview/tilejson endpoints return HTTP 200 with real imagery against staging

## Notes

- The S1 fallback block keeps #186's `/{orbit}:vh` fix; it's reached only for S1 items without a `renders` property.
- `register_v0.py` (legacy, docs-only references) left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)