### PR TITLE
fix(s1-phase6): cross-run cube append on consolidated stores (T4 / F2)

### DIFF
--- a/scripts/ingest_v1_s1_rtc.py
+++ b/scripts/ingest_v1_s1_rtc.py
@@ -9,6 +9,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import shutil
@@ -244,6 +245,23 @@ def _fetch_store_from_s3(s3_uri: str, local_store: str) -> None:
     _get_tree(fs, src, local_store)
 
 
+def _drop_consolidated_metadata(local_store: str) -> None:
+    """Strip zarr-v3 consolidated metadata from a fetched cube so the append can grow `time`.
+
+    Reopening a *consolidated* store ``mode="r+"`` serves the consolidated (stale) array shapes, so
+    ``eopf_geozarr``'s resize-then-write raises ``BoundsCheckError`` ("index out of bounds for
+    dimension with length 1"). Removing the root ``consolidated_metadata`` makes zarr read per-array
+    metadata, so ``resize`` is honoured; ``ingest_all`` re-consolidates at the end.
+    """
+    zj = Path(local_store) / "zarr.json"
+    if not zj.exists():
+        return
+    meta = json.loads(zj.read_text())
+    if meta.pop("consolidated_metadata", None) is not None:
+        zj.write_text(json.dumps(meta))
+        log.info("Dropped consolidated metadata from %s (so append can resize time)", local_store)
+
+
 def _upload_store_to_s3(local_store: str, s3_uri: str) -> None:
     """Upload a local Zarr store directory to an ``s3://`` URI via s3fs.
 
@@ -278,6 +296,7 @@ def run_ingest(s3_geotiff_prefix: str, store: str, orbit_direction: str) -> int:
     local_store = os.path.join(tmp_dir, os.path.basename(store.rstrip("/")))
     try:
         _fetch_store_from_s3(store, local_store)  # append to the existing per-tile cube (T4)
+        _drop_consolidated_metadata(local_store)  # so eopf_geozarr can resize `time` on append
         rc = ingest_all(s3_geotiff_prefix, local_store, orbit_direction)
         if rc != 0:
             return rc

--- a/scripts/ingest_v1_s1_rtc.py
+++ b/scripts/ingest_v1_s1_rtc.py
@@ -248,18 +248,24 @@ def _fetch_store_from_s3(s3_uri: str, local_store: str) -> None:
 def _drop_consolidated_metadata(local_store: str) -> None:
     """Strip zarr-v3 consolidated metadata from a fetched cube so the append can grow `time`.
 
-    Reopening a *consolidated* store ``mode="r+"`` serves the consolidated (stale) array shapes, so
-    ``eopf_geozarr``'s resize-then-write raises ``BoundsCheckError`` ("index out of bounds for
-    dimension with length 1"). Removing the root ``consolidated_metadata`` makes zarr read per-array
-    metadata, so ``resize`` is honoured; ``ingest_all`` re-consolidates at the end.
+    Reopening a *consolidated* store ``mode="r+"`` serves the consolidated (stale, length-1) array
+    shapes, so ``eopf_geozarr``'s resize-then-write raises ``BoundsCheckError`` ("index out of bounds
+    for dimension with length 1"). ``eopf_geozarr`` consolidates at the **orbit-group** level (not the
+    root), so we strip ``consolidated_metadata`` from *every* group node, not just the root; zarr then
+    reads per-array metadata and honours ``resize``. ``ingest_all`` re-consolidates at the end.
     """
-    zj = Path(local_store) / "zarr.json"
-    if not zj.exists():
-        return
-    meta = json.loads(zj.read_text())
-    if meta.pop("consolidated_metadata", None) is not None:
-        zj.write_text(json.dumps(meta))
-        log.info("Dropped consolidated metadata from %s (so append can resize time)", local_store)
+    dropped = 0
+    for zj in Path(local_store).rglob("zarr.json"):
+        meta = json.loads(zj.read_text())
+        if meta.get("node_type") == "group" and meta.pop("consolidated_metadata", None) is not None:
+            zj.write_text(json.dumps(meta))
+            dropped += 1
+    if dropped:
+        log.info(
+            "Dropped consolidated metadata from %d group(s) in %s (so append can resize)",
+            dropped,
+            local_store,
+        )
 
 
 def _upload_store_to_s3(local_store: str, s3_uri: str) -> None:

--- a/tests/unit/test_ingest_v1_s1_rtc.py
+++ b/tests/unit/test_ingest_v1_s1_rtc.py
@@ -348,3 +348,38 @@ def test_run_ingest_local_does_not_fetch(tmp_path) -> None:
     ):
         run_ingest("/input", local_store, "descending")
     mock_fetch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# T4 fix -- appending to a *consolidated* fetched cube must resize `time`
+# ---------------------------------------------------------------------------
+
+
+def test_drop_consolidated_metadata_enables_resize(tmp_path) -> None:
+    """A consolidated v3 store can't be grown via resize+write on reopen; dropping the root
+    consolidated_metadata restores it (the cross-run append path, T4)."""
+    import numpy as np
+    from ingest_v1_s1_rtc import _drop_consolidated_metadata
+
+    store = str(tmp_path / "cube.zarr")
+    root = zarr.open_group(store, mode="w", zarr_format=3)
+    g = root.create_group("descending").create_group("r10m")
+    g.create_array("vv", shape=(1, 4, 4), dtype="float32", dimension_names=("time", "y", "x"))[
+        0
+    ] = 1
+    zarr.consolidate_metadata(store)
+
+    # Without the fix, resize-then-write on the consolidated store is out of bounds.
+    import pytest
+
+    r = zarr.open_group(store, mode="r+", zarr_format=3)["descending"]["r10m"]
+    r["vv"].resize((2, 4, 4))
+    with pytest.raises(Exception):  # noqa: B017 -- zarr BoundsCheckError on consolidated store
+        r["vv"][1, :, :] = np.zeros((4, 4), dtype="float32")
+
+    # After dropping consolidated metadata, the same append succeeds.
+    _drop_consolidated_metadata(store)
+    r2 = zarr.open_group(store, mode="r+", zarr_format=3)["descending"]["r10m"]
+    r2["vv"].resize((2, 4, 4))
+    r2["vv"][1, :, :] = np.zeros((4, 4), dtype="float32")
+    assert r2["vv"].shape == (2, 4, 4)

--- a/tests/unit/test_ingest_v1_s1_rtc.py
+++ b/tests/unit/test_ingest_v1_s1_rtc.py
@@ -356,28 +356,33 @@ def test_run_ingest_local_does_not_fetch(tmp_path) -> None:
 
 
 def test_drop_consolidated_metadata_enables_resize(tmp_path) -> None:
-    """A consolidated v3 store can't be grown via resize+write on reopen; dropping the root
-    consolidated_metadata restores it (the cross-run append path, T4)."""
+    """A cube consolidated at the *orbit-group* level (as eopf_geozarr does) can't be grown via
+    resize+write on reopen — the group serves the stale length-1 shape. Stripping consolidated
+    metadata from *every* group (not just the root) restores the append (the cross-run path, T4)."""
     import numpy as np
+    import pytest
     from ingest_v1_s1_rtc import _drop_consolidated_metadata
 
     store = str(tmp_path / "cube.zarr")
     root = zarr.open_group(store, mode="w", zarr_format=3)
-    g = root.create_group("descending").create_group("r10m")
-    g.create_array("vv", shape=(1, 4, 4), dtype="float32", dimension_names=("time", "y", "x"))[
-        0
-    ] = 1
-    zarr.consolidate_metadata(store)
+    root.create_group("descending").create_group("r10m").create_array(
+        "vv", shape=(1, 4, 4), dtype="float32", dimension_names=("time", "y", "x")
+    )[0] = 1
+    # eopf_geozarr consolidates the orbit group, not the root.
+    zarr.consolidate_metadata(store, path="descending")
+    import json
 
-    # Without the fix, resize-then-write on the consolidated store is out of bounds.
-    import pytest
+    assert "consolidated_metadata" in json.loads(
+        (tmp_path / "cube.zarr" / "descending" / "zarr.json").read_text()
+    )
 
+    # Bug: with the orbit group consolidated, resize is not seen on re-navigation -> out of bounds.
     r = zarr.open_group(store, mode="r+", zarr_format=3)["descending"]["r10m"]
     r["vv"].resize((2, 4, 4))
-    with pytest.raises(Exception):  # noqa: B017 -- zarr BoundsCheckError on consolidated store
+    with pytest.raises(Exception):  # noqa: B017 -- zarr BoundsCheckError on the consolidated group
         r["vv"][1, :, :] = np.zeros((4, 4), dtype="float32")
 
-    # After dropping consolidated metadata, the same append succeeds.
+    # Fix: a root-only strip would miss descending/; the recursive strip clears it everywhere.
     _drop_consolidated_metadata(store)
     r2 = zarr.open_group(store, mode="r+", zarr_format=3)["descending"]["r10m"]
     r2["vv"].resize((2, 4, 4))


### PR DESCRIPTION
Fixes **F2** from the 32TLR staging e2e (tracker #226): the cross-run datacube append (T4) failed with `BoundsCheckError` on any already-published cube.

## Root cause
`eopf_geozarr` consolidates at the **orbit-group** level (`descending/zarr.json`). Reopening such a cube `mode="r+"` serves the consolidated (stale, length-1) array shapes, so `ingest_s1tiling_acquisition`'s resize-then-write goes out of bounds. A root-only metadata strip misses `descending/`.

## Fix
`_drop_consolidated_metadata` now strips `consolidated_metadata` from **every** group node (recursive `rglob`) of the fetched cube before append; `ingest_all` re-consolidates at the end.

## Verification
- `uv run pytest tests/unit/test_ingest_v1_s1_rtc.py` — unit test reproduces the orbit-group-consolidation failure and asserts the recursive strip fixes it.
- **Verified live in staging**: appended a 2nd acquisition to `s1-grd-rtc-32TLR.zarr` → cube now has **2 time slices** (confirmed on S3), and both per-acquisition items registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)