### PR TITLE
feat(s1-trigger): emit s1tiling window (date_start/date_end) per product

### DIFF
--- a/scripts/trigger_cdse.py
+++ b/scripts/trigger_cdse.py
@@ -7,6 +7,10 @@ logged), drops acquisitions whose **per-acquisition STAC item already exists** i
 product (decision B); the **cube-time-present** dedup arm runs downstream in ingest (T4). This is a
 pure query -> filter -> dedup -> emit step: no subprocess, no S3, no submission.
 
+Each emitted record is ``{tile, orbit, date_start, date_end, date, product_id, platform}``; the
+CronWorkflow's ``withParam`` consumes the controlled ``tile/orbit/date_start/date_end`` (the s1tiling
+window = acquisition day ∓1), never the raw ``product_id``.
+
 Usage:
     uv run python scripts/trigger_cdse.py --tiles 31TCH --orbit-direction descending \
       --lookback-days 7 --stac-api-url <eopf-stac> [--output new_products.json]
@@ -130,6 +134,9 @@ def select_new_products(args: argparse.Namespace) -> list[dict[str, str]]:
             if item_exists(args.stac_api_url, args.acq_collection, item_id):
                 log.info("skip %s: item %s already registered", product["product_id"], item_id)
                 continue
+            # s1tiling window brackets the acquisition day (date∓1, matching the local watcher), so
+            # the CronWorkflow fans out child pipelines with no per-product date-math step.
+            acq_date = dt.date.fromisoformat(product["date"])
             new_products.append(
                 {
                     "tile": tile,
@@ -137,6 +144,8 @@ def select_new_products(args: argparse.Namespace) -> list[dict[str, str]]:
                     "product_id": product["product_id"],
                     "datetime": product["datetime"],
                     "date": product["date"],
+                    "date_start": (acq_date - dt.timedelta(days=1)).isoformat(),
+                    "date_end": (acq_date + dt.timedelta(days=1)).isoformat(),
                     "platform": platform,
                 }
             )

--- a/tests/unit/test_trigger_cdse.py
+++ b/tests/unit/test_trigger_cdse.py
@@ -200,6 +200,32 @@ def test_select_all_registered_returns_empty_idempotent() -> None:
         assert select_new_products(_args()) == []
 
 
+def test_select_emits_s1tiling_window_date_minus_plus_one() -> None:
+    """Each emitted product carries the s1tiling window date_start=date-1 / date_end=date+1, so the
+    CronWorkflow fans out child pipelines with no per-product date-math step (C0)."""
+    products = [_product("S1A_new", "S1A", "2026-06-05T06:08:42+00:00")]
+    with (
+        patch(f"{_MOD}.query_products", return_value=products),
+        patch(f"{_MOD}.item_exists", return_value=False),
+    ):
+        new = select_new_products(_args())
+    assert new[0]["date"] == "2026-06-05"
+    assert new[0]["date_start"] == "2026-06-04"
+    assert new[0]["date_end"] == "2026-06-06"
+
+
+def test_select_window_crosses_month_boundary() -> None:
+    """Adversarial: date-1/date+1 use real date arithmetic, not string slicing (month rollover)."""
+    products = [_product("S1A_eom", "S1A", "2026-05-31T06:00:32+00:00")]
+    with (
+        patch(f"{_MOD}.query_products", return_value=products),
+        patch(f"{_MOD}.item_exists", return_value=False),
+    ):
+        new = select_new_products(_args())
+    assert new[0]["date_start"] == "2026-05-30"
+    assert new[0]["date_end"] == "2026-06-01"
+
+
 def test_select_skips_s1d_at_query_time_no_dedup_call() -> None:
     """S1D is dropped before the dedup check -> never emitted, never a child Workflow."""
     products = [


### PR DESCRIPTION
## What

The data-driven CronWorkflow (T6 cluster tail) needs a per-product s1tiling window. Rather than a per-product date-math pod in the Argo manifest, `trigger_cdse.select_new_products` now emits **`date_start = date-1`** / **`date_end = date+1`** (matching the local watcher's bracket) on each record.

This **deletes an entire Argo template + a pod-per-product** from the planned CronWorkflow — the simplest overall design, chosen during the `/ai-engineering` plan review (the trigger already knows the date; the image isn't deployed yet, so there's no live version to protect).

## Contract

Emitted record is now `{tile, orbit, date_start, date_end, date, product_id, platform}`. The CronWorkflow's `withParam` consumes **only** the controlled `tile/orbit/date_start/date_end` — never the raw `product_id` (injection boundary).

## Tests

- `test_select_emits_s1tiling_window_date_minus_plus_one` + a **month-boundary** case (real date arithmetic, not string slicing). RED (`KeyError`) → GREEN.
- Full suite **502 passed**; ruff + mypy clean.

Plan: `claude-docs/plans/subissue_T6_cronworkflow.md` (task C0) · enables the CronWorkflow (#226, T6 cluster tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)