### PR TITLE
chore(deps): bump data-model pin 0b45dea -> 8c8ee81 (s1-tiling merged into #180)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.1",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@0b45dea2aa8c2d447f39a93a7c2ee77b456324c3",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@8c8ee8142b90fd98e0f8f8deea31148d40b729ed",
     "requests==2.34.1",
     "mgrs==1.5.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.1" },
     { name = "click", specifier = "==8.3.3" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=0b45dea2aa8c2d447f39a93a7c2ee77b456324c3" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=8c8ee8142b90fd98e0f8f8deea31148d40b729ed" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mgrs", specifier = "==1.5.4" },
     { name = "morecantile", specifier = "==7.0.3" },
@@ -954,7 +954,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.0"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=0b45dea2aa8c2d447f39a93a7c2ee77b456324c3#0b45dea2aa8c2d447f39a93a7c2ee77b456324c3" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=8c8ee8142b90fd98e0f8f8deea31148d40b729ed#8c8ee8142b90fd98e0f8f8deea31148d40b729ed" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
Advances the `eopf-geozarr` SHA pin to the current tip of `feat/s1-rtc-stac-builder` (data-model PR #180), which now has **s1-tiling merged in** — i.e. **#184** (multi-frame masked-timestamp discovery, `discover_s1tiling_acquisitions`) plus the latest integration state.

- Still a **SHA pin** (per the hold until #226 lands), just newer — `0b45dea → 8c8ee81`.
- `uv.lock` relocked to the new rev.
- Verified the new rev still exposes `build_s1_rtc_stac_item` + the render extension (`_rgb_render` → `rescale [[0.0, 0.1]]`); register unit tests pass.

Follow-up (separate, to be planned): now that #184's durable fix is in the pinned data-model, the temporary masked-name workaround from #237 in `ingest_all` can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)