### PR TITLE
fix(s1-ingest): run_ingest_register appends to the cube instead of overwriting it

### DIFF
--- a/scripts/run_ingest_register.py
+++ b/scripts/run_ingest_register.py
@@ -3,12 +3,16 @@
 Derives the Zarr store path from bucket/collection/tile-id, calls ingest_v1_s1_rtc.py,
 and — unless ingest reports no acquisitions (exit 2) — calls register_v1_s1_rtc.py.
 
-S3 endpoint/credentials are configured two ways and must agree: the ingest subprocess
-reads GeoTIFFs and writes the local store via s3fs/rasterio, which use the ambient
-``AWS_ENDPOINT_URL`` / ``AWS_PROFILE`` (or ``AWS_ACCESS_KEY_ID``/``AWS_SECRET_ACCESS_KEY``);
-the ``aws s3 sync`` upload and register step instead use the ``--s3-endpoint`` arg. Set
-``AWS_ENDPOINT_URL`` to the same endpoint passed as ``--s3-endpoint`` (with read+write creds
-for the output bucket) or the store will be read from one endpoint and written to another.
+Ingest writes the ``s3://`` cube directly via ``ingest_v1_s1_rtc.run_ingest``, which fetches any
+existing per-tile cube, **appends** the new scene as a ``time`` slice (T4), and uploads with s3fs —
+so the cube accumulates across runs instead of being overwritten.
+
+S3 endpoint/credentials are configured two ways and must agree: the ingest subprocess reads the
+GeoTIFFs and fetches/appends/uploads the ``s3://`` cube via s3fs/rasterio, which use the ambient
+``AWS_ENDPOINT_URL`` / ``AWS_PROFILE`` (or ``AWS_ACCESS_KEY_ID``/``AWS_SECRET_ACCESS_KEY``); the
+register step instead uses the ``--s3-endpoint`` arg. Set ``AWS_ENDPOINT_URL`` to the same endpoint
+passed as ``--s3-endpoint`` (with read+write creds for the output bucket) or the cube will be read
+from one endpoint and written to another.
 
 Exit codes:
     0 -- success, or ingest found no acquisitions (register skipped)
@@ -19,11 +23,8 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
-import shutil
 import subprocess
 import sys
-import tempfile
 
 log = logging.getLogger(__name__)
 
@@ -82,14 +83,11 @@ def run_pipeline(
         )
     check_env_consistency(collection, s3_output_bucket)
     s3_zarr = f"s3://{s3_output_bucket}/{collection}/s1-grd-rtc-{tile_id}.zarr"
-    # eopf_geozarr uses pathlib.Path internally, which collapses s3:// to s3:/ and
-    # writes the zarr to a local directory. Use a local temp path for ingest, then
-    # sync the result to S3 before registering.
-    local_zarr = os.path.join(tempfile.gettempdir(), f"s1-grd-rtc-{tile_id}.zarr")
-    if os.path.exists(local_zarr):
-        shutil.rmtree(local_zarr)
 
-    # Step 1 — ingest (writes to local temp dir)
+    # Step 1 — ingest directly into the s3:// cube. run_ingest fetches any existing cube, appends the
+    # new scene as a time slice (T4), and uploads via s3fs — so the per-tile cube accumulates across
+    # runs instead of being overwritten. Endpoint/creds come from the ambient AWS_ENDPOINT_URL/AWS_*
+    # (see the module docstring); no separate `aws s3 sync` step.
     ingest_cmd = [  # noqa: S607
         "uv",
         "run",
@@ -98,7 +96,7 @@ def run_pipeline(
         "--s3-geotiff-prefix",
         s3_geotiff_prefix,
         "--s3-zarr-store",
-        local_zarr,
+        s3_zarr,
         "--tile-id",
         tile_id,
         "--orbit-direction",
@@ -111,22 +109,7 @@ def run_pipeline(
     if result.returncode != 0:
         return result.returncode
 
-    # Step 2 — upload local zarr to S3
-    upload_cmd = [  # noqa: S607
-        "aws",
-        "s3",
-        "sync",
-        local_zarr,
-        s3_zarr,
-        "--endpoint-url",
-        s3_endpoint,
-    ]
-    result = subprocess.run(upload_cmd)  # noqa: S603
-    if result.returncode != 0:
-        log.error("zarr upload to %s failed (exit %d)", s3_zarr, result.returncode)
-        return result.returncode
-
-    # Step 3 — register (only reached when upload exited 0)
+    # Step 2 — register (only reached when ingest exited 0)
     register_cmd = [  # noqa: S607
         "uv",
         "run",
@@ -147,8 +130,8 @@ def run_pipeline(
     if result.returncode != 0:
         return result.returncode
 
-    # Step 4 — register the per-acquisition items (the -acquisitions collection). The data model
-    # has TWO registrations — the per-tile cube item (Step 3, -staging) AND one item per acquisition
+    # Step 3 — register the per-acquisition items (the -acquisitions collection). The data model
+    # has TWO registrations — the per-tile cube item (Step 2, -staging) AND one item per acquisition
     # (here). Running both from this single stage keeps the collections in sync; skipping either is
     # the kind of gap that leaves a tile invisible in one collection.
     peracq_cmd = [  # noqa: S607

--- a/tests/unit/test_run_ingest_register.py
+++ b/tests/unit/test_run_ingest_register.py
@@ -1,4 +1,11 @@
-"""Unit tests for run_ingest_register.py -- run_pipeline."""
+"""Unit tests for run_ingest_register.py -- run_pipeline.
+
+`run_pipeline` orchestrates three subprocesses: (0) ingest into the **s3:// cube** via
+`ingest_v1_s1_rtc.py` (which fetches the existing cube and **appends** the new scene — the T4 path),
+(1) register the cube item, (2) register the per-acquisition items. These tests prove the
+*delegation* contract (the s3:// store is passed; no separate upload step; correct ordering); the
+append correctness itself is covered by `test_ingest_v1_s1_rtc.py`.
+"""
 
 from __future__ import annotations
 
@@ -26,6 +33,9 @@ _KWARGS = {
     "raster_api_url": "https://raster.example.com",
 }
 
+# The derived per-tile cube URI: s3://{bucket}/{collection}/s1-grd-rtc-{tile}.zarr
+_S3_CUBE = "s3://my-bucket/sentinel-1-grd-rtc-staging/s1-grd-rtc-31TCH.zarr"
+
 
 def _mock_proc(returncode: int) -> MagicMock:
     m = MagicMock()
@@ -34,17 +44,38 @@ def _mock_proc(returncode: int) -> MagicMock:
 
 
 def test_exits_0_on_success() -> None:
-    """Ingest, upload, cube register, per-acq register all rc=0 -> 0; all 4 subprocesses called."""
-    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
+    """Ingest, cube register, per-acq register all rc=0 -> 0; exactly 3 subprocesses (no upload)."""
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 3) as mock_run:
         result = run_pipeline(**_KWARGS)
     assert result == 0
-    assert mock_run.call_count == 4
+    assert mock_run.call_count == 3
+
+
+def test_ingest_uses_s3_store_for_append() -> None:
+    """The fix: ingest must receive the **s3:// cube** as --s3-zarr-store so run_ingest fetches the
+    existing cube and appends (T4) — not a fresh local temp store that would overwrite it."""
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 3) as mock_run:
+        run_pipeline(**_KWARGS)
+    ingest_cmd: list[str] = mock_run.call_args_list[0][0][0]
+    store = ingest_cmd[ingest_cmd.index("--s3-zarr-store") + 1]
+    assert store.startswith("s3://"), f"ingest must append into the s3:// cube, got: {store!r}"
+    assert store == _S3_CUBE
+
+
+def test_no_separate_aws_sync_step() -> None:
+    """No standalone `aws s3 sync` step — run_ingest uploads via s3fs after appending, so a separate
+    sync (the old overwrite mechanism, also dependent on the aws CLI) must not be invoked."""
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 3) as mock_run:
+        run_pipeline(**_KWARGS)
+    for call in mock_run.call_args_list:
+        cmd = call[0][0]
+        assert not (cmd[0] == "aws" and "sync" in cmd), f"unexpected aws s3 sync: {cmd}"
 
 
 def test_registers_both_cube_item_and_per_acquisition_items() -> None:
     """The register stage runs BOTH register_v1_s1_rtc (cube item -> -staging) AND
     register_per_acquisition (per-acq items -> -acquisitions), so neither collection is missed."""
-    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 3) as mock_run:
         run_pipeline(**_KWARGS)
     scripts_called = [
         tok
@@ -58,25 +89,25 @@ def test_registers_both_cube_item_and_per_acquisition_items() -> None:
     assert any(
         s.endswith("register_per_acquisition.py") for s in scripts_called
     ), "per-acquisition items not registered"
-    # per-acq register targets the acquisitions collection with the same s3 store
-    peracq_cmd = mock_run.call_args_list[3][0][0]
+    # per-acq register (3rd call) targets the acquisitions collection with the same s3 store
+    peracq_cmd = mock_run.call_args_list[2][0][0]
     assert "sentinel-1-grd-rtc-acquisitions" in peracq_cmd
-    assert "s3://my-bucket/sentinel-1-grd-rtc-staging/s1-grd-rtc-31TCH.zarr" in peracq_cmd
+    assert _S3_CUBE in peracq_cmd
 
 
 def test_per_acquisition_skipped_when_cube_register_fails() -> None:
-    """If the cube-item register fails, the per-acquisition register is not attempted."""
+    """If the cube-item register (2nd call) fails, the per-acquisition register is not attempted."""
     with patch(
         f"{_MOD}.subprocess.run",
-        side_effect=[_mock_proc(0), _mock_proc(0), _mock_proc(1)],
+        side_effect=[_mock_proc(0), _mock_proc(1)],
     ) as mock_run:
         result = run_pipeline(**_KWARGS)
     assert result == 1
-    assert mock_run.call_count == 3  # ingest, upload, failed cube register; no per-acq
+    assert mock_run.call_count == 2  # ingest, failed cube register; no per-acq
 
 
 def test_exits_0_skips_register_on_empty_prefix() -> None:
-    """Ingest rc=2 (no acquisitions) -> upload and register not called, pipeline returns 0."""
+    """Ingest rc=2 (no acquisitions) -> register not called, pipeline returns 0."""
     with patch(f"{_MOD}.subprocess.run", return_value=_mock_proc(2)) as mock_run:
         result = run_pipeline(**_KWARGS)
     assert result == 0
@@ -84,49 +115,20 @@ def test_exits_0_skips_register_on_empty_prefix() -> None:
 
 
 def test_exits_1_on_ingest_error() -> None:
-    """Ingest rc=1 -> upload and register not called, pipeline returns 1."""
+    """Ingest rc=1 (includes an append/upload failure inside run_ingest) -> register not called."""
     with patch(f"{_MOD}.subprocess.run", return_value=_mock_proc(1)) as mock_run:
         result = run_pipeline(**_KWARGS)
     assert result == 1
     assert mock_run.call_count == 1
 
 
-def test_ingest_uses_local_zarr_path() -> None:
-    """Ingest subprocess must receive a local (non-s3://) path as --s3-zarr-store."""
-    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
-        run_pipeline(**_KWARGS)
-
-    ingest_cmd: list[str] = mock_run.call_args_list[0][0][0]
-    store_idx = ingest_cmd.index("--s3-zarr-store")
-    local_store = ingest_cmd[store_idx + 1]
-    assert not local_store.startswith(
-        "s3://"
-    ), f"ingest must receive a local path, got: {local_store!r}"
-
-
-def test_upload_called_between_ingest_and_register() -> None:
-    """An S3 sync upload must be called after ingest and before register."""
-    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
-        run_pipeline(**_KWARGS)
-
-    upload_cmd: list[str] = mock_run.call_args_list[1][0][0]
-    assert (
-        "s3" in upload_cmd and "sync" in upload_cmd
-    ), f"second subprocess call must be aws s3 sync, got: {upload_cmd}"
-    # upload destination must be the S3 zarr (prefix == collection)
-    expected_s3_zarr = "s3://my-bucket/sentinel-1-grd-rtc-staging/s1-grd-rtc-31TCH.zarr"
-    assert expected_s3_zarr in upload_cmd, f"upload must target {expected_s3_zarr}"
-
-
 def test_zarr_store_derived_correctly() -> None:
-    """--store arg to register subprocess must equal s3://{bucket}/{collection}/s1-grd-rtc-{tile}.zarr."""
-    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
+    """--store arg to the cube register (2nd call) must equal s3://{bucket}/{collection}/...zarr."""
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 3) as mock_run:
         run_pipeline(**_KWARGS)
-
-    register_cmd: list[str] = mock_run.call_args_list[2][0][0]  # third call = register
-    expected_store = "s3://my-bucket/sentinel-1-grd-rtc-staging/s1-grd-rtc-31TCH.zarr"
+    register_cmd: list[str] = mock_run.call_args_list[1][0][0]  # second call = cube register
     store_idx = register_cmd.index("--store")
-    assert register_cmd[store_idx + 1] == expected_store
+    assert register_cmd[store_idx + 1] == _S3_CUBE
 
 
 @pytest.mark.parametrize("bad_collection", ["", "has/slash", "a/b/c"])
@@ -143,26 +145,17 @@ def test_invalid_collection_rejected(bad_collection: str) -> None:
 def test_store_prefix_tracks_collection() -> None:
     """Store key prefix must be derived from --collection, not a fixed value.
 
-    Adversarial: a *different* collection must move the store path accordingly.
-    The staging-only assertions above would also pass a hardcoded prefix; this one
-    would not.
+    Adversarial: a *different* collection must move the store path accordingly (in the ingest store
+    and the cube register --store).
     """
     kwargs = {**_KWARGS, "collection": "sentinel-1-grd-rtc-tests"}
-    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
-        run_pipeline(**kwargs)
-
-    register_cmd: list[str] = mock_run.call_args_list[2][0][0]
     expected_store = "s3://my-bucket/sentinel-1-grd-rtc-tests/s1-grd-rtc-31TCH.zarr"
-    store_idx = register_cmd.index("--store")
-    assert register_cmd[store_idx + 1] == expected_store
-
-
-def test_upload_failure_stops_pipeline() -> None:
-    """Upload rc=1 -> register not called, pipeline returns 1."""
-    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0), _mock_proc(1)]) as mock_run:
-        result = run_pipeline(**_KWARGS)
-    assert result == 1
-    assert mock_run.call_count == 2  # ingest + failed upload; no register
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 3) as mock_run:
+        run_pipeline(**kwargs)
+    ingest_cmd: list[str] = mock_run.call_args_list[0][0][0]
+    assert ingest_cmd[ingest_cmd.index("--s3-zarr-store") + 1] == expected_store
+    register_cmd: list[str] = mock_run.call_args_list[1][0][0]
+    assert register_cmd[register_cmd.index("--store") + 1] == expected_store
 
 
 def test_env_mismatch_rejected_before_any_subprocess() -> None:
@@ -189,11 +182,11 @@ def test_env_mismatch_rejected_before_any_subprocess() -> None:
     ],
 )
 def test_matched_env_pairs_allowed(collection: str, bucket: str) -> None:
-    """Matching per-env bucket/collection pairs run the full pipeline (4 subprocesses)."""
+    """Matching per-env bucket/collection pairs run the full pipeline (3 subprocesses)."""
     kwargs = {**_KWARGS, "collection": collection, "s3_output_bucket": bucket}
-    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4) as mock_run:
+    with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 3) as mock_run:
         assert run_pipeline(**kwargs) == 0
-    assert mock_run.call_count == 4
+    assert mock_run.call_count == 3
 
 
 @pytest.mark.parametrize(
@@ -208,17 +201,3 @@ def test_matched_env_pairs_allowed(collection: str, bucket: str) -> None:
 def test_unrecognized_names_pass_through(collection: str, bucket: str) -> None:
     """When either name isn't a known per-env value, the guard can't infer env and stays out."""
     check_env_consistency(collection, bucket)  # must not raise
-
-
-def test_local_zarr_cleaned_before_ingest() -> None:
-    """Stale local zarr must be removed before ingest to avoid appending to old data."""
-    with (
-        patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 4),
-        patch(f"{_MOD}.shutil.rmtree") as mock_rm,
-        patch(f"{_MOD}.os.path.exists", return_value=True),
-    ):
-        run_pipeline(**_KWARGS)
-
-    mock_rm.assert_called_once()
-    cleaned_path = mock_rm.call_args[0][0]
-    assert "s1-grd-rtc-31TCH" in cleaned_path


### PR DESCRIPTION
## What

The local combined Script B (`scripts/run_ingest_register.py`) ingested into a **fresh local temp** dir then `aws s3 sync`-uploaded it over the S3 store — so each run **replaced** the per-tile cube and orphaned the prior acquisitions' STAC items. The T4 fetch-then-append (`run_ingest` → `_fetch_store_from_s3`) only fires when `ingest_v1_s1_rtc.py` is given an **`s3://`** store — which the **Argo** ingest step does, but this script did not.

**Fix:** pass the `s3://` cube URI to ingest and delete the local-temp creation + the separate `aws s3 sync` step. `run_ingest` now owns fetch → append → s3fs-upload, so the cube **accumulates** across runs (matching the Argo path). Bonus: drops this script's dependency on the `aws` CLI.

## How it was found

CP-A-local on a fresh tile (31TCJ) — a 2nd acquisition ingested via `run_ingest_register` wiped the first from the cube while both per-acq STAC items remained, orphaning one. Finding **F4** in `claude-docs/runs/cp_a_local_31TCJ.md` (local; `runs/` is gitignored).

## Tests

- Rewritten to the **delegation contract**: ingest receives the `s3://` store, no `aws s3 sync` step, 3 subprocesses (register at index 1). The previous tests pinned the buggy local-temp/upload mechanism.
- **No new append-logic surface** — append correctness is covered by `test_ingest_v1_s1_rtc.py` and was live-proven in CP-A (the `run_ingest` s3:// recovery → 2-time cube).
- RED→GREEN: 9 failed against the buggy code → all 18 pass. Full suite **474 passed**; ruff + mypy clean.

Plan: `claude-docs/plans/fix_run_ingest_register_append.md` · surfaced by CP-A (#226).

🤖 Generated with [Claude Code](https://claude.com/claude-code)