### PR TITLE
fix(s1-dem): pin ensure_dem anon S3 client to public AWS endpoint

### DIFF
--- a/scripts/ensure_dem.py
+++ b/scripts/ensure_dem.py
@@ -124,7 +124,16 @@ def _anon_s3(region: str) -> Any:
     from botocore import UNSIGNED
     from botocore.config import Config
 
-    return boto3.client("s3", region_name=region, config=Config(signature_version=UNSIGNED))
+    # Pin the public AWS S3 endpoint explicitly: `copernicus-dem-30m` lives on AWS, but boto3 would
+    # otherwise inherit an ambient `AWS_ENDPOINT_URL` (e.g. the OVH endpoint used for the output
+    # bucket) and 400 the anonymous DEM fetch (HeadObject Bad Request). Pinning it makes the fetch
+    # independent of whatever endpoint the surrounding pipeline set.
+    return boto3.client(
+        "s3",
+        region_name=region,
+        endpoint_url=f"https://s3.{region}.amazonaws.com",
+        config=Config(signature_version=UNSIGNED),
+    )
 
 
 def _download(s3: Any, bucket: str, key: str, dest: Path) -> None:

--- a/tests/unit/test_ensure_dem.py
+++ b/tests/unit/test_ensure_dem.py
@@ -119,3 +119,26 @@ def test_tiles_to_fetch_rejects_malformed_tile():
 
     with pytest.raises(ValueError):
         m.tiles_to_fetch("not-a-tile", set(), set())
+
+
+# --- _anon_s3 endpoint pinning (F1) -----------------------------------------
+
+
+def test_anon_s3_pins_public_aws_endpoint_ignoring_ambient_env(monkeypatch):
+    """F1: the anonymous client must hit public AWS S3 for ``copernicus-dem-30m``, not an ambient
+    ``AWS_ENDPOINT_URL`` (e.g. the OVH endpoint set for the output bucket) — which would 400 the DEM
+    fetch (HeadObject Bad Request). The client must pin the regional AWS endpoint regardless of env."""
+    m = _mod()
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://s3.de.io.cloud.ovh.net")
+    client = m._anon_s3("eu-central-1")
+    assert client.meta.endpoint_url == "https://s3.eu-central-1.amazonaws.com"
+
+
+def test_anon_s3_is_unsigned():
+    """The DEM bucket is public — the client must stay unsigned (no creds), so pinning the endpoint
+    must not reintroduce credential signing."""
+    from botocore import UNSIGNED
+
+    m = _mod()
+    client = m._anon_s3("eu-central-1")
+    assert client.meta.config.signature_version is UNSIGNED


### PR DESCRIPTION
## What

`ensure_dem._anon_s3` built an UNSIGNED client **without an explicit `endpoint_url`**, so boto3 inherited the ambient `AWS_ENDPOINT_URL`. Where that points at a non-AWS S3 (e.g. the **OVH** endpoint set for the output bucket — the local/operator setup), the anonymous `copernicus-dem-30m` DEM fetch was routed to the wrong endpoint and **400'd** (`HeadObject Bad Request`).

**Fix:** pin `endpoint_url=https://s3.{region}.amazonaws.com` so the public-AWS DEM fetch is independent of whatever endpoint the surrounding pipeline set. `UNSIGNED` (anonymous) preserved.

## How it was found

CP-A-local on 31TCJ — `ensure_dem` 400'd until I unset `AWS_ENDPOINT_URL` as a workaround. Finding **F1** in `claude-docs/runs/cp_a_local_31TCJ.md`. Masked on-cluster (the DEM step runs without that env).

## Tests

- `test_anon_s3_pins_public_aws_endpoint_ignoring_ambient_env` — RED against the old client (it picks up the ambient `AWS_ENDPOINT_URL`), GREEN after the pin.
- `test_anon_s3_is_unsigned` — guards that pinning the endpoint doesn't reintroduce credential signing.
- **Live-proven**: with `AWS_ENDPOINT_URL` set to OVH, a HEAD on a real DEM tile (`…N42_00_E001…`) returns **HTTP 200** (42 MB).
- Full suite **478 passed**; ruff + mypy clean.

Surfaced by CP-A (#226).

🤖 Generated with [Claude Code](https://claude.com/claude-code)