### PR TITLE
feat(s1-register): per-acquisition item preview (sel=time xyz + thumbnail)

### DIFF
--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -3,8 +3,8 @@
 The cube (`s1-rtc-{tile}.zarr`, collection `sentinel-1-grd-rtc-staging`) holds all acquisitions on a
 `time` axis. This emits **one queryable STAC item per `time` slice** (`s1-rtc-{tile}-{datetime}`,
 single `datetime`) into the `sentinel-1-grd-rtc-acquisitions` collection, each pointing at the cube
-via asset href with a `sel=time` tilejson link baked in. Explorer rendering is deferred (see #228);
-the links render once titiler resolves the store from the item href — no later data change.
+via asset href and carrying `sel=time` preview links (tilejson + xyz) and a thumbnail asset, so a
+per-acquisition item renders in the Explorer like the cube item — scoped to its own slice.
 
 Usage:
     uv run python scripts/register_per_acquisition.py --store <cube-uri> --tile-id 31TCH \
@@ -27,6 +27,17 @@ def acquisition_id(tile_id: str, when: dt.datetime) -> str:
     return f"s1-rtc-{tile_id}-{when.strftime('%Y%m%dt%H%M%S')}"
 
 
+def _sel_time_query(when: dt.datetime, orbit: str, var: str) -> str:
+    """Shared TiTiler query selecting this acquisition's slice (``sel=time``) + the VH render params."""
+    sel = urllib.parse.quote(f"time=nearest::{when.isoformat()}", safe="")
+    variables = urllib.parse.quote(f"/{orbit}:{var}", safe="")
+    return f"variables={variables}&bidx=1&rescale=0%2C219&assets={var}&sel={sel}"
+
+
+def _item_raster_base(raster_api: str, collection: str, item_id: str) -> str:
+    return f"{raster_api}/collections/{collection}/items/{item_id}"
+
+
 def sel_time_tilejson(
     raster_api: str,
     collection: str,
@@ -37,13 +48,38 @@ def sel_time_tilejson(
     var: str = "vh",
 ) -> str:
     """TiTiler tilejson URL that renders this acquisition's slice of the cube (``sel=time``)."""
-    sel = urllib.parse.quote(f"time=nearest::{when.isoformat()}", safe="")
-    variables = urllib.parse.quote(f"/{orbit}:{var}", safe="")
-    return (
-        f"{raster_api}/collections/{collection}/items/{item_id}"
-        f"/WebMercatorQuad/tilejson.json?variables={variables}&bidx=1&rescale=0%2C219"
-        f"&assets={var}&sel={sel}"
-    )
+    base = _item_raster_base(raster_api, collection, item_id)
+    return f"{base}/WebMercatorQuad/tilejson.json?{_sel_time_query(when, orbit, var)}"
+
+
+def sel_time_xyz(
+    raster_api: str,
+    collection: str,
+    item_id: str,
+    when: dt.datetime,
+    orbit: str,
+    *,
+    var: str = "vh",
+) -> str:
+    """TiTiler XYZ tile template (``{z}/{x}/{y}.png``) for this acquisition's slice — the map preview,
+    mirroring the cube item's ``xyz`` link (register_v0.add_visualization_links)."""
+    base = _item_raster_base(raster_api, collection, item_id)
+    return f"{base}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{_sel_time_query(when, orbit, var)}"
+
+
+def sel_time_thumbnail(
+    raster_api: str,
+    collection: str,
+    item_id: str,
+    when: dt.datetime,
+    orbit: str,
+    *,
+    var: str = "vh",
+) -> str:
+    """TiTiler ``preview`` PNG for this acquisition's slice — the static thumbnail, mirroring the cube
+    item's thumbnail asset (register_v0.add_thumbnail_asset)."""
+    base = _item_raster_base(raster_api, collection, item_id)
+    return f"{base}/preview?format=png&{_sel_time_query(when, orbit, var)}"
 
 
 def per_acquisition_items(
@@ -58,8 +94,8 @@ def per_acquisition_items(
     """Clone the per-tile ``base_item`` into one item per `time` slice.
 
     Each clone keeps the base geometry/assets/SAR+proj properties, sets a single ``datetime`` (drops
-    the start/end range), targets ``collection``, and carries a ``sel=time`` tilejson link. The input
-    ``base_item`` is not mutated.
+    the start/end range), targets ``collection``, and carries ``sel=time`` preview links + a thumbnail
+    asset (tilejson + xyz + thumbnail) so it renders like the cube item. ``base_item`` is not mutated.
     """
     items: list[dict] = []
     for t_ns in times_ns:
@@ -81,8 +117,20 @@ def per_acquisition_items(
                 "type": "application/json",
                 "href": sel_time_tilejson(raster_api, collection, item_id, when, orbit),
                 "title": "tilejson (sel=time)",
-            }
+            },
+            {
+                "rel": "xyz",
+                "type": "image/png",
+                "href": sel_time_xyz(raster_api, collection, item_id, when, orbit),
+                "title": "Sentinel-1 GRD VH (sel=time)",
+            },
         ]
+        item.setdefault("assets", {})["thumbnail"] = {
+            "href": sel_time_thumbnail(raster_api, collection, item_id, when, orbit),
+            "type": "image/png",
+            "roles": ["thumbnail"],
+            "title": "Sentinel-1 GRD VH Preview (sel=time)",
+        }
         items.append(item)
     return items
 

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -1,7 +1,7 @@
 """Unit tests for scripts/register_per_acquisition.py — per-acquisition STAC items (plan T5).
 
-One STAC item per cube `time` slice, id `s1-rtc-{tile}-{datetime}`, with `sel=time` viz links
-baked (explorer rendering deferred to #228). Pure builders tested here; store I/O + upsert in main().
+One STAC item per cube `time` slice, id `s1-rtc-{tile}-{datetime}`, with `sel=time` preview links
+(tilejson + xyz) and a thumbnail asset. Pure builders tested here; store I/O + upsert in main().
 """
 
 import datetime as dt
@@ -72,6 +72,28 @@ def test_sel_time_tilejson_carries_sel_and_item():
     assert "tilejson.json" in url
 
 
+# --- sel_time_xyz / sel_time_thumbnail (preview parity with the cube item) ----
+
+
+def test_sel_time_xyz_is_png_tile_template_with_sel():
+    m = _mod()
+    when = dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC)
+    url = m.sel_time_xyz(RASTER, ACQ, "s1-rtc-31TCH-20260605t060907", when, "descending")
+    # XYZ tile template (titiler {z}/{x}/{y}.png), scoped to this acquisition's slice
+    assert "/tiles/WebMercatorQuad/{z}/{x}/{y}.png" in url
+    assert "s1-rtc-31TCH-20260605t060907" in url
+    assert "sel=" in url and "time%3Dnearest" in url
+    assert "rescale=0%2C219" in url and "assets=vh" in url
+
+
+def test_sel_time_thumbnail_is_png_preview_with_sel():
+    m = _mod()
+    when = dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC)
+    url = m.sel_time_thumbnail(RASTER, ACQ, "s1-rtc-31TCH-20260605t060907", when, "descending")
+    assert "/preview" in url and "format=png" in url
+    assert "sel=" in url and "time%3Dnearest" in url
+
+
 # --- per_acquisition_items ---------------------------------------------------
 
 
@@ -112,6 +134,32 @@ def test_per_acquisition_items_collection_and_sel_link():
     tilejson = [link for link in item["links"] if link["rel"] == "tilejson"]
     assert len(tilejson) == 1
     assert "sel=" in tilejson[0]["href"] and item["id"] in tilejson[0]["href"]
+
+
+def test_per_acquisition_items_has_xyz_link_and_thumbnail_asset():
+    """Preview parity with the cube item: each per-acq item carries an xyz link + a thumbnail
+    asset, both scoped to the acquisition's slice (sel=time)."""
+    m = _mod()
+    items = m.per_acquisition_items(
+        _base_item(), [_T0], tile_id="31TCH", orbit="descending", collection=ACQ, raster_api=RASTER
+    )
+    item = items[0]
+    rels = {link["rel"] for link in item["links"]}
+    assert {"tilejson", "xyz"} <= rels
+    xyz = next(link for link in item["links"] if link["rel"] == "xyz")
+    assert "{z}/{x}/{y}.png" in xyz["href"] and "sel=" in xyz["href"]
+    thumb = item["assets"]["thumbnail"]
+    assert thumb["type"] == "image/png" and thumb["roles"] == ["thumbnail"]
+    assert "sel=" in thumb["href"] and item["id"] in thumb["href"]
+
+
+def test_per_acquisition_items_does_not_add_thumbnail_to_base():
+    m = _mod()
+    base = _base_item()
+    m.per_acquisition_items(
+        base, [_T0], tile_id="31TCH", orbit="descending", collection=ACQ, raster_api=RASTER
+    )
+    assert "thumbnail" not in base["assets"]  # base assets untouched
 
 
 def test_per_acquisition_items_does_not_mutate_base():


### PR DESCRIPTION
## What
Give per-acquisition STAC items a titiler **preview** like the cube item (`s1-rtc-32TLR`): add a
`sel=time` **xyz** map-tile link and a **thumbnail** PNG asset to each item in
`register_per_acquisition.per_acquisition_items()`, alongside the existing `sel=time` tilejson link.

## Why
Per-acq items previously had only a tilejson link, so the Explorer didn't render a tile preview for
them. The cube item gets `xyz` + `thumbnail` via the shared `register_v0` helpers — but those don't
support time selection, which is why the per-acq path hand-rolls `sel_time_*` builders. This adds the
two missing pieces, each scoped to the acquisition's slice (`sel=time=nearest::{datetime}`).

## How
- New `sel_time_xyz()` / `sel_time_thumbnail()` mirroring the existing `sel_time_tilejson()`.
- Factored the shared query into `_sel_time_query()` (no triplication).
- Render extension already inherited from the base item — no change there; cube-item registration
  (`register_v1_s1_rtc`) untouched.

## Tests
4 new TDD unit tests (builders + per-item emission + base-not-mutated). Full suite: 443 passed,
ruff + mypy clean.

Part of the per-acquisition plan (Workstream B). Ships independently of the cron dedup-loop work (F7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)