### PR TITLE
fix(s1-phase6): e2e follow-ups — masked-stamp (F1), S3-creds migration, register both collections

### DIFF
--- a/scripts/ingest_v1_s1_rtc.py
+++ b/scripts/ingest_v1_s1_rtc.py
@@ -24,6 +24,7 @@ from eopf_geozarr.conversion.s1_ingest import (
     consolidate_s1_store,
     discover_s1tiling_acquisitions,
     discover_s1tiling_conditions,
+    extract_geotiff_metadata,
     ingest_s1tiling_acquisition,
     ingest_s1tiling_conditions,
 )
@@ -113,6 +114,34 @@ def new_acquisitions(acquisitions: list[dict], present_ns: set[int]) -> list[dic
     return [a for a in acquisitions if acq_time_ns(a["acq_stamp"]) not in present_ns]
 
 
+def _normalize_masked_stamps(geotiff_prefix: str) -> int:
+    """Rename s1tiling daily-concatenated products whose time is masked (``…txxxxxx…``) using the
+    real ``ACQUISITION_DATETIME`` GeoTIFF tag, so ``discover_s1tiling_acquisitions`` can parse them.
+
+    A pass spanning two frames is concatenated into a *daily* product whose filename masks the time
+    as ``txxxxxx``; eopf_geozarr's filename regex requires ``\\d{6}`` and would otherwise skip it
+    (F1). Each ``GammaNaughtRTC`` data file is renamed with the tag's HH:MM:SS, and its companion
+    ``_BorderMask`` in lockstep. No-op on a non-local prefix (e.g. ``s3://``) — the durable fix is
+    upstream in eopf_geozarr's discover/parse. Returns the number of data files normalized.
+    """
+    base = Path(geotiff_prefix)
+    if not base.is_dir():
+        return 0
+    renamed = 0
+    for data in sorted(base.glob("*txxxxxx*GammaNaughtRTC.tif")):
+        hhmmss = extract_geotiff_metadata(data).datetime.split("T")[1].replace(":", "")[:6]
+        mask = data.with_name(
+            data.name.replace("GammaNaughtRTC.tif", "GammaNaughtRTC_BorderMask.tif")
+        )
+        for f in (data, mask):
+            if f.exists():
+                f.rename(f.with_name(f.name.replace("txxxxxx", f"t{hhmmss}")))
+        renamed += 1
+    if renamed:
+        log.info("Normalized %d masked daily-product stamp(s) in %s (F1)", renamed, geotiff_prefix)
+    return renamed
+
+
 def ingest_all(s3_geotiff_prefix: str, store_path: str, orbit_direction: str) -> int:
     """Run the 5-step S1 ingest pipeline, appending new acquisitions to the per-tile cube.
 
@@ -122,6 +151,9 @@ def ingest_all(s3_geotiff_prefix: str, store_path: str, orbit_direction: str) ->
 
     Returns exit code: 0 = success (or nothing new to ingest), 1 = ingest error, 2 = no acquisitions.
     """
+    # Step 0 -- normalize masked daily-product stamps so discover can parse multi-frame passes (F1)
+    _normalize_masked_stamps(s3_geotiff_prefix)
+
     # Step 1 -- discover acquisitions
     acquisitions = discover_s1tiling_acquisitions(s3_geotiff_prefix)
     if not acquisitions:

--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -136,8 +136,15 @@ def main() -> None:
     args = ap.parse_args()
 
     from eopf_geozarr.stac.s1_rtc import build_s1_rtc_stac_item
+    from register_v1 import s3_to_https
 
     base = build_s1_rtc_stac_item(args.store, args.collection).to_dict()
+    # build_s1_rtc_stac_item emits s3:// hrefs for an s3 store; rewrite to the https gateway so the
+    # per-acquisition items match the cube item (register_v1 does the same). Reading times below
+    # still uses the s3 store, which is authoritative and avoids the gateway's read-cache lag.
+    for asset in base.get("assets", {}).values():
+        if isinstance(asset.get("href"), str) and asset["href"].startswith("s3://"):
+            asset["href"] = s3_to_https(asset["href"])
     times = read_times_ns(args.store, args.orbit_direction)
     items = per_acquisition_items(
         base,

--- a/scripts/run_ingest_register.py
+++ b/scripts/run_ingest_register.py
@@ -37,6 +37,7 @@ def run_pipeline(
     s3_endpoint: str,
     stac_api_url: str,
     raster_api_url: str,
+    acquisitions_collection: str = "sentinel-1-grd-rtc-acquisitions",
 ) -> int:
     # Store key prefix is the STAC collection, so per-mission/per-env buckets stay
     # self-describing: s3://{bucket}/{collection}/s1-grd-rtc-{tile}.zarr
@@ -107,6 +108,32 @@ def run_pipeline(
         s3_endpoint,
     ]
     result = subprocess.run(register_cmd)  # noqa: S603
+    if result.returncode != 0:
+        return result.returncode
+
+    # Step 4 — register the per-acquisition items (the -acquisitions collection). The data model
+    # has TWO registrations — the per-tile cube item (Step 3, -staging) AND one item per acquisition
+    # (here). Running both from this single stage keeps the collections in sync; skipping either is
+    # the kind of gap that leaves a tile invisible in one collection.
+    peracq_cmd = [  # noqa: S607
+        "uv",
+        "run",
+        "python",
+        "scripts/register_per_acquisition.py",
+        "--store",
+        s3_zarr,
+        "--tile-id",
+        tile_id,
+        "--orbit-direction",
+        orbit_direction,
+        "--collection",
+        acquisitions_collection,
+        "--stac-api-url",
+        stac_api_url,
+        "--raster-api-url",
+        raster_api_url,
+    ]
+    result = subprocess.run(peracq_cmd)  # noqa: S603
     return result.returncode
 
 
@@ -122,6 +149,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--s3-endpoint", required=True, help="S3 endpoint URL")
     parser.add_argument("--stac-api-url", required=True, help="STAC API base URL")
     parser.add_argument("--raster-api-url", required=True, help="TiTiler raster API base URL")
+    parser.add_argument(
+        "--acquisitions-collection",
+        default="sentinel-1-grd-rtc-acquisitions",
+        help="STAC collection for the per-acquisition items (registered alongside the cube item)",
+    )
     return parser
 
 
@@ -138,6 +170,7 @@ def main() -> None:
             s3_endpoint=args.s3_endpoint,
             stac_api_url=args.stac_api_url,
             raster_api_url=args.raster_api_url,
+            acquisitions_collection=args.acquisitions_collection,
         )
     )
 

--- a/scripts/run_s1tiling.py
+++ b/scripts/run_s1tiling.py
@@ -118,6 +118,12 @@ def main() -> None:
     ap.add_argument("--s3-bucket", required=True)
     ap.add_argument("--s3-prefix", required=True)
     ap.add_argument("--s3-endpoint", required=True)
+    ap.add_argument(
+        "--aws-profile",
+        default=None,
+        help="aws CLI profile for the S3 sync; omit to use ambient AWS_* creds (default — matches "
+        "the op-sourced eopfexplorer keys). Pass a profile name only if your setup still uses one.",
+    )
     ap.add_argument("--eodag-cfg", required=True, type=Path)
     ap.add_argument("--dem-dir", required=True, type=Path)
     ap.add_argument("--data-dir", required=True, type=Path)
@@ -235,7 +241,9 @@ def main() -> None:
         f"s3://{args.s3_bucket}/{args.s3_prefix}"
         f"/{args.tile_id}/{args.orbit_direction}/{args.date_start}/"
     )
-    s3_flags = ["--endpoint-url", args.s3_endpoint, "--profile", "eopfexplorer"]
+    s3_flags = ["--endpoint-url", args.s3_endpoint]
+    if args.aws_profile:
+        s3_flags += ["--profile", args.aws_profile]
     if not args.keep_output:
         if not all([args.s3_bucket, args.s3_prefix, args.tile_id, args.date_start]):
             sys.exit("Error: refusing S3 purge with an empty bucket/prefix/tile/date-start")

--- a/tests/unit/test_ingest_v1_s1_rtc.py
+++ b/tests/unit/test_ingest_v1_s1_rtc.py
@@ -388,3 +388,51 @@ def test_drop_consolidated_metadata_enables_resize(tmp_path) -> None:
     r2["vv"].resize((2, 4, 4))
     r2["vv"][1, :, :] = np.zeros((4, 4), dtype="float32")
     assert r2["vv"].shape == (2, 4, 4)
+
+
+# ---------------------------------------------------------------------------
+# F1 -- normalize multi-frame "daily" products whose time is masked (…txxxxxx…)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_masked_stamps_renames_via_tag(tmp_path, monkeypatch) -> None:
+    """A concatenated daily product (…txxxxxx…) is renamed using the GeoTIFF ACQUISITION_DATETIME
+    tag so discover_s1tiling_acquisitions can parse it; its BorderMask is renamed in lockstep."""
+    from types import SimpleNamespace
+
+    import ingest_v1_s1_rtc as m
+
+    d = tmp_path / "out"
+    d.mkdir()
+    data = d / "s1a_32TLR_vv_DES_139_20260602txxxxxx_GammaNaughtRTC.tif"
+    mask = d / "s1a_32TLR_vv_DES_139_20260602txxxxxx_GammaNaughtRTC_BorderMask.tif"
+    data.write_text("x")
+    mask.write_text("x")
+    monkeypatch.setattr(
+        m, "extract_geotiff_metadata", lambda p: SimpleNamespace(datetime="2026-06-02T05:43:23")
+    )
+
+    assert m._normalize_masked_stamps(str(d)) == 1
+    assert (d / "s1a_32TLR_vv_DES_139_20260602t054323_GammaNaughtRTC.tif").exists()
+    assert (d / "s1a_32TLR_vv_DES_139_20260602t054323_GammaNaughtRTC_BorderMask.tif").exists()
+    assert not data.exists() and not mask.exists()
+
+
+def test_normalize_masked_stamps_noop_when_unmasked(tmp_path, monkeypatch) -> None:
+    """Already-real stamps (single-frame tiles like 31TCH) are untouched."""
+    import ingest_v1_s1_rtc as m
+
+    d = tmp_path / "out"
+    d.mkdir()
+    (d / "s1a_31TCH_vv_DES_037_20230115t061234_GammaNaughtRTC.tif").write_text("x")
+    called = []
+    monkeypatch.setattr(m, "extract_geotiff_metadata", lambda p: called.append(p))
+    assert m._normalize_masked_stamps(str(d)) == 0
+    assert called == []  # no tag reads when nothing is masked
+
+
+def test_normalize_masked_stamps_noop_on_non_local_prefix() -> None:
+    """An s3:// prefix can't be renamed locally -> no-op (durable fix is upstream)."""
+    import ingest_v1_s1_rtc as m
+
+    assert m._normalize_masked_stamps("s3://bucket/s1tiling-output/32TLR") == 0

--- a/tests/unit/test_run_ingest_register.py
+++ b/tests/unit/test_run_ingest_register.py
@@ -34,13 +34,45 @@ def _mock_proc(returncode: int) -> MagicMock:
 
 
 def test_exits_0_on_success() -> None:
-    """Ingest rc=0, upload rc=0, register rc=0 -> pipeline returns 0; all 3 subprocesses called."""
-    with patch(
-        f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0), _mock_proc(0), _mock_proc(0)]
-    ) as mock_run:
+    """Ingest, upload, cube register, per-acq register all rc=0 -> 0; all 4 subprocesses called."""
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
         result = run_pipeline(**_KWARGS)
     assert result == 0
-    assert mock_run.call_count == 3
+    assert mock_run.call_count == 4
+
+
+def test_registers_both_cube_item_and_per_acquisition_items() -> None:
+    """The register stage runs BOTH register_v1_s1_rtc (cube item -> -staging) AND
+    register_per_acquisition (per-acq items -> -acquisitions), so neither collection is missed."""
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
+        run_pipeline(**_KWARGS)
+    scripts_called = [
+        tok
+        for call in mock_run.call_args_list
+        for tok in call[0][0]
+        if tok.endswith("register_v1_s1_rtc.py") or tok.endswith("register_per_acquisition.py")
+    ]
+    assert any(
+        s.endswith("register_v1_s1_rtc.py") for s in scripts_called
+    ), "cube item not registered"
+    assert any(
+        s.endswith("register_per_acquisition.py") for s in scripts_called
+    ), "per-acquisition items not registered"
+    # per-acq register targets the acquisitions collection with the same s3 store
+    peracq_cmd = mock_run.call_args_list[3][0][0]
+    assert "sentinel-1-grd-rtc-acquisitions" in peracq_cmd
+    assert "s3://my-bucket/sentinel-1-grd-rtc-staging/s1-grd-rtc-31TCH.zarr" in peracq_cmd
+
+
+def test_per_acquisition_skipped_when_cube_register_fails() -> None:
+    """If the cube-item register fails, the per-acquisition register is not attempted."""
+    with patch(
+        f"{_MOD}.subprocess.run",
+        side_effect=[_mock_proc(0), _mock_proc(0), _mock_proc(1)],
+    ) as mock_run:
+        result = run_pipeline(**_KWARGS)
+    assert result == 1
+    assert mock_run.call_count == 3  # ingest, upload, failed cube register; no per-acq
 
 
 def test_exits_0_skips_register_on_empty_prefix() -> None:
@@ -61,9 +93,7 @@ def test_exits_1_on_ingest_error() -> None:
 
 def test_ingest_uses_local_zarr_path() -> None:
     """Ingest subprocess must receive a local (non-s3://) path as --s3-zarr-store."""
-    with patch(
-        f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0), _mock_proc(0), _mock_proc(0)]
-    ) as mock_run:
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
         run_pipeline(**_KWARGS)
 
     ingest_cmd: list[str] = mock_run.call_args_list[0][0][0]
@@ -76,9 +106,7 @@ def test_ingest_uses_local_zarr_path() -> None:
 
 def test_upload_called_between_ingest_and_register() -> None:
     """An S3 sync upload must be called after ingest and before register."""
-    with patch(
-        f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0), _mock_proc(0), _mock_proc(0)]
-    ) as mock_run:
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
         run_pipeline(**_KWARGS)
 
     upload_cmd: list[str] = mock_run.call_args_list[1][0][0]
@@ -92,9 +120,7 @@ def test_upload_called_between_ingest_and_register() -> None:
 
 def test_zarr_store_derived_correctly() -> None:
     """--store arg to register subprocess must equal s3://{bucket}/{collection}/s1-grd-rtc-{tile}.zarr."""
-    with patch(
-        f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0), _mock_proc(0), _mock_proc(0)]
-    ) as mock_run:
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
         run_pipeline(**_KWARGS)
 
     register_cmd: list[str] = mock_run.call_args_list[2][0][0]  # third call = register
@@ -122,9 +148,7 @@ def test_store_prefix_tracks_collection() -> None:
     would not.
     """
     kwargs = {**_KWARGS, "collection": "sentinel-1-grd-rtc-tests"}
-    with patch(
-        f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0), _mock_proc(0), _mock_proc(0)]
-    ) as mock_run:
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
         run_pipeline(**kwargs)
 
     register_cmd: list[str] = mock_run.call_args_list[2][0][0]
@@ -144,7 +168,7 @@ def test_upload_failure_stops_pipeline() -> None:
 def test_local_zarr_cleaned_before_ingest() -> None:
     """Stale local zarr must be removed before ingest to avoid appending to old data."""
     with (
-        patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0), _mock_proc(0), _mock_proc(0)]),
+        patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4),
         patch(f"{_MOD}.shutil.rmtree") as mock_rm,
         patch(f"{_MOD}.os.path.exists", return_value=True),
     ):

--- a/tests/unit/test_run_s1tiling.py
+++ b/tests/unit/test_run_s1tiling.py
@@ -566,3 +566,22 @@ def test_main_exits_when_docker_fails_and_no_output(tmp_path, monkeypatch):
         _invoke_main(tmp_path, monkeypatch, run_stub=fake_run)
     assert exc.value.code == 2
     assert not any(c[0] == "aws" and "sync" in c for c in calls), "no sync after a true failure"
+
+
+# ---------------------------------------------------------------------------
+# Migration: S3 sync uses ambient creds by default (no hardcoded --profile)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_s3_sync_has_no_profile_by_default(tmp_path):
+    """New S3 access is op-sourced AWS_* creds, not a profile — aws calls must omit --profile."""
+    out = _dry_run(tmp_path).stdout
+    assert "--profile" not in out
+    assert "eopfexplorer" not in out
+
+
+def test_dry_run_s3_sync_uses_aws_profile_when_given(tmp_path):
+    """--aws-profile is still honoured for setups that use a named profile."""
+    out = _dry_run(tmp_path, ["--aws-profile", "myprof"]).stdout
+    assert "--profile" in out
+    assert "myprof" in out


### PR DESCRIPTION
Three fixes surfaced by the 32TLR staging e2e (tracker #226).

### F1 — multi-frame masked timestamp (`ingest_v1_s1_rtc.py`)
A pass spanning two frames is concatenated into a *daily* product named `…txxxxxx…`; eopf_geozarr's discover regex needs `\d{6}` and skips it → ingest finds 0 acquisitions (31TCH single-frame never hit this; 32TLR did). `ingest_all` now normalizes such filenames from the real `ACQUISITION_DATETIME` tag before discover (no-op on non-local prefixes; durable fix is upstream).

### S3-creds migration (`run_s1tiling.py`)
The S3-access change replaced the `eopfexplorer` aws profile with `op`-sourced `AWS_*` env creds, so the hardcoded `--profile eopfexplorer` would fail. Now defaults to ambient creds; `--aws-profile` optional.

### Register BOTH collections (`run_ingest_register.py` + `register_per_acquisition.py`)
A tile showed in `-acquisitions` but not `-staging` because the register stage only ran `register_v1_s1_rtc` (cube item). Now `run_ingest_register` runs **both** the cube-item register (`-staging`) and the per-acquisition register (`-acquisitions`) as one stage, so neither is missed. `register_per_acquisition` rewrites `s3://`→gateway hrefs (matching `register_v1`).

## Tests
`uv run pytest tests/unit` → 395 passed. New/updated: masked-stamp normalization, ambient-creds sync, and both-registrations-run (+ per-acq skipped if cube register fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)