### PR TITLE
feat(s1-phase6): CDSE data-driven trigger entrypoint (T6 in-repo half)

### DIFF
--- a/claude-docs/plans/s1_grd_phase6_productionization.md
+++ b/claude-docs/plans/s1_grd_phase6_productionization.md
@@ -28,8 +28,8 @@ per-tile cube writes; tests at each new-code boundary; **staging only** (prod = 
 | `scripts/validate_s1_rtc.py` quality-gate CLI (T1) | ✅ shipped (#229); unit-tested + **verified tile-agnostic** on 31TDH; Argo step pending |
 | `scripts/register_per_acquisition.py` per-acq register (T5) | ✅ shipped (#229); unit-tested + live (31TCH ×2 items); P-3 multi-time notebook pending |
 | titiler store resolution | ⚠️ reconstructs + ignores href (Spike 3); explorer rendering **deferred (#228)** — not a phase blocker (validation is via notebook) |
-| Local watcher query/bbox/dedup logic | ✅ port; dedup → per-acquisition STAC item-exists (T6) |
-| Blind daily cron + sensor (sub-issue 8) | ✅ shipped, suspended — replaced by the data-driven trigger (T6) |
+| Local watcher query/bbox/dedup logic | ✅ ported to `scripts/trigger_cdse.py` (T6): query→{S1A,S1C}→per-acq item-exists dedup→emit JSON; 24 tests. CronWorkflow + cluster pending |
+| Blind daily cron + sensor (sub-issue 8) | ✅ shipped, suspended — replaced by the data-driven trigger (T6 in-repo done; retire on cluster) |
 
 ---
 
@@ -160,17 +160,34 @@ the items now so they render later when option 2 lands, with **no data change**.
 > wiring): `ensure_dem.py` → `run_s1tiling.py` → ingest → `validate_s1_rtc.py` → `register_per_acquisition.py`
 > on a chosen tile (tile choice = OQ #1).
 
-### Task 6 — Port the CDSE watcher to an Argo CronWorkflow (data-driven trigger)  <status: blocked by 1–5>
+### Task 6 — Port the CDSE watcher to an Argo CronWorkflow (data-driven trigger)  <status: in-repo trigger shipped; CronWorkflow + cluster pending>
 **What**: trigger entrypoint (reuse `tile_bbox`/`query_cdse`) queries CDSE for a tile+window, filters
 platform to {S1A,S1C} (**skips S1D**, logged), and emits **new** products — dedup = **per-acquisition
 STAC item-exists** + cube time-present (P2). CronWorkflow (**6 h**) submits one child Workflow per new
 product (decision B), **replacing** the suspended blind cron.
-**Verify**: `uv run pytest tests/unit/test_trigger.py` (query→dedup, mocked STAC); cluster: data-bearing window submits only new products; no-data → nothing; re-run → 0.
+*(In-repo impl `scripts/trigger_cdse.py` — see plan `claude-docs/plans/subissue_T6_trigger.md`. The
+two P2 dedup arms are **split across components** per spec §5/P2: the *trigger* does the
+per-acquisition **STAC item-exists** check; the **cube-time-present** arm is already shipped in T4
+(`new_acquisitions`) and runs downstream in ingest — so the trigger stays off S3. The trigger is a
+pure query→filter→dedup→**emit JSON array**; the CronWorkflow's `withParam` does the child-Workflow
+fan-out, so "submits" = "emits a product record".)*
+**Verify**: `uv run pytest tests/unit/test_trigger_cdse.py` (query→dedup, mocked STAC); cluster: data-bearing window submits only new products; no-data → nothing; re-run → 0.
 **Acceptance**:
-- [ ] Submits only for acquisitions with no existing per-acquisition item (dedup), unit-tested
-- [ ] No-data window → 0 submissions; re-run → 0 (idempotent)
-- [ ] S1D filtered at query time (logged), no child Workflow
-- [ ] Suspended sub-issue-8 cron retired (one trigger of record)
+- [x] Submits only for acquisitions with no existing per-acquisition item (dedup), unit-tested —
+      `select_new_products` emits only products whose `expected_item_id` (= `acquisition_id`,
+      `s1-rtc-{tile}-{stamp}`) is absent from `sentinel-1-grd-rtc-acquisitions`
+      (`test_select_emits_only_unregistered_products`; 24 tests in `test_trigger_cdse.py`, all green;
+      full suite 500 passed). 2026-06-10.
+- [x] No-data window → 0 submissions; re-run → 0 (idempotent) — `test_select_empty_query_returns_empty`
+      + `test_select_all_registered_returns_empty_idempotent` (all-registered → `[]`) *(unit; cluster
+      re-run → 0 pending)*
+- [x] S1D filtered at query time (logged), no child Workflow — allowlist `ENABLED_PLATFORMS={S1A,S1C}`;
+      S1D dropped **before** the dedup call (`test_select_skips_s1d_at_query_time_no_dedup_call`:
+      asserts the S1D product is absent from the emit and `item_exists` is consulted only for the
+      enabled platform) *(cluster: no child Workflow — pending)*
+- [ ] Suspended sub-issue-8 cron retired (one trigger of record) *(platform-deploy / cluster — pending)*
+- [ ] CronWorkflow (6 h) runs `trigger_cdse.py` + `withParam` child-Workflow fan-out (decision B);
+      **CDSE↔cube `datetime` parity** ground-truthed (OQ-T6-1) *(platform-deploy / cluster — pending)*
 
 ### Task 7 — Multi-tile AOI iteration  <status: blocked by 3,6; OQ #1>
 **What**: CronWorkflow iterates the configured AOI; each tile self-provisions DEM (T3), accumulates its

--- a/claude-docs/plans/subissue_T6_trigger.md
+++ b/claude-docs/plans/subissue_T6_trigger.md
@@ -1,0 +1,171 @@
+# Plan: T6 — CDSE data-driven trigger (in-repo entrypoint) (`claude-docs/specs/s1_grd_phase6_productionization.md` · plan Task 6)
+
+**Goal**: ship the **in-repo trigger entrypoint** for Phase-6 Task 6 — query CDSE for a tile+window,
+keep only **{S1A, S1C}** (skip S1D, logged), drop acquisitions whose **per-acquisition STAC item
+already exists**, and **emit the remaining new products as JSON** for the CronWorkflow to fan out
+child Workflows over (decision B). Pure query→filter→dedup→emit; **no subprocess, no S3, no submit**.
+**Constraint**: reuse `tile_bbox` + the CDSE query path and `acquisition_id`; leave
+`watch_cdse_and_process.py` (the local stand-in) untouched; new code only; TDD at each boundary;
+staging-only.
+
+> **Repo split (mirrors T1–T5).** The *in-repo* deliverable is `scripts/trigger.py` +
+> `tests/unit/test_trigger.py`. The **CronWorkflow manifest (6 h), the `withParam` child-Workflow
+> fan-out (decision B), and retiring the suspended sub-issue-8 cron** ship in **platform-deploy** and
+> are verified on-cluster — tracked here as the "(cluster — pending)" tail of Task 6's acceptance,
+> not built in this repo.
+
+---
+
+## Current state
+
+| Resource | Status |
+|----------|--------|
+| `tile_bbox`, `query_cdse` (`watch_cdse_and_process.py`) | ✅ live (sub-issue 10); reused read-only |
+| `acquisition_id(tile, when)` → `s1-rtc-{tile}-{YYYYMMDDtHHMMSS}` (`register_per_acquisition.py`) | ✅ shipped (#229); the dedup key |
+| `sentinel-1-grd-rtc-acquisitions` per-acq items | ✅ live (31TCH ×2); the dedup authority |
+| cube time-present skip (`new_acquisitions`/`store_times_ns`, `ingest_v1_s1_rtc.py`) | ✅ shipped (#231) — the **downstream** backstop (T4), runs in ingest, **not** in the trigger |
+| `scripts/trigger.py` (this task) | ❌ to build |
+| CronWorkflow 6 h + child-Workflow fan-out + retire blind cron | ⏳ platform-deploy / cluster (out of in-repo scope) |
+
+---
+
+## Architecture & key decisions
+
+- **The trigger is a pure function: query → platform-allowlist → STAC item-exists dedup → emit JSON.**
+  It does **not** run s1tiling/ingest (that's the child Workflow the CronWorkflow submits via
+  `workflowTemplateRef`, decision B) and it does **not** read S3. This keeps it decoupled, fast, and
+  fully unit-testable by mocking the STAC client — the same boundary `query_cdse` is already tested at.
+- **Dedup split across components (faithful to spec §3 + P2).** The *trigger's* arm is the
+  **per-acquisition STAC item-exists** check against `sentinel-1-grd-rtc-acquisitions`. The
+  **cube-time-present** arm is **already shipped in T4** and runs *downstream in ingest*
+  (`new_acquisitions`) — it is the backstop for the STAC-indexing-latency race, so the trigger does
+  **not** open the cube. (P2: "the trigger skips a product whose per-acquisition STAC item already
+  exists; the ingest also skips a `time` already present in the cube.")
+- **Platform filter = product-id prefix allowlist** `{S1A, S1C}` (`product_id.split("_")[0]`). S1D (and
+  anything else) is dropped *before* emit with a `log.info` line → no child Workflow. Allowlist (not an
+  S1D denylist) so a future S1B/S1E can't leak through.
+- **Dedup key precision (the one real risk).** `acquisition_id` needs the acquisition instant **to the
+  second**; `query_cdse` keeps only the date, so the trigger keeps the full `item.datetime`. The
+  registered item id is built from the **cube** time (the s1tiling `ACQUISITION_DATETIME` tag), while
+  the trigger derives the id from the **CDSE** `datetime`. If those differ by ≥1 s the id-exists check
+  never matches and the trigger re-submits every 6 h. **Mitigation is layered:** (1) a one-time
+  ground-truth on cluster — compare the two live items (`s1-rtc-31TCH-20260605t060907`,
+  `…-20260607t055248`) against their CDSE product `datetime`s; (2) even on a miss, the **T4 cube-time
+  backstop** prevents a duplicate `time` slice and `register_per_acquisition` re-emits the *canonical*
+  id, so the worst case is a redundant s1tiling run, **never** cube corruption or duplicate items;
+  (3) if parity fails on cluster, switch the existence check to a bounded **datetime-window search**
+  (S1 revisit ≫ tolerance) — a localized change behind the same `item_exists` seam. Tracked as OQ-T6-1.
+
+### Module reuse (no edits to existing files)
+`trigger.py` imports `tile_bbox` + the CDSE constants from `watch_cdse_and_process`, and
+`acquisition_id` + `DEFAULT_ACQ_COLLECTION` from `register_per_acquisition`. `query_cdse` is *not*
+edited (its date-only contract + tests stay intact); the trigger has its own `query_products` that
+runs the same `Client.search(...)` but keeps `datetime` + `platform`. ~6 lines of search construction
+are duplicated deliberately rather than widening `query_cdse`'s tested contract.
+
+---
+
+## Dependency graph
+
+```
+T1–T5 (shipped) ── acquisition_id + acquisitions collection (dedup key+authority)
+        │           tile_bbox + CDSE query path (reused)
+        ▼
+T6.1 platform parse + allowlist ─┐
+T6.2 query_products (+datetime)  ─┤
+T6.3 item_exists dedup           ─┼─► T6.4 select_new_products + main() emit JSON
+                                  ┘        │
+                                           ▼  CP-T6 (pytest test_trigger.py green)
+                          ── platform-deploy: CronWorkflow 6 h + withParam fan-out + retire blind cron
+                             + cluster verify (only-new submit; re-run→0; S1D skipped; datetime parity)
+```
+
+---
+
+## Tasks
+
+> **Build complete (2026-06-10)**: `scripts/trigger_cdse.py` + `tests/unit/test_trigger_cdse.py`
+> (24 tests) shipped; T6.1–T6.4 ✅; CP-T6 met (full suite **500 passed**, ruff clean, watcher
+> untouched). Platform-deploy CronWorkflow + cluster verify remain.
+
+### Task T6.1 — Platform parse + {S1A,S1C} allowlist  <status: ✅ DONE>
+**What**: `platform_of(product_id) -> str` (`product_id.split("_", 1)[0].upper()`); module constant
+`ENABLED_PLATFORMS = {"S1A", "S1C"}`; `is_enabled_platform(platform) -> bool`. No I/O.
+**Verify**: `uv run pytest tests/unit/test_trigger.py -k platform`
+**Acceptance**:
+- [ ] `platform_of("S1A_IW_GRDH_…")=="S1A"`, `…("S1D_…")=="S1D"`, `…("S1C_…")=="S1C"`
+- [ ] `is_enabled_platform` true for S1A/S1C, false for S1D (and S1B/garbage)
+- [ ] Malformed id (no `_`) → returns the upper-cased token, `is_enabled_platform` false (no crash)
+**Files**: `scripts/trigger.py`, `tests/unit/test_trigger.py` · **Scope**: XS
+
+### Task T6.2 — `query_products` (CDSE query keeping datetime+platform)  <status: ✅ DONE>
+**What**: `query_products(stac_url, bbox, orbit_direction, lookback_days) -> list[dict]` returning
+`{"product_id", "platform", "datetime"(ISO, to seconds), "date"}`. Same `Client.search` filter as
+`query_cdse` (collection `sentinel-1-grd`, bbox, `sat:orbit_state`, lookback). Items without a
+datetime are skipped (logged), mirroring `query_cdse`.
+**Verify**: `uv run pytest tests/unit/test_trigger.py -k query`
+**Acceptance**:
+- [ ] Returns one record per item with full `datetime` (not just date) + parsed `platform`
+- [ ] Search scoped to `sentinel-1-grd`, the bbox, and `{"sat:orbit_state": {"eq": orbit}}` (asserted)
+- [ ] Item with no datetime is skipped, not crashed on (adversarial)
+**Files**: `scripts/trigger.py`, `tests/unit/test_trigger.py` · **Dep**: none · **Scope**: S
+
+### Task T6.3 — Per-acquisition STAC item-exists dedup  <status: ✅ DONE>
+**What**: `expected_item_id(tile, when)` = `acquisition_id(tile, when)` (reused);
+`item_exists(stac_api_url, acq_collection, item_id) -> bool` via
+`Client.open(...).search(collections=[acq_collection], ids=[item_id])` → any item returned ⇒ True.
+**Verify**: `uv run pytest tests/unit/test_trigger.py -k exists`
+**Acceptance**:
+- [ ] `expected_item_id("31TCH", 2026-06-07T05:52:48Z) == "s1-rtc-31TCH-20260607t055248"`
+- [ ] `item_exists` True when search yields an item, False when it yields none (mocked client)
+- [ ] Search is scoped to the acquisitions collection + the exact `ids=[item_id]` (asserted)
+**Files**: `scripts/trigger.py`, `tests/unit/test_trigger.py` · **Dep**: T6.1 · **Scope**: S
+
+### Task T6.4 — `select_new_products` + `main()` JSON emit  <status: ✅ DONE>
+**What**: `select_new_products(args) -> list[dict]`: per tile → `query_products` → drop
+`not is_enabled_platform` (log `"skip %s: platform %s not enabled"`) → drop `item_exists(...)` (log
+`"skip %s: item %s already registered"`) → keep `{tile, orbit, product_id, datetime, date, platform}`.
+`main()` parses args (`--tiles`, `--orbit-direction`, `--lookback-days`, `--acq-collection`
+[default `DEFAULT_ACQ_COLLECTION`], `--stac-api-url`, optional `--output`), writes the JSON **array**
+to `--output` or stdout (the CronWorkflow's `withParam` source). Logging on stderr so stdout is clean
+JSON.
+**Verify**: `uv run pytest tests/unit/test_trigger.py -k select`
+**Acceptance**:
+- [ ] Emits only products with no existing per-acq item (dedup), mocked `query_products`+`item_exists`
+- [ ] Empty CDSE result → `[]`; all-already-registered → `[]` (idempotent re-run)
+- [ ] An S1D product is dropped (logged), absent from the emitted array
+- [ ] Multiple tiles iterate; each record carries its tile+orbit; stdout is valid JSON only
+**Files**: `scripts/trigger.py`, `tests/unit/test_trigger.py` · **Dep**: T6.1–T6.3 · **Scope**: S
+
+### Checkpoint CP-T6 (after T6.1–T6.4)
+- [ ] `uv run pytest tests/unit/test_trigger.py` green; full `uv run pytest` green (no regressions)
+- [ ] `scripts/trigger.py` is query→filter→dedup→emit only (no subprocess/S3/submit) — re-read diff
+- [ ] `watch_cdse_and_process.py` + its tests unchanged
+- [ ] Update plan Task 6 in-repo acceptance bullets with evidence; **human review before platform-deploy**
+
+---
+
+## Out of in-repo scope (platform-deploy / cluster — the Task 6 "pending" tail)
+- CronWorkflow (6 h) that runs `trigger.py` then `withParam`-fans-out one child Workflow per emitted
+  product (decision B, `workflowTemplateRef`).
+- Retire/replace the suspended sub-issue-8 blind cron (one trigger of record).
+- **Cluster verify**: data-bearing window → only-new submissions; no-data → 0; re-run → 0; S1D skipped
+  (logged), no child Workflow; **CDSE↔cube `datetime` parity ground-truth** (OQ-T6-1).
+
+## Open questions
+| OQ | Question | Blocks | Owner |
+|----|----------|--------|-------|
+| T6-1 | Does CDSE product `datetime` equal the cube `ACQUISITION_DATETIME` to the second? If not, switch `item_exists` to a bounded datetime-window search. | cluster idempotency | me (cluster verify) |
+
+## Risks & mitigations
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| CDSE `datetime` ≠ cube id second → trigger re-submits forever | Med | T4 cube-time backstop (no dup slice/item; worst case = redundant s1tiling run); cluster parity check; window-search fallback behind `item_exists` seam (OQ-T6-1) |
+| STAC indexing latency → brief re-submit window | Low | downstream T4 cube-time-present skip is the backstop (by design) |
+| Pulling `watch_cdse_and_process` transitively imports `run_ingest_register` | Low | same import the live watcher already carries; only `tile_bbox`+constants used |
+
+## Done definition (in-repo)
+`scripts/trigger.py` emits a JSON array of **new** {S1A,S1C} products for a tile+window — S1D skipped
+(logged), already-registered acquisitions deduped via per-acq item-exists, idempotent re-run → `[]` —
+covered by `tests/unit/test_trigger.py` (all green, no regressions). CronWorkflow wiring + cluster
+verify are tracked as the platform-deploy tail of Phase-6 Task 6.

--- a/claude-docs/plans/subissue_T6_trigger.md
+++ b/claude-docs/plans/subissue_T6_trigger.md
@@ -155,7 +155,7 @@ JSON.
 ## Open questions
 | OQ | Question | Blocks | Owner |
 |----|----------|--------|-------|
-| T6-1 | Does CDSE product `datetime` equal the cube `ACQUISITION_DATETIME` to the second? If not, switch `item_exists` to a bounded datetime-window search. | cluster idempotency | me (cluster verify) |
+| T6-1 | ~~Does CDSE product `datetime` equal the cube `ACQUISITION_DATETIME` to the second?~~ **RESOLVED 2026-06-10 (CP-A on 31TCJ)**: CDSE product start `2026-06-05T06:08:42.283Z` → `expected_item_id = s1-rtc-31TCJ-20260605t060842` == the registered cube per-acq id, **exact match to the second**. Exact-id dedup ships; no datetime-window fallback needed. Evidence: `claude-docs/runs/cp_a_local_31TCJ.md`. | ~~cluster idempotency~~ | resolved |
 
 ## Risks & mitigations
 | Risk | Impact | Mitigation |

--- a/scripts/trigger_cdse.py
+++ b/scripts/trigger_cdse.py
@@ -1,0 +1,181 @@
+"""Data-driven CDSE trigger for the S1 GRD RTC pipeline (Phase-6 Task 6).
+
+Queries CDSE for new S1 GRD products over a tile+window, keeps only ``{S1A, S1C}`` (S1D skipped,
+logged), drops acquisitions whose **per-acquisition STAC item already exists** in
+``sentinel-1-grd-rtc-acquisitions``, and emits the remaining NEW products as a JSON array (to
+``--output`` or stdout). The Argo CronWorkflow consumes that array to fan out one child Workflow per
+product (decision B); the **cube-time-present** dedup arm runs downstream in ingest (T4). This is a
+pure query -> filter -> dedup -> emit step: no subprocess, no S3, no submission.
+
+Usage:
+    uv run python scripts/trigger_cdse.py --tiles 31TCH --orbit-direction descending \
+      --lookback-days 7 --stac-api-url <eopf-stac> [--output new_products.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+import sys
+from pathlib import Path
+
+from pystac_client import Client
+from register_per_acquisition import DEFAULT_ACQ_COLLECTION, acquisition_id
+
+# Reuse the watcher's tile geometry + CDSE query constants (single source of truth); query_cdse
+# itself is *not* reused -- it drops the datetime/platform this trigger needs (see query_products).
+from watch_cdse_and_process import (
+    CDSE_COLLECTION,
+    CDSE_STAC_URL,
+    ORBIT_STATE_PROPERTY,
+    tile_bbox,
+)
+
+log = logging.getLogger(__name__)
+
+# Phase-6 platform allowlist (spec §2): S1A + S1C only. Allowlist (not an S1D denylist) so a future
+# S1B/S1E can't leak through until s1tiling support is confirmed.
+ENABLED_PLATFORMS = {"S1A", "S1C"}
+
+
+def platform_of(product_id: str) -> str:
+    """Mission prefix of a CDSE product id, e.g. ``S1A_IW_GRDH_...`` -> ``S1A``."""
+    return product_id.split("_", 1)[0].upper()
+
+
+def is_enabled_platform(platform: str) -> bool:
+    return platform in ENABLED_PLATFORMS
+
+
+def _item_datetime(item: object) -> dt.datetime | None:
+    """Acquisition instant of a CDSE item, or None if it carries neither datetime nor start."""
+    when = getattr(item, "datetime", None)
+    if isinstance(when, dt.datetime):
+        return when
+    start = getattr(item, "properties", {}).get("start_datetime")
+    if isinstance(start, str):
+        return dt.datetime.fromisoformat(start.replace("Z", "+00:00"))
+    return None
+
+
+def query_products(
+    stac_url: str, bbox: list[float], orbit_direction: str, lookback_days: int
+) -> list[dict[str, str]]:
+    """Query CDSE for S1 GRD products over `bbox` in the last `lookback_days`.
+
+    Returns ``[{"product_id", "platform", "datetime"(ISO, to seconds), "date"}, ...]``. Mirrors
+    ``watch_cdse_and_process.query_cdse``'s filter but keeps the per-second ``datetime`` (needed for
+    the per-acquisition item-id dedup) and the parsed ``platform``. Items without a datetime are
+    skipped (logged).
+    """
+    now = dt.datetime.now(dt.UTC)
+    start = now - dt.timedelta(days=lookback_days)
+    search = Client.open(stac_url).search(
+        collections=[CDSE_COLLECTION],
+        bbox=bbox,
+        datetime=f"{start.isoformat()}/{now.isoformat()}",
+        query={ORBIT_STATE_PROPERTY: {"eq": orbit_direction}},
+    )
+    products: list[dict[str, str]] = []
+    for item in search.items():
+        when = _item_datetime(item)
+        if when is None:
+            log.warning("skipping %s: no datetime", item.id)
+            continue
+        products.append(
+            {
+                "product_id": item.id,
+                "platform": platform_of(item.id),
+                "datetime": when.isoformat(),
+                "date": when.date().isoformat(),
+            }
+        )
+    return products
+
+
+def expected_item_id(tile_id: str, when: dt.datetime) -> str:
+    """Per-acquisition STAC item id this acquisition would register as (the dedup key)."""
+    return acquisition_id(tile_id, when)
+
+
+def item_exists(stac_api_url: str, acq_collection: str, item_id: str) -> bool:
+    """True if `item_id` already exists in `acq_collection` on the target STAC API.
+
+    Uses an id-scoped search (any hit ⇒ exists). If a deployment's ``ids`` filter proves unreliable,
+    this is the seam to swap for a direct ``GET /collections/{c}/items/{id}`` (200/404), mirroring
+    ``register_per_acquisition._upsert_items``.
+    """
+    search = Client.open(stac_api_url).search(collections=[acq_collection], ids=[item_id])
+    return next(iter(search.items()), None) is not None
+
+
+def select_new_products(args: argparse.Namespace) -> list[dict[str, str]]:
+    """Per tile: query CDSE, drop non-{S1A,S1C} (logged) and already-registered acquisitions (logged),
+    and return the new products to submit as ``{tile, orbit, product_id, datetime, date, platform}``."""
+    tiles = [t.strip() for t in args.tiles.split(",") if t.strip()]
+    new_products: list[dict[str, str]] = []
+    for tile in tiles:
+        products = query_products(
+            CDSE_STAC_URL, tile_bbox(tile), args.orbit_direction, args.lookback_days
+        )
+        for product in products:
+            platform = product["platform"]
+            if not is_enabled_platform(platform):
+                log.info("skip %s: platform %s not enabled", product["product_id"], platform)
+                continue
+            when = dt.datetime.fromisoformat(product["datetime"])
+            item_id = expected_item_id(tile, when)
+            if item_exists(args.stac_api_url, args.acq_collection, item_id):
+                log.info("skip %s: item %s already registered", product["product_id"], item_id)
+                continue
+            new_products.append(
+                {
+                    "tile": tile,
+                    "orbit": args.orbit_direction,
+                    "product_id": product["product_id"],
+                    "datetime": product["datetime"],
+                    "date": product["date"],
+                    "platform": platform,
+                }
+            )
+    return new_products
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tiles", required=True, help="Comma-separated MGRS tile IDs (e.g. 31TCH)")
+    parser.add_argument("--orbit-direction", required=True, choices=["ascending", "descending"])
+    parser.add_argument("--lookback-days", required=True, type=int, help="CDSE query window (days)")
+    parser.add_argument(
+        "--stac-api-url", required=True, help="EOPF target STAC API (per-acquisition dedup)"
+    )
+    parser.add_argument(
+        "--acq-collection",
+        default=DEFAULT_ACQ_COLLECTION,
+        help=f"Per-acquisition collection to dedup against (default: {DEFAULT_ACQ_COLLECTION})",
+    )
+    parser.add_argument("--output", help="Write the JSON array here (default: stdout)")
+    return parser
+
+
+def main() -> None:
+    # Logs on stderr so stdout stays a clean JSON array (Argo can capture either stdout or --output).
+    logging.basicConfig(
+        level=logging.INFO, format="%(levelname)s %(name)s %(message)s", stream=sys.stderr
+    )
+    args = build_parser().parse_args()
+    products = select_new_products(args)
+    payload = json.dumps(products, indent=2)
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(payload)
+    else:
+        print(payload)
+    log.info("emitted %d new product(s)", len(products))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_trigger_cdse.py
+++ b/tests/unit/test_trigger_cdse.py
@@ -1,0 +1,276 @@
+"""Unit tests for scripts/trigger_cdse.py (Phase-6 Task 6 — data-driven CDSE trigger)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+sys.path.insert(0, str(scripts_dir))
+
+from trigger_cdse import (  # noqa: E402
+    build_parser,
+    expected_item_id,
+    is_enabled_platform,
+    item_exists,
+    platform_of,
+    query_products,
+    select_new_products,
+)
+
+_MOD = "trigger_cdse"
+
+
+# --- platform parse + allowlist (T6.1) ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("product_id", "expected"),
+    [
+        ("S1A_IW_GRDH_1SDV_20260607T055248", "S1A"),
+        ("S1C_IW_GRDH_1SDV_20260605T060907", "S1C"),
+        ("S1D_IW_GRDH_1SDV_20260607T055248", "S1D"),
+    ],
+)
+def test_platform_of_reads_id_prefix(product_id: str, expected: str) -> None:
+    assert platform_of(product_id) == expected
+
+
+def test_platform_of_malformed_id_does_not_crash() -> None:
+    """Adversarial: an id with no underscore yields the upper-cased token (and is not enabled)."""
+    assert platform_of("garbage") == "GARBAGE"
+    assert is_enabled_platform(platform_of("garbage")) is False
+
+
+@pytest.mark.parametrize("platform", ["S1A", "S1C"])
+def test_is_enabled_platform_allows_s1a_s1c(platform: str) -> None:
+    assert is_enabled_platform(platform) is True
+
+
+@pytest.mark.parametrize("platform", ["S1D", "S1B", "ZZZ"])
+def test_is_enabled_platform_rejects_others(platform: str) -> None:
+    assert is_enabled_platform(platform) is False
+
+
+# --- query_products (T6.2) ------------------------------------------------------------------
+
+
+def _item(item_id: str, when: dt.datetime | None, properties: dict | None = None) -> MagicMock:
+    item = MagicMock()
+    item.id = item_id
+    item.datetime = when
+    item.properties = properties or {}
+    return item
+
+
+def _patched_client(items: list[MagicMock]) -> MagicMock:
+    client = MagicMock()
+    client.search.return_value.items.return_value = iter(items)
+    return client
+
+
+def test_query_products_keeps_full_datetime_and_platform() -> None:
+    """Unlike query_cdse (date-only), the trigger keeps the per-second datetime + parsed platform."""
+    items = [
+        _item("S1A_IW_GRDH_A", dt.datetime(2026, 6, 7, 5, 52, 48, tzinfo=dt.UTC)),
+        _item("S1D_IW_GRDH_B", dt.datetime(2026, 6, 7, 5, 53, 0, tzinfo=dt.UTC)),
+    ]
+    with patch(f"{_MOD}.Client.open", return_value=_patched_client(items)):
+        products = query_products("https://cdse/stac", [0.5, 42.4, 1.8, 43.3], "descending", 7)
+    assert products == [
+        {
+            "product_id": "S1A_IW_GRDH_A",
+            "platform": "S1A",
+            "datetime": "2026-06-07T05:52:48+00:00",
+            "date": "2026-06-07",
+        },
+        {
+            "product_id": "S1D_IW_GRDH_B",
+            "platform": "S1D",
+            "datetime": "2026-06-07T05:53:00+00:00",
+            "date": "2026-06-07",
+        },
+    ]
+
+
+def test_query_products_applies_orbit_and_collection_filter() -> None:
+    """The CDSE search is scoped to sentinel-1-grd, the bbox, and the orbit-state filter."""
+    client = _patched_client([])
+    with patch(f"{_MOD}.Client.open", return_value=client):
+        query_products("https://cdse/stac", [0.5, 42.4, 1.8, 43.3], "descending", 7)
+    kwargs = client.search.call_args.kwargs
+    assert kwargs["collections"] == ["sentinel-1-grd"]
+    assert kwargs["bbox"] == [0.5, 42.4, 1.8, 43.3]
+    assert kwargs["query"] == {"sat:orbit_state": {"eq": "descending"}}
+
+
+def test_query_products_skips_item_without_datetime() -> None:
+    """Adversarial: an item with no datetime and no start_datetime is skipped, not crashed on."""
+    items = [
+        _item("S1A_good", dt.datetime(2026, 6, 7, 5, 52, 48, tzinfo=dt.UTC)),
+        _item("S1A_bad", None, properties={}),
+    ]
+    with patch(f"{_MOD}.Client.open", return_value=_patched_client(items)):
+        products = query_products("https://cdse/stac", [0.5, 42.4, 1.8, 43.3], "descending", 7)
+    assert [p["product_id"] for p in products] == ["S1A_good"]
+
+
+# --- item-exists dedup (T6.3) ---------------------------------------------------------------
+
+
+def test_expected_item_id_matches_per_acquisition_convention() -> None:
+    """The dedup key is exactly the id register_per_acquisition emits (s1-rtc-{tile}-{stamp})."""
+    when = dt.datetime(2026, 6, 7, 5, 52, 48, tzinfo=dt.UTC)
+    assert expected_item_id("31TCH", when) == "s1-rtc-31TCH-20260607t055248"
+
+
+def test_item_exists_true_when_search_yields_item() -> None:
+    item = _item("s1-rtc-31TCH-20260607t055248", dt.datetime(2026, 6, 7, tzinfo=dt.UTC))
+    client = _patched_client([item])
+    with patch(f"{_MOD}.Client.open", return_value=client):
+        exists = item_exists("https://stac", "sentinel-1-grd-rtc-acquisitions", item.id)
+    assert exists is True
+    kwargs = client.search.call_args.kwargs
+    assert kwargs["collections"] == ["sentinel-1-grd-rtc-acquisitions"]
+    assert kwargs["ids"] == ["s1-rtc-31TCH-20260607t055248"]
+
+
+def test_item_exists_false_when_search_empty() -> None:
+    with patch(f"{_MOD}.Client.open", return_value=_patched_client([])):
+        assert item_exists("https://stac", "sentinel-1-grd-rtc-acquisitions", "nope") is False
+
+
+# --- select_new_products + main wiring (T6.4) -----------------------------------------------
+
+
+def _args(**overrides: object) -> object:
+    ns = build_parser().parse_args(
+        [
+            "--tiles", "31TCH",
+            "--orbit-direction", "descending",
+            "--lookback-days", "7",
+            "--stac-api-url", "https://eopf-target/stac",
+        ]
+    )  # fmt: skip
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def _product(product_id: str, platform: str, when: str) -> dict[str, str]:
+    return {
+        "product_id": product_id,
+        "platform": platform,
+        "datetime": when,
+        "date": when[:10],
+    }
+
+
+def test_select_emits_only_unregistered_products() -> None:
+    products = [
+        _product("S1A_new", "S1A", "2026-06-07T05:52:48+00:00"),
+        _product("S1A_old", "S1A", "2026-06-05T06:09:07+00:00"),
+    ]
+    with (
+        patch(f"{_MOD}.query_products", return_value=products),
+        patch(f"{_MOD}.item_exists", side_effect=[False, True]) as exists,
+    ):
+        new = select_new_products(_args())
+    assert [p["product_id"] for p in new] == ["S1A_new"]
+    # dedup key is the per-acquisition item id derived from the acquisition datetime
+    assert exists.call_args_list[0].args[2] == "s1-rtc-31TCH-20260607t055248"
+
+
+def test_select_empty_query_returns_empty() -> None:
+    with patch(f"{_MOD}.query_products", return_value=[]):
+        assert select_new_products(_args()) == []
+
+
+def test_select_all_registered_returns_empty_idempotent() -> None:
+    products = [_product("S1A_old", "S1A", "2026-06-05T06:09:07+00:00")]
+    with (
+        patch(f"{_MOD}.query_products", return_value=products),
+        patch(f"{_MOD}.item_exists", return_value=True),
+    ):
+        assert select_new_products(_args()) == []
+
+
+def test_select_skips_s1d_at_query_time_no_dedup_call() -> None:
+    """S1D is dropped before the dedup check -> never emitted, never a child Workflow."""
+    products = [
+        _product("S1D_skip", "S1D", "2026-06-07T05:52:48+00:00"),
+        _product("S1C_keep", "S1C", "2026-06-07T17:10:00+00:00"),
+    ]
+    with (
+        patch(f"{_MOD}.query_products", return_value=products),
+        patch(f"{_MOD}.item_exists", return_value=False) as exists,
+    ):
+        new = select_new_products(_args())
+    assert [p["product_id"] for p in new] == ["S1C_keep"]
+    # dedup is only consulted for the enabled platform, not for the skipped S1D
+    assert exists.call_count == 1
+
+
+def test_select_carries_tile_and_orbit_per_record() -> None:
+    products = [_product("S1A_new", "S1A", "2026-06-07T05:52:48+00:00")]
+    with (
+        patch(f"{_MOD}.query_products", return_value=products),
+        patch(f"{_MOD}.item_exists", return_value=False),
+    ):
+        new = select_new_products(_args())
+    assert new[0]["tile"] == "31TCH"
+    assert new[0]["orbit"] == "descending"
+    assert new[0]["platform"] == "S1A"
+
+
+def test_select_iterates_multiple_tiles() -> None:
+    products = [_product("S1A_new", "S1A", "2026-06-07T05:52:48+00:00")]
+    with (
+        patch(f"{_MOD}.query_products", return_value=products) as q,
+        patch(f"{_MOD}.item_exists", return_value=False),
+    ):
+        new = select_new_products(_args(tiles="31TCH,30TXM"))
+    assert q.call_count == 2
+    assert {p["tile"] for p in new} == {"31TCH", "30TXM"}
+
+
+def test_select_queries_cdse_catalogue_not_target_stac() -> None:
+    """The acquisition query hits the CDSE source catalogue, not the EOPF target STAC."""
+    from trigger_cdse import CDSE_STAC_URL
+
+    with (
+        patch(f"{_MOD}.query_products", return_value=[]) as q,
+        patch(f"{_MOD}.item_exists", return_value=False),
+    ):
+        select_new_products(_args(stac_api_url="https://eopf-target/stac"))
+    assert q.call_args.args[0] == CDSE_STAC_URL
+
+
+def test_parser_acq_collection_defaults_to_acquisitions() -> None:
+    assert _args().acq_collection == "sentinel-1-grd-rtc-acquisitions"
+
+
+def test_main_writes_json_array_to_output(tmp_path: Path) -> None:
+    out = tmp_path / "new.json"
+    from trigger_cdse import main
+
+    argv = [
+        "trigger.py", "--tiles", "31TCH", "--orbit-direction", "descending",
+        "--lookback-days", "7", "--stac-api-url", "https://eopf-target/stac",
+        "--output", str(out),
+    ]  # fmt: skip
+    products = [_product("S1A_new", "S1A", "2026-06-07T05:52:48+00:00")]
+    with (
+        patch.object(sys, "argv", argv),
+        patch(f"{_MOD}.query_products", return_value=products),
+        patch(f"{_MOD}.item_exists", return_value=False),
+    ):
+        main()
+    written = json.loads(out.read_text())
+    assert [p["product_id"] for p in written] == ["S1A_new"]
+    assert written[0]["tile"] == "31TCH"


### PR DESCRIPTION
## What

Phase-6 **Task 6** in-repo half: `scripts/trigger_cdse.py` — the data-driven trigger that replaces the suspended blind daily cron. A pure **query → filter → dedup → emit** step the Argo CronWorkflow runs to decide *what* to submit.

- Queries CDSE for a tile+window (reuses `tile_bbox` + CDSE constants from `watch_cdse_and_process`, **untouched**).
- Platform **allowlist `{S1A, S1C}`**; S1D dropped *before* dedup, logged (→ no child Workflow).
- Dedup = **per-acquisition STAC item-exists** against `sentinel-1-grd-rtc-acquisitions`, keyed on `acquisition_id` (reused) → `s1-rtc-{tile}-{stamp}`.
- Emits a **JSON array** (`--output` or stdout) for the CronWorkflow's `withParam` child-Workflow fan-out (decision B).

## Why a pure emit step (no subprocess / no S3 / no submit)

The two P2 dedup arms are **split across components** per spec §5:
- **trigger** → per-acquisition STAC item-exists (this PR)
- **cube-time-present** → already shipped in **T4** (`new_acquisitions`), runs downstream in ingest

So the trigger stays off S3 and is fully unit-testable by mocking the STAC client.

## Verification

- `uv run pytest tests/unit/test_trigger_cdse.py` → **24 passed** (97% of the new module)
- Full suite green; `ruff` + `mypy` clean (pre-commit)
- `watch_cdse_and_process.py` and its tests untouched

## Out of scope (platform-deploy / cluster — the Task 6 "pending" tail)

CronWorkflow (6 h) + `withParam` fan-out; retire the suspended sub-issue-8 cron; cluster verify.

## Known cluster-verify item — OQ-T6-1

Confirm CDSE product `datetime` == cube `ACQUISITION_DATETIME` to the second (else swap `item_exists` to a bounded datetime-window search — a localized change behind the same seam). T4's cube-time backstop bounds any miss to a **redundant s1tiling run** — never cube corruption or a duplicate item.

Plan: `claude-docs/plans/subissue_T6_trigger.md` · Tracker #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)