### PR TITLE
refactor(s1-ingest): remove the #237 masked-name workaround (durable fix upstream)

### DIFF
--- a/claude-docs/plans/remove_237_masked_name_workaround.md
+++ b/claude-docs/plans/remove_237_masked_name_workaround.md
@@ -1,0 +1,79 @@
+# Plan: Remove the #237 masked-name workaround (F1)
+
+> Convention note: project plans live here (`claude-docs/plans/`), not `tasks/plan.md` (which is a
+> pointer for sub-issue 10). Task checklist is embedded below rather than overwriting `tasks/todo.md`.
+
+## Goal
+Delete data-pipeline's `_normalize_masked_stamps` workaround now that the durable upstream fix
+(data-model #184, pinned via #240 at rev `8c8ee81`) makes `discover_s1tiling_acquisitions` resolve
+the masked `…txxxxxx` multi-frame timestamp itself — and verify multi-frame ingest still works.
+
+## Background
+- **Workaround** (`scripts/ingest_v1_s1_rtc.py`): `_normalize_masked_stamps(prefix)` is Step 0 of
+  `ingest_all`. It globs `*txxxxxx*GammaNaughtRTC.tif`, reads `ACQUISITION_DATETIME`, and **renames
+  the files on disk** (data + `_BorderMask`) so the old filename regex could parse them. No-op on `s3://`.
+- **Durable fix** (data-model #184): the filename regex accepts a masked time, and `discover` resolves
+  the real `acq_stamp` from the `ACQUISITION_DATETIME` tag in-memory (`_acq_stamp_from_geotiff`).
+  Works for both local and `s3://` (via `_list_tifs`).
+
+## Why removal is safe (correctness argument)
+- The cube's `time` is written from the GeoTIFF `ACQUISITION_DATETIME` tag (`np.datetime64(tag)`), and
+  `acq_stamp` now comes from discover's resolved value — **neither depends on the filename time**. The
+  on-disk rename is redundant; masked filenames are fine for reading.
+- **Bonus:** removal + #184's s3fs-aware discover means masked `s3://` inputs now work too — the
+  workaround silently no-op'd on `s3://`.
+
+## Dependency graph / ordering
+1. **#240 (pin bump → `8c8ee81`) must merge into `feat--s1_grd_phase6` first.** Removing the workaround
+   before the pinned data-model resolves masked stamps would break multi-frame ingest.
+2. Then the removal is a single vertical slice in `scripts/ingest_v1_s1_rtc.py` + its tests.
+
+## Tasks
+
+### T1 — Gate: pinned data-model resolves masked stamps  ⟦CP-A⟧
+- Precondition: #240 merged (or branch synced to the `8c8ee81` pin).
+- Verify: `discover_s1tiling_acquisitions` on a masked local fixture returns one acquisition with
+  `acq_stamp` resolved from the tag (upstream `test_resolves_masked_multiframe_stamp_from_tag` covers
+  this; confirm it runs against the pinned rev).
+- Done when: import + discover smoke passes on the pinned data-model.
+
+### T2 — Remove the workaround
+- Delete `_normalize_masked_stamps`; remove the Step 0 call in `ingest_all`; drop the now-orphan
+  `extract_geotiff_metadata` import (used only by the workaround in this file); renumber step comments.
+- Verify: `ruff` + `mypy` clean; no remaining `_normalize_masked_stamps` / `extract_geotiff_metadata`
+  references in `ingest_v1_s1_rtc.py`.
+
+### T3 — Tests: remove workaround tests, add regression guard  ⟦CP-B⟧
+- Remove the 3 `test_normalize_masked_stamps_*` tests in `tests/unit/test_ingest_v1_s1_rtc.py`.
+- Add a regression test: a masked-stamp local fixture flows through `ingest_all` (or at least
+  `discover_s1tiling_acquisitions`) and yields a complete acquisition with the resolved `acq_stamp` —
+  proving the path works **without** the rename.
+- Verify: full `uv run pytest tests/unit` green.
+
+### T4 — End-to-end verification (real multi-frame tile)  ⟦CP-C⟧
+- On a multi-frame tile (e.g. 32TLR), run the ingest path against real GeoTIFFs and confirm `discover`
+  count > 0 and the cube gains the expected `time` slice(s). Needs creds/data — run manually / in the
+  e2e harness, not CI.
+
+### T5 — PR
+- Open PR → `feat--s1_grd_phase6`, referencing #184 (fix), #240 (pin), #237 (workaround retired); note
+  the `s3://` masked-input improvement.
+
+## Checkpoints
+- **CP-A** (after T1, before T2): do not remove until #240 is merged and masked-stamp discover is
+  confirmed on the pinned version.
+- **CP-B** (after T3): unit suite green → safe to open the PR.
+- **CP-C** (after T4): real multi-frame ingest confirmed before the pipeline relies on the removal.
+
+## Risks
+- **Ordering** — removing before #240 merges breaks masked ingest (mitigated by CP-A).
+- **Behavior parity** — anything downstream re-parsing the filename for time would break with masked
+  names; argued safe (time comes from the tag), T3 guards it.
+- **s3:// path** — previously untested for masked stamps; T4 ideally exercises a real prefix.
+
+## Checklist
+- [ ] T1 — confirm pinned data-model resolves masked stamps (gate on #240)  ⟦CP-A⟧
+- [ ] T2 — remove `_normalize_masked_stamps` + Step 0 call + orphan import
+- [ ] T3 — drop 3 workaround tests, add regression guard; unit suite green  ⟦CP-B⟧
+- [ ] T4 — real multi-frame ingest verified (32TLR)  ⟦CP-C⟧
+- [ ] T5 — PR → `feat--s1_grd_phase6` (refs #184 / #240 / #237)

--- a/scripts/ingest_v1_s1_rtc.py
+++ b/scripts/ingest_v1_s1_rtc.py
@@ -24,7 +24,6 @@ from eopf_geozarr.conversion.s1_ingest import (
     consolidate_s1_store,
     discover_s1tiling_acquisitions,
     discover_s1tiling_conditions,
-    extract_geotiff_metadata,
     ingest_s1tiling_acquisition,
     ingest_s1tiling_conditions,
 )
@@ -114,34 +113,6 @@ def new_acquisitions(acquisitions: list[dict], present_ns: set[int]) -> list[dic
     return [a for a in acquisitions if acq_time_ns(a["acq_stamp"]) not in present_ns]
 
 
-def _normalize_masked_stamps(geotiff_prefix: str) -> int:
-    """Rename s1tiling daily-concatenated products whose time is masked (``…txxxxxx…``) using the
-    real ``ACQUISITION_DATETIME`` GeoTIFF tag, so ``discover_s1tiling_acquisitions`` can parse them.
-
-    A pass spanning two frames is concatenated into a *daily* product whose filename masks the time
-    as ``txxxxxx``; eopf_geozarr's filename regex requires ``\\d{6}`` and would otherwise skip it
-    (F1). Each ``GammaNaughtRTC`` data file is renamed with the tag's HH:MM:SS, and its companion
-    ``_BorderMask`` in lockstep. No-op on a non-local prefix (e.g. ``s3://``) — the durable fix is
-    upstream in eopf_geozarr's discover/parse. Returns the number of data files normalized.
-    """
-    base = Path(geotiff_prefix)
-    if not base.is_dir():
-        return 0
-    renamed = 0
-    for data in sorted(base.glob("*txxxxxx*GammaNaughtRTC.tif")):
-        hhmmss = extract_geotiff_metadata(data).datetime.split("T")[1].replace(":", "")[:6]
-        mask = data.with_name(
-            data.name.replace("GammaNaughtRTC.tif", "GammaNaughtRTC_BorderMask.tif")
-        )
-        for f in (data, mask):
-            if f.exists():
-                f.rename(f.with_name(f.name.replace("txxxxxx", f"t{hhmmss}")))
-        renamed += 1
-    if renamed:
-        log.info("Normalized %d masked daily-product stamp(s) in %s (F1)", renamed, geotiff_prefix)
-    return renamed
-
-
 def ingest_all(s3_geotiff_prefix: str, store_path: str, orbit_direction: str) -> int:
     """Run the 5-step S1 ingest pipeline, appending new acquisitions to the per-tile cube.
 
@@ -151,10 +122,8 @@ def ingest_all(s3_geotiff_prefix: str, store_path: str, orbit_direction: str) ->
 
     Returns exit code: 0 = success (or nothing new to ingest), 1 = ingest error, 2 = no acquisitions.
     """
-    # Step 0 -- normalize masked daily-product stamps so discover can parse multi-frame passes (F1)
-    _normalize_masked_stamps(s3_geotiff_prefix)
-
-    # Step 1 -- discover acquisitions
+    # Step 1 -- discover acquisitions (multi-frame masked stamps are resolved upstream in
+    # eopf_geozarr's discover from the ACQUISITION_DATETIME tag; data-model #184)
     acquisitions = discover_s1tiling_acquisitions(s3_geotiff_prefix)
     if not acquisitions:
         log.warning("No acquisitions found in %s", s3_geotiff_prefix)

--- a/tests/unit/test_ingest_v1_s1_rtc.py
+++ b/tests/unit/test_ingest_v1_s1_rtc.py
@@ -391,48 +391,51 @@ def test_drop_consolidated_metadata_enables_resize(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# F1 -- normalize multi-frame "daily" products whose time is masked (…txxxxxx…)
+# F1 -- multi-frame "daily" products whose time is masked (…txxxxxx…) are resolved upstream
+# (data-model #184); the local _normalize_masked_stamps workaround (#237) has been removed.
 # ---------------------------------------------------------------------------
 
 
-def test_normalize_masked_stamps_renames_via_tag(tmp_path, monkeypatch) -> None:
-    """A concatenated daily product (…txxxxxx…) is renamed using the GeoTIFF ACQUISITION_DATETIME
-    tag so discover_s1tiling_acquisitions can parse it; its BorderMask is renamed in lockstep."""
-    from types import SimpleNamespace
-
-    import ingest_v1_s1_rtc as m
-
-    d = tmp_path / "out"
-    d.mkdir()
-    data = d / "s1a_32TLR_vv_DES_139_20260602txxxxxx_GammaNaughtRTC.tif"
-    mask = d / "s1a_32TLR_vv_DES_139_20260602txxxxxx_GammaNaughtRTC_BorderMask.tif"
-    data.write_text("x")
-    mask.write_text("x")
-    monkeypatch.setattr(
-        m, "extract_geotiff_metadata", lambda p: SimpleNamespace(datetime="2026-06-02T05:43:23")
-    )
-
-    assert m._normalize_masked_stamps(str(d)) == 1
-    assert (d / "s1a_32TLR_vv_DES_139_20260602t054323_GammaNaughtRTC.tif").exists()
-    assert (d / "s1a_32TLR_vv_DES_139_20260602t054323_GammaNaughtRTC_BorderMask.tif").exists()
-    assert not data.exists() and not mask.exists()
-
-
-def test_normalize_masked_stamps_noop_when_unmasked(tmp_path, monkeypatch) -> None:
-    """Already-real stamps (single-frame tiles like 31TCH) are untouched."""
-    import ingest_v1_s1_rtc as m
+def test_discover_resolves_masked_multiframe_stamp(tmp_path: Path) -> None:
+    """Durable fix (data-model #184, pinned) resolves multi-frame masked stamps with no on-disk
+    rename: discover_s1tiling_acquisitions parses a '…txxxxxx' product and derives acq_stamp from
+    the GeoTIFF ACQUISITION_DATETIME tag. This is the safety net for removing _normalize_masked_stamps
+    (#237) -- green on the pinned data-model, red on any pin predating #184."""
+    import numpy as np
+    import rasterio
+    from eopf_geozarr.conversion.s1_ingest import discover_s1tiling_acquisitions
+    from rasterio.transform import from_bounds
 
     d = tmp_path / "out"
     d.mkdir()
-    (d / "s1a_31TCH_vv_DES_037_20230115t061234_GammaNaughtRTC.tif").write_text("x")
-    called = []
-    monkeypatch.setattr(m, "extract_geotiff_metadata", lambda p: called.append(p))
-    assert m._normalize_masked_stamps(str(d)) == 0
-    assert called == []  # no tag reads when nothing is masked
+    transform = from_bounds(500000.0, 4997440.0, 502560.0, 5000000.0, 16, 16)
+    tags = {
+        "ACQUISITION_DATETIME": "2026:06:02T05:43:23Z",
+        "ORBIT_NUMBER": "12345",
+        "RELATIVE_ORBIT_NUMBER": "139",
+        "FLYING_UNIT_CODE": "S1A",
+    }
+    for pol in ("vv", "vh"):
+        base = f"s1a_32TLR_{pol}_DES_139_20260602txxxxxx_GammaNaughtRTC"
+        for name in (f"{base}.tif", f"{base}_BorderMask.tif"):
+            with rasterio.open(
+                d / name,
+                "w",
+                driver="GTiff",
+                height=16,
+                width=16,
+                count=1,
+                dtype="float32",
+                crs="EPSG:32632",
+                transform=transform,
+            ) as dst:
+                dst.update_tags(**tags)
+                dst.write(np.ones((16, 16), dtype="float32"), 1)
 
+    acqs = discover_s1tiling_acquisitions(str(d))
 
-def test_normalize_masked_stamps_noop_on_non_local_prefix() -> None:
-    """An s3:// prefix can't be renamed locally -> no-op (durable fix is upstream)."""
-    import ingest_v1_s1_rtc as m
-
-    assert m._normalize_masked_stamps("s3://bucket/s1tiling-output/32TLR") == 0
+    assert len(acqs) == 1
+    # ACQUISITION_DATETIME "2026:06:02T05:43:23Z" -> resolved stamp (no rename)
+    assert acqs[0]["acq_stamp"] == "20260602t054323"
+    for k in ("vv", "vh", "vv_mask", "vh_mask"):
+        assert k in acqs[0]


### PR DESCRIPTION
Now that the durable upstream fix (data-model #184) is pinned via #240 (`8c8ee81`), the local masked-name workaround can go.

## What
- Remove `_normalize_masked_stamps` from `scripts/ingest_v1_s1_rtc.py` — it renamed multi-frame `…txxxxxx` GeoTIFFs on disk (from the `ACQUISITION_DATETIME` tag) before discovery so the old filename regex could parse them.
- Remove its Step 0 call in `ingest_all` and the now-orphan `extract_geotiff_metadata` import.
- Replace the 3 `_normalize_masked_stamps` unit tests with one **integration guard** (`test_discover_resolves_masked_multiframe_stamp`): builds a real masked-stamp GeoTIFF + tag and asserts the **pinned** `discover_s1tiling_acquisitions` resolves `acq_stamp` from the tag with **no rename**.

## Why it's safe
- The cube's `time` and `acq_stamp` both derive from the `ACQUISITION_DATETIME` tag, not the filename — the on-disk rename was redundant.
- The new guard is **green on the pinned `8c8ee81`**, **red on any pin predating #184** — it fails loudly if the pin regresses.
- Bonus: masked `s3://` inputs now work too (the workaround silently no-op'd on `s3://`).

## Tests
Full `tests/unit`: **413 passed**. ruff clean; the 3 mypy errors in `_patch_cf_grid_mapping` are pre-existing.

Plan: `claude-docs/plans/remove_237_masked_name_workaround.md`. T4 (real multi-frame e2e on 32TLR) left to run manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)