### PR TITLE
fix(s1-register): guard env mismatch on the standalone register path

### DIFF
--- a/scripts/register_v1_s1_rtc.py
+++ b/scripts/register_v1_s1_rtc.py
@@ -15,6 +15,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -29,6 +30,7 @@ from register_v1 import (
     upsert_item,
     warm_thumbnail_cache,
 )
+from run_ingest_register import check_env_consistency
 
 log = logging.getLogger(__name__)
 
@@ -44,6 +46,13 @@ def register(
 
     Returns exit code: 0 = success, 1 = failure.
     """
+    # Fail fast on a per-env bucket/collection mismatch (the 32TLR footgun): the standalone
+    # register path takes a hand-typed --store + --collection, so it needs the same guard as
+    # run_ingest_register. Only s3:// stores carry an identifiable bucket in the netloc.
+    parsed = urlparse(store)
+    if parsed.scheme == "s3":
+        check_env_consistency(collection, parsed.netloc)
+
     try:
         item = build_s1_rtc_stac_item(store, collection)
     except Exception:

--- a/tests/unit/test_register_v1_s1_rtc.py
+++ b/tests/unit/test_register_v1_s1_rtc.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pystac
+import pytest
 
 scripts_dir = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(scripts_dir))
@@ -156,3 +157,50 @@ def test_exits_nonzero_on_bad_store() -> None:
 
     assert result != 0
     mock_upsert.assert_not_called()
+
+
+def test_env_mismatch_rejected_before_build() -> None:
+    """A staging collection paired with a tests-bucket store is the 32TLR footgun on the
+    standalone register path -> reject before building or upserting anything."""
+    bad_store = (
+        "s3://esa-zarr-sentinel-explorer-tests/sentinel-1-grd-rtc-staging/s1-grd-rtc-31TCH.zarr"
+    )
+    with (
+        patch(f"{_MOD}.build_s1_rtc_stac_item") as mock_build,
+        patch(f"{_MOD}.upsert_item") as mock_upsert,
+        pytest.raises(ValueError, match="mismatch"),
+    ):
+        register(
+            bad_store,
+            "sentinel-1-grd-rtc-staging",
+            "https://stac.example.com",
+            "https://raster.example.com",
+            "https://s3.example.com",
+        )
+
+    mock_build.assert_not_called()
+    mock_upsert.assert_not_called()
+
+
+def test_matched_env_store_allowed() -> None:
+    """A staging-bucket store + staging collection passes the guard and registers normally."""
+    good_store = (
+        "s3://esa-zarr-sentinel-explorer-s1-l1grd-staging/"
+        "sentinel-1-grd-rtc-staging/s1-grd-rtc-31TCH.zarr"
+    )
+    with (
+        patch(f"{_MOD}.build_s1_rtc_stac_item", return_value=_make_item()),
+        patch(f"{_MOD}.warm_thumbnail_cache"),
+        patch(f"{_MOD}.upsert_item") as mock_upsert,
+        patch(f"{_MOD}.Client"),
+    ):
+        result = register(
+            good_store,
+            "sentinel-1-grd-rtc-staging",
+            "https://stac.example.com",
+            "https://raster.example.com",
+            "https://s3.example.com",
+        )
+
+    assert result == 0
+    mock_upsert.assert_called_once()


### PR DESCRIPTION
## Why
`run_ingest_register` and `watch_cdse_and_process` already reject a per-env **bucket** paired with a different-env **collection** (via `check_env_consistency`). But `register_v1_s1_rtc.py` can be invoked **directly** with a hand-typed `--store` + `--collection` — and that's exactly how `s1-rtc-32TLR` ended up registered into the `sentinel-1-grd-rtc-staging` collection with its Zarr in the **tests** bucket. The guard had a hole on the path that caused the incident.

## What
- Extract the bucket from the `s3://` `--store` URI and call the existing `check_env_consistency(collection, bucket)` at the top of `register()`, **before** building the item or touching the STAC API — fail fast.
- Reuses the shared guard (no new env maps) via the same import pattern `watch_cdse_and_process` already uses.

## Scope (deliberate)
- **Only `register_v1_s1_rtc.py`.** `register_per_acquisition.py` is untouched: its collection (`…-acquisitions`) is cross-env and unrecognized by the env maps, so the guard would be a no-op there.
- Non-`s3://` stores (no identifiable bucket) and unrecognized bucket/collection names pass through unchecked — same semantics as the existing guard.

## Tests
- `test_env_mismatch_rejected_before_build` (adversarial): tests-bucket store + staging collection → raises before `build_s1_rtc_stac_item`/`upsert_item`.
- `test_matched_env_store_allowed`: staging-bucket store + staging collection registers normally.
- Full unit suite: **415 passed**. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)