### PR TITLE
fix(s1-phase6): S1 RTC render extension + env guard + single-platform default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.1",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@9231a5c372953e2ce55823f169ef4fbfebf4e196",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@0b45dea2aa8c2d447f39a93a7c2ee77b456324c3",
     "requests==2.34.1",
     "mgrs==1.5.4",
 ]

--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -169,10 +169,97 @@ def add_projection_from_zarr(item: Item) -> None:
                 logger.debug(f"Could not read zarr projection: {e}")
 
 
+# Render names preferred when an item declares the STAC `render` extension,
+# in priority order. The first match wins; otherwise the first render is used.
+_PREFERRED_RENDERS = ("rgb", "visual", "thumbnail", "default")
+
+
+def _select_render(item: Item) -> dict | None:
+    """Return the preferred render config from a render-extension ``renders`` dict.
+
+    Items built with the render extension carry ``properties.renders`` mapping a
+    render name to a config (expression/variables, rescale, bidx, ...). This lets
+    the data producer own the visualization rather than hardcoding it here.
+    Returns ``None`` when no usable renders are present.
+    """
+    renders = item.properties.get("renders")
+    if not isinstance(renders, dict) or not renders:
+        return None
+    for name in _PREFERRED_RENDERS:
+        if isinstance(renders.get(name), dict):
+            return renders[name]
+    first = next(iter(renders.values()))
+    return first if isinstance(first, dict) else None
+
+
+def _render_to_query(render: dict, *, include_tilesize: bool) -> str:
+    """Convert a render-extension config into a titiler query string.
+
+    Mirrors titiler's parameter names. ``rescale`` may be a list of ``[min, max]``
+    pairs (one per band) or a single pair; identical pairs are collapsed to one
+    ``rescale`` param (titiler then applies it to every band). ``tilesize`` is
+    only meaningful for the tiles/tilejson endpoints, not ``/preview``.
+    """
+    q = urllib.parse.quote
+    parts: list[str] = []
+    for var in render.get("variables") or []:
+        parts.append(f"variables={q(str(var), safe='')}")
+    if expression := render.get("expression"):
+        parts.append(f"expression={q(str(expression), safe='')}")
+    for asset in render.get("assets") or []:
+        parts.append(f"assets={q(str(asset), safe='')}")
+    bidx = render.get("bidx")
+    if bidx is not None:
+        for b in bidx if isinstance(bidx, list) else [bidx]:
+            parts.append(f"bidx={b}")
+    rescale = render.get("rescale")
+    if rescale:
+        pairs = rescale if isinstance(rescale[0], (list, tuple)) else [rescale]
+        if len({tuple(p) for p in pairs}) == 1:
+            pairs = [pairs[0]]
+        for mn, mx in pairs:
+            parts.append(f"rescale={q(f'{mn},{mx}', safe='')}")
+    if color_formula := render.get("color_formula"):
+        parts.append(f"color_formula={q(str(color_formula), safe='')}")
+    if colormap_name := render.get("colormap_name"):
+        parts.append(f"colormap_name={q(str(colormap_name), safe='')}")
+    if (nodata := render.get("nodata")) is not None:
+        parts.append(f"nodata={q(str(nodata), safe='')}")
+    if resampling := render.get("resampling"):
+        parts.append(f"resampling={q(str(resampling), safe='')}")
+    if include_tilesize and (tilesize := render.get("tilesize")):
+        parts.append(f"tilesize={tilesize}")
+    return "&".join(parts)
+
+
 def add_visualization_links(item: Item, raster_base: str, collection_id: str) -> None:
     """Add viewer/xyz/tilejson links for TiTiler visualization."""
     base_url = f"{raster_base}/collections/{collection_id}/items/{item.id}"
     item.add_link(Link("viewer", f"{base_url}/viewer", "text/html", f"Viewer for {item.id}"))
+
+    # Prefer a producer-declared render config (STAC render extension) over the
+    # hardcoded mission defaults below.
+    if render := _select_render(item):
+        query = _render_to_query(render, include_tilesize=True)
+        title = render.get("title") or f"Visualization for {item.id}"
+        item.add_link(
+            Link(
+                "xyz",
+                f"{base_url}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{query}",
+                "image/png",
+                title,
+            )
+        )
+        item.add_link(
+            Link(
+                "tilejson",
+                f"{base_url}/WebMercatorQuad/tilejson.json?{query}",
+                "application/json",
+                f"TileJSON for {item.id}",
+            )
+        )
+        _add_explorer_link(item, collection_id)
+        return
 
     # Mission-specific tile configurations
     coll_lower = collection_id.lower()
@@ -221,7 +308,11 @@ def add_visualization_links(item: Item, raster_base: str, collection_id: str) ->
             )
         )
 
-    # Add EOPF Explorer link
+    _add_explorer_link(item, collection_id)
+
+
+def _add_explorer_link(item: Item, collection_id: str) -> None:
+    """Add the EOPF Explorer ``via`` link for the item."""
     item.add_link(
         Link(
             "via",
@@ -238,6 +329,22 @@ def add_thumbnail_asset(item: Item, raster_base: str, collection_id: str) -> Non
 
     base_url = f"{raster_base}/collections/{collection_id}/items/{item.id}"
     coll_lower = collection_id.lower()
+
+    # Prefer a producer-declared render config (STAC render extension).
+    if render := _select_render(item):
+        params = "format=png&" + _render_to_query(render, include_tilesize=False)
+        title = render.get("title") or f"{item.id} preview"
+        item.add_asset(
+            "thumbnail",
+            Asset(
+                href=f"{base_url}/preview?{params}",
+                media_type="image/png",
+                roles=["thumbnail"],
+                title=title,
+            ),
+        )
+        logger.debug(f"Added thumbnail asset from render config: {title}")
+        return
 
     # Mission-specific thumbnail parameters
     if coll_lower.startswith(("sentinel-2", "sentinel2")):

--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -185,11 +185,12 @@ def _select_render(item: Item) -> dict | None:
     renders = item.properties.get("renders")
     if not isinstance(renders, dict) or not renders:
         return None
-    for name in _PREFERRED_RENDERS:
-        if isinstance(renders.get(name), dict):
-            return renders[name]
-    first = next(iter(renders.values()))
-    return first if isinstance(first, dict) else None
+    candidates = [renders.get(name) for name in _PREFERRED_RENDERS]
+    candidates.append(next(iter(renders.values())))
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            return candidate
+    return None
 
 
 def _render_to_query(render: dict, *, include_tilesize: bool) -> str:
@@ -214,7 +215,7 @@ def _render_to_query(render: dict, *, include_tilesize: bool) -> str:
             parts.append(f"bidx={b}")
     rescale = render.get("rescale")
     if rescale:
-        pairs = rescale if isinstance(rescale[0], (list, tuple)) else [rescale]
+        pairs = rescale if isinstance(rescale[0], list | tuple) else [rescale]
         if len({tuple(p) for p in pairs}) == 1:
             pairs = [pairs[0]]
         for mn, mx in pairs:

--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -196,38 +196,17 @@ def _select_render(item: Item) -> dict | None:
 def _render_to_query(render: dict, *, include_tilesize: bool) -> str:
     """Convert a render-extension config into a titiler query string.
 
-    Mirrors titiler's parameter names. ``rescale`` may be a list of ``[min, max]``
-    pairs (one per band) or a single pair; identical pairs are collapsed to one
-    ``rescale`` param (titiler then applies it to every band). ``tilesize`` is
-    only meaningful for the tiles/tilejson endpoints, not ``/preview``.
+    Serializes the fields S1 RTC renders use: ``expression``, ``rescale`` (a
+    list of ``[min, max]`` pairs — a single pair applies to all bands) and
+    ``bidx``. ``tilesize`` is only valid on the tiles/tilejson endpoints, not
+    ``/preview``.
     """
     q = urllib.parse.quote
-    parts: list[str] = []
-    for var in render.get("variables") or []:
-        parts.append(f"variables={q(str(var), safe='')}")
-    if expression := render.get("expression"):
-        parts.append(f"expression={q(str(expression), safe='')}")
-    for asset in render.get("assets") or []:
-        parts.append(f"assets={q(str(asset), safe='')}")
-    bidx = render.get("bidx")
-    if bidx is not None:
-        for b in bidx if isinstance(bidx, list) else [bidx]:
-            parts.append(f"bidx={b}")
-    rescale = render.get("rescale")
-    if rescale:
-        pairs = rescale if isinstance(rescale[0], list | tuple) else [rescale]
-        if len({tuple(p) for p in pairs}) == 1:
-            pairs = [pairs[0]]
-        for mn, mx in pairs:
-            parts.append(f"rescale={q(f'{mn},{mx}', safe='')}")
-    if color_formula := render.get("color_formula"):
-        parts.append(f"color_formula={q(str(color_formula), safe='')}")
-    if colormap_name := render.get("colormap_name"):
-        parts.append(f"colormap_name={q(str(colormap_name), safe='')}")
-    if (nodata := render.get("nodata")) is not None:
-        parts.append(f"nodata={q(str(nodata), safe='')}")
-    if resampling := render.get("resampling"):
-        parts.append(f"resampling={q(str(resampling), safe='')}")
+    parts = [f"expression={q(render['expression'], safe='')}"]
+    for mn, mx in render.get("rescale", []):
+        parts.append(f"rescale={q(f'{mn},{mx}', safe='')}")
+    for b in render.get("bidx", []):
+        parts.append(f"bidx={b}")
     if include_tilesize and (tilesize := render.get("tilesize")):
         parts.append(f"tilesize={tilesize}")
     return "&".join(parts)

--- a/scripts/run_ingest_register.py
+++ b/scripts/run_ingest_register.py
@@ -27,6 +27,41 @@ import tempfile
 
 log = logging.getLogger(__name__)
 
+# Per-environment S3 buckets and STAC collections are matched pairs: a tile ingested for
+# `staging` must land in BOTH the staging bucket and the staging collection. Crossing them
+# (e.g. the `-tests` bucket with the `-staging` collection) produces an item whose Zarr lives
+# where the gateway/TiTiler won't serve it for that collection -- the 32TLR footgun, where a
+# staging-collection item was written to the local tests bucket and rendered broken. We can only
+# judge consistency when BOTH names are recognized per-env values; ad-hoc names (CI fixtures,
+# one-off buckets, the cross-env `-acquisitions` collection) are unrecognized and pass through.
+_BUCKET_ENV = {
+    "esa-zarr-sentinel-explorer-tests": "test",
+    "esa-zarr-sentinel-explorer-s1-l1grd-staging": "staging",
+    "esa-zarr-sentinel-explorer-s1-l1grd-prod": "prod",
+}
+_COLLECTION_ENV = {
+    "sentinel-1-grd-rtc-tests": "test",
+    "sentinel-1-grd-rtc-staging": "staging",
+    "sentinel-1-grd-rtc-prod": "prod",
+}
+
+
+def check_env_consistency(collection: str, s3_output_bucket: str) -> None:
+    """Reject a collection/bucket pair that mixes environments.
+
+    Raises ``ValueError`` when both names are recognized per-env values but disagree on the
+    environment. Unrecognized names pass through unchecked (their environment is unknown).
+    """
+    bucket_env = _BUCKET_ENV.get(s3_output_bucket)
+    collection_env = _COLLECTION_ENV.get(collection)
+    if bucket_env and collection_env and bucket_env != collection_env:
+        raise ValueError(
+            f"environment mismatch: bucket {s3_output_bucket!r} is '{bucket_env}' but collection "
+            f"{collection!r} is '{collection_env}'. Per-env buckets and collections must match "
+            f"(the 32TLR footgun: a staging item written to the tests bucket renders broken). "
+            f"Use a '{collection_env}' bucket, or the collection matching this bucket's environment."
+        )
+
 
 def run_pipeline(
     s3_geotiff_prefix: str,
@@ -45,6 +80,7 @@ def run_pipeline(
         raise ValueError(
             f"collection must be a non-empty single path segment (no '/'), got: {collection!r}"
         )
+    check_env_consistency(collection, s3_output_bucket)
     s3_zarr = f"s3://{s3_output_bucket}/{collection}/s1-grd-rtc-{tile_id}.zarr"
     # eopf_geozarr uses pathlib.Path internally, which collapses s3:// to s3:/ and
     # writes the zarr to a local directory. Use a local temp path for ingest, then

--- a/scripts/run_s1tiling.py
+++ b/scripts/run_s1tiling.py
@@ -130,8 +130,11 @@ def main() -> None:
     ap.add_argument("--cfg", required=True, type=Path)
     ap.add_argument(
         "--platform-list",
-        default="S1A S1C",
-        help="space-separated S1Tiling platform_list (default: S1A S1C; S1D unsupported)",
+        default="S1A",
+        help="S1Tiling platform_list — run ONE platform at a time (e.g. S1A or S1C). s1tiling 1.4.0's "
+        "multi-platform post-filter is broken (a 'S1A S1C' list yields 0 products), so combined "
+        "lists are unsupported here; the data-driven trigger submits one product (one platform) per "
+        "run anyway. S1D unsupported (#223).",
     )
     ap.add_argument(
         "--keep-output",

--- a/scripts/run_s1tiling.py
+++ b/scripts/run_s1tiling.py
@@ -154,6 +154,15 @@ def main() -> None:
     except ValueError as exc:
         sys.exit(f"Error: {exc}")
 
+    # Fail fast on a multi-platform list: s1tiling 1.4.0's multi-platform post-filter discards
+    # everything (a 'S1A S1C' list yields 0 products), so a combined list silently produces nothing.
+    if len(args.platform_list.split()) != 1:
+        sys.exit(
+            f"Error: --platform-list must be a single platform (got {args.platform_list!r}); "
+            "s1tiling 1.4.0's multi-platform filter discards all products. Run one platform per "
+            "invocation (the data-driven trigger submits one product per run anyway)."
+        )
+
     for p, name in [
         (args.cfg, "--cfg"),
         (args.eodag_cfg, "--eodag-cfg"),

--- a/scripts/watch_cdse_and_process.py
+++ b/scripts/watch_cdse_and_process.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import mgrs
 from pystac_client import Client
+from run_ingest_register import check_env_consistency
 
 log = logging.getLogger(__name__)
 
@@ -215,6 +216,9 @@ def process_product(args: argparse.Namespace, product: dict[str, str], tile: str
 
 def run_watch(args: argparse.Namespace) -> dict[str, int]:
     """Query each tile, run Script A -> B for unseen products, persist state, return run counts."""
+    # Fail fast on a cross-env bucket/collection pair, before the CDSE query or any s1tiling run --
+    # Script B (run_ingest_register) enforces the same invariant, but only after orthorectification.
+    check_env_consistency(args.collection, args.s3_zarr_bucket)
     tiles = [t.strip() for t in args.tiles.split(",") if t.strip()]
     state = load_processed(STATE_FILE)
     counts = {"found": 0, "new": 0, "processed": 0, "failed": 0}

--- a/tests/unit/test_register_v1.py
+++ b/tests/unit/test_register_v1.py
@@ -12,7 +12,13 @@ import requests
 scripts_dir = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(scripts_dir))
 
-from register_v1 import upsert_item  # noqa: E402
+from register_v1 import (  # noqa: E402
+    _render_to_query,
+    _select_render,
+    add_thumbnail_asset,
+    add_visualization_links,
+    upsert_item,
+)
 
 
 def _make_client(item_exists: bool, base_url: str = "https://stac.example.com") -> MagicMock:
@@ -138,3 +144,110 @@ class TestUpsertItemNewItem:
 
         with pytest.raises(requests.HTTPError):
             upsert_item(client, "my-collection", _make_item())
+
+
+# =============================================================================
+# Render-extension visualization
+# =============================================================================
+
+import datetime as _dt  # noqa: E402
+
+from pystac import Asset, Item  # noqa: E402
+
+RASTER_BASE = "https://api.example.com/raster"
+S1_RGB_EXPR = "/descending:vv;/descending:vh;(/descending:vv)/(/descending:vh)"
+
+
+def _real_item(renders: dict | None = None) -> Item:
+    """A real pystac Item with vv/vh assets and an optional renders property."""
+    props: dict = {}
+    if renders is not None:
+        props["renders"] = renders
+    item = Item(
+        id="s1-rtc-31TCH",
+        geometry=None,
+        bbox=None,
+        datetime=_dt.datetime(2026, 6, 7, tzinfo=_dt.UTC),
+        properties=props,
+    )
+    href = "s3://bucket/s1-grd-rtc-31TCH.zarr/descending"
+    for pol in ("vv", "vh"):
+        item.add_asset(pol, Asset(href=href, roles=["data"]))
+    return item
+
+
+def _s1_rgb_renders() -> dict:
+    return {
+        "rgb": {
+            "title": "VV, VH, VV/VH composite",
+            "expression": S1_RGB_EXPR,
+            "rescale": [[0.0, 0.1], [0.0, 0.1], [0.0, 0.1]],
+            "bidx": [1],
+            "tilesize": 256,
+        }
+    }
+
+
+class TestSelectRender:
+    def test_returns_none_without_renders(self):
+        assert _select_render(_real_item()) is None
+
+    def test_prefers_rgb_name(self):
+        renders = {"other": {"expression": "x"}, "rgb": {"expression": "y"}}
+        assert _select_render(_real_item(renders))["expression"] == "y"
+
+    def test_falls_back_to_first_render(self):
+        renders = {"only": {"expression": "z"}}
+        assert _select_render(_real_item(renders))["expression"] == "z"
+
+
+class TestRenderToQuery:
+    def test_collapses_identical_rescale_pairs(self):
+        q = _render_to_query(_s1_rgb_renders()["rgb"], include_tilesize=True)
+        # identical [0,0.1] pairs collapse to a single rescale param
+        assert q.count("rescale=") == 1
+        assert "rescale=0.0%2C0.1" in q
+        assert "bidx=1" in q
+        assert "tilesize=256" in q
+        assert "expression=" in q
+
+    def test_tilesize_excluded_when_requested(self):
+        q = _render_to_query(_s1_rgb_renders()["rgb"], include_tilesize=False)
+        assert "tilesize" not in q
+
+    def test_per_band_rescale_preserved_when_differing(self):
+        render = {"expression": "a;b", "rescale": [[0, 1], [0, 2]]}
+        q = _render_to_query(render, include_tilesize=False)
+        assert q.count("rescale=") == 2
+
+
+class TestVisualizationFromRenders:
+    def test_xyz_and_tilejson_use_render_expression(self):
+        item = _real_item(_s1_rgb_renders())
+        add_visualization_links(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
+
+        xyz = next(link for link in item.links if link.rel == "xyz")
+        tilejson = next(link for link in item.links if link.rel == "tilejson")
+        # render expression is used, NOT the old VH-grayscale rescale=0,219
+        for link in (xyz, tilejson):
+            assert "expression=" in link.href
+            assert "rescale=0%2C219" not in link.href
+            assert "0.1" in link.href
+        assert "/tiles/WebMercatorQuad/{z}/{x}/{y}.png" in xyz.href
+        assert "tilejson.json" in tilejson.href
+
+    def test_thumbnail_uses_render_expression(self):
+        item = _real_item(_s1_rgb_renders())
+        add_thumbnail_asset(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
+
+        thumb = item.assets["thumbnail"]
+        assert "expression=" in thumb.href
+        assert "rescale=0%2C219" not in thumb.href
+        assert "tilesize" not in thumb.href  # not valid on /preview
+        assert thumb.href.startswith(f"{RASTER_BASE}/collections/")
+
+    def test_falls_back_to_mission_default_without_renders(self):
+        item = _real_item()  # no renders property
+        add_thumbnail_asset(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
+        # legacy VH grayscale path still applies when no render config present
+        assert "thumbnail" in item.assets

--- a/tests/unit/test_register_v1.py
+++ b/tests/unit/test_register_v1.py
@@ -181,7 +181,7 @@ def _s1_rgb_renders() -> dict:
         "rgb": {
             "title": "VV, VH, VV/VH composite",
             "expression": S1_RGB_EXPR,
-            "rescale": [[0.0, 0.1], [0.0, 0.1], [0.0, 0.1]],
+            "rescale": [[0.0, 0.1]],
             "bidx": [1],
             "tilesize": 256,
         }
@@ -202,9 +202,8 @@ class TestSelectRender:
 
 
 class TestRenderToQuery:
-    def test_collapses_identical_rescale_pairs(self):
+    def test_serializes_render_fields(self):
         q = _render_to_query(_s1_rgb_renders()["rgb"], include_tilesize=True)
-        # identical [0,0.1] pairs collapse to a single rescale param
         assert q.count("rescale=") == 1
         assert "rescale=0.0%2C0.1" in q
         assert "bidx=1" in q
@@ -215,7 +214,7 @@ class TestRenderToQuery:
         q = _render_to_query(_s1_rgb_renders()["rgb"], include_tilesize=False)
         assert "tilesize" not in q
 
-    def test_per_band_rescale_preserved_when_differing(self):
+    def test_one_rescale_param_per_pair(self):
         render = {"expression": "a;b", "rescale": [[0, 1], [0, 2]]}
         q = _render_to_query(render, include_tilesize=False)
         assert q.count("rescale=") == 2

--- a/tests/unit/test_run_ingest_register.py
+++ b/tests/unit/test_run_ingest_register.py
@@ -11,7 +11,7 @@ import pytest
 scripts_dir = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(scripts_dir))
 
-from run_ingest_register import run_pipeline  # noqa: E402
+from run_ingest_register import check_env_consistency, run_pipeline  # noqa: E402
 
 _MOD = "run_ingest_register"
 
@@ -163,6 +163,51 @@ def test_upload_failure_stops_pipeline() -> None:
         result = run_pipeline(**_KWARGS)
     assert result == 1
     assert mock_run.call_count == 2  # ingest + failed upload; no register
+
+
+def test_env_mismatch_rejected_before_any_subprocess() -> None:
+    """A staging collection paired with the tests bucket is the 32TLR footgun -> reject early.
+
+    The guard must fire before ingest, so no Zarr is written and no API is touched.
+    """
+    kwargs = {
+        **_KWARGS,
+        "collection": "sentinel-1-grd-rtc-staging",
+        "s3_output_bucket": "esa-zarr-sentinel-explorer-tests",
+    }
+    with patch(f"{_MOD}.subprocess.run") as mock_run, pytest.raises(ValueError, match="mismatch"):
+        run_pipeline(**kwargs)
+    mock_run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("collection", "bucket"),
+    [
+        ("sentinel-1-grd-rtc-staging", "esa-zarr-sentinel-explorer-s1-l1grd-staging"),
+        ("sentinel-1-grd-rtc-tests", "esa-zarr-sentinel-explorer-tests"),
+        ("sentinel-1-grd-rtc-prod", "esa-zarr-sentinel-explorer-s1-l1grd-prod"),
+    ],
+)
+def test_matched_env_pairs_allowed(collection: str, bucket: str) -> None:
+    """Matching per-env bucket/collection pairs run the full pipeline (4 subprocesses)."""
+    kwargs = {**_KWARGS, "collection": collection, "s3_output_bucket": bucket}
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
+        assert run_pipeline(**kwargs) == 0
+    assert mock_run.call_count == 4
+
+
+@pytest.mark.parametrize(
+    ("collection", "bucket"),
+    [
+        # Unrecognized bucket: env unknown -> can't judge -> allowed (existing _KWARGS case).
+        ("sentinel-1-grd-rtc-staging", "my-bucket"),
+        # Unrecognized collection (e.g. the cross-env -acquisitions collection) -> allowed.
+        ("sentinel-1-grd-rtc-acquisitions", "esa-zarr-sentinel-explorer-tests"),
+    ],
+)
+def test_unrecognized_names_pass_through(collection: str, bucket: str) -> None:
+    """When either name isn't a known per-env value, the guard can't infer env and stays out."""
+    check_env_consistency(collection, bucket)  # must not raise
 
 
 def test_local_zarr_cleaned_before_ingest() -> None:

--- a/tests/unit/test_run_s1tiling.py
+++ b/tests/unit/test_run_s1tiling.py
@@ -587,3 +587,15 @@ def test_dry_run_s3_sync_uses_aws_profile_when_given(tmp_path):
     out = _dry_run(tmp_path, ["--aws-profile", "myprof"]).stdout
     assert "--profile" in out
     assert "myprof" in out
+
+
+def test_multi_platform_list_rejected(tmp_path):
+    """A combined platform list silently yields 0 products on s1tiling 1.4.0 -> fail fast."""
+    result = _dry_run(tmp_path, ["--platform-list", "S1A S1C"])
+    assert result.returncode != 0
+    assert "single platform" in (result.stderr + result.stdout)
+
+
+def test_single_platform_list_accepted(tmp_path):
+    """A single platform passes the guard (dry-run reaches normal exit 0)."""
+    assert _dry_run(tmp_path, ["--platform-list", "S1C"]).returncode == 0

--- a/tests/unit/test_run_s1tiling.py
+++ b/tests/unit/test_run_s1tiling.py
@@ -202,7 +202,7 @@ def _render(tmp_path: Path, **kwargs) -> str:
         kwargs.get("orbit_direction", "ascending"),
         kwargs.get("date_start", "2026-06-04"),
         kwargs.get("date_end", "2026-06-06"),
-        kwargs.get("platform_list", "S1A S1C"),
+        kwargs.get("platform_list", "S1A"),
     )
     return dst.read_text()
 
@@ -229,15 +229,17 @@ def test_render_cfg_descending_maps_to_des(tmp_path):
 
 
 def test_render_cfg_injects_platform(tmp_path):
-    """platform_list is now run-specific (T2): default S1A S1C, overwriting the base cfg value."""
+    """platform_list is run-specific (T2); default is a single platform (S1A) — s1tiling 1.4.0's
+    multi-platform filter is broken, so platforms are run one at a time."""
     out = _render(tmp_path)
-    assert "platform_list : S1A S1C" in out
+    assert "platform_list : S1A" in out
 
 
 def test_render_cfg_platform_list_configurable(tmp_path):
-    out = _render(tmp_path, platform_list="S1A")
-    assert "platform_list : S1A" in out
-    assert "platform_list : S1A S1C" not in out
+    """A different single platform (e.g. S1C) renders too — the way S1C is processed (one per run)."""
+    out = _render(tmp_path, platform_list="S1C")
+    assert "platform_list : S1C" in out
+    assert "platform_list : S1A" not in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_watch_cdse_and_process.py
+++ b/tests/unit/test_watch_cdse_and_process.py
@@ -346,3 +346,17 @@ def test_run_watch_counts_failures_and_does_not_persist_them(tmp_path: Path) -> 
     state = load_processed(state_file)
     assert is_processed(state, "31TCH", "descending", "ok")
     assert not is_processed(state, "31TCH", "descending", "boom")
+
+
+def test_run_watch_rejects_env_mismatch_before_querying_cdse() -> None:
+    """A cross-env bucket/collection pair fails fast -- before any CDSE query or s1tiling run."""
+    args = _args(
+        collection="sentinel-1-grd-rtc-staging",
+        s3_zarr_bucket="esa-zarr-sentinel-explorer-tests",
+    )
+    with (
+        patch(f"{_MOD}.query_cdse") as mock_query,
+        pytest.raises(ValueError, match="mismatch"),
+    ):
+        run_watch(args)
+    mock_query.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.1" },
     { name = "click", specifier = "==8.3.3" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=9231a5c372953e2ce55823f169ef4fbfebf4e196" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=0b45dea2aa8c2d447f39a93a7c2ee77b456324c3" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mgrs", specifier = "==1.5.4" },
     { name = "morecantile", specifier = "==7.0.3" },
@@ -954,7 +954,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.0"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=9231a5c372953e2ce55823f169ef4fbfebf4e196#9231a5c372953e2ce55823f169ef4fbfebf4e196" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=0b45dea2aa8c2d447f39a93a7c2ee77b456324c3#0b45dea2aa8c2d447f39a93a7c2ee77b456324c3" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
Bundles the s1tiling single-platform fix (original scope) with the S1 RTC **render-extension + env-guard** work surfaced while debugging why `s1-rtc-32TLR` rendered broken while `31TCH` did not.

---

## 1. s1tiling single-platform default (original scope)
Surfaced by the 32TLR **S1C** e2e (tracker #226).

**Finding:** `s1tiling 1.4.0`'s multi-platform post-filter drops everything: `--platform-list "S1A S1C"` → **0 products**. eodag returns the frames, then the joined `S1A|S1C` filter matches against the full STAC name (`sentinel-1c`) so the short-code regex never matches. **Single-platform works** (verified live).

**Fix:** default `--platform-list` to **`S1A`** (single) + a hard guard that rejects a multi-value list with a clear error (`run_s1tiling.py`). Per-product submission (T6) runs one platform per run, so the cluster path is unaffected.

## 2. Bucket/collection env-mismatch guard + data-model pin bump
**Root cause of the 32TLR breakage (part 1):** the staging-collection item was registered with its Zarr in the **tests** bucket (`esa-zarr-sentinel-explorer-tests`) instead of the staging bucket — a hand-typed `--s3-output-bucket`/`--collection` mismatch that nothing caught.

- `check_env_consistency()` in `run_ingest_register.py` rejects a per-env bucket paired with a different-env collection, **before any subprocess**; mirrored early in `watch_cdse_and_process.py` (fails before the CDSE query / s1tiling run). Unrecognized names pass through.
- Bump `eopf-geozarr` pin `9231a5c → 0b45dea` so the builder emits the `render` extension (`renders.rgb` = VV/VH/VV-VH RGB, `rescale 0,0.1`).

## 3. Honor the STAC render extension for S1 viz links (merge of `feat/s1-render-extension-preview`)
**Root cause of the 32TLR breakage (part 2):** `register_v1.py` hardcoded the S1 `xyz`/`tilejson`/`thumbnail` links as single-band VH `rescale=0,219` and ignored `renders.rgb` — so even with the new builder, registered items previewed via the broken VH links.

- Merges `_render_to_query`, which builds the S1 visualization links from `properties.renders.rgb` (VV/VH/VV-VH RGB, `rescale 0,0.1`), with the VH form only as a fallback. Pairs with the pin bump in §2.

## Tests
`uv run pytest tests/unit` — **413 passed** (incl. `test_run_s1tiling.py`, `test_run_ingest_register.py` env-guard cases, and the merged `test_register_v1.py` `_render_to_query` cases).

## Note on 32TLR rendering (not fixed by code)
Even with all three fixes, 32TLR still previews broken in the browser because the deployed prod `/raster` TiTiler resolves the store from a hardcoded base (`fra/tests-output/{item_id}.zarr`), **not** the STAC href (titiler-eopf#108). The 32TLR store + STAC item are fully prepped to render once #108 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)