### PR TITLE
feat(s1-trigger): collapse same-pass frames to one product per pass (OQ-1)

### DIFF
--- a/scripts/trigger_cdse.py
+++ b/scripts/trigger_cdse.py
@@ -115,14 +115,36 @@ def item_exists(stac_api_url: str, acq_collection: str, item_id: str) -> bool:
     return next(iter(search.items()), None) is not None
 
 
+def collapse_same_pass(products: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Collapse adjacent frames of one satellite pass to a single representative product.
+
+    CDSE returns one product per *frame*; a tile is typically covered by 2+ adjacent frames of the same
+    pass (same relative orbit + datatake), which s1tiling mosaics into ONE tile ``time``. Emitting per
+    frame would spawn redundant pipelines and register only one of the N per-acquisition ids — a re-run
+    then re-emits the rest (the dedup loop never closes). A pass images a tile once per date+platform for
+    a fixed orbit direction, so group by ``(date, platform)`` and keep the earliest-datetime frame.
+    """
+    # Keep one product per (date, platform); the dict preserves first-seen pass order, and within a
+    # pass the earliest-datetime frame wins (the representative). No global re-sort — that would reorder
+    # distinct acquisitions relative to the CDSE query order.
+    by_pass: dict[tuple[str, str], dict[str, str]] = {}
+    for product in products:
+        key = (product["date"], product["platform"])
+        current = by_pass.get(key)
+        if current is None or product["datetime"] < current["datetime"]:
+            by_pass[key] = product
+    return list(by_pass.values())
+
+
 def select_new_products(args: argparse.Namespace) -> list[dict[str, str]]:
-    """Per tile: query CDSE, drop non-{S1A,S1C} (logged) and already-registered acquisitions (logged),
-    and return the new products to submit as ``{tile, orbit, product_id, datetime, date, platform}``."""
+    """Per tile: query CDSE, collapse same-pass frames, drop non-{S1A,S1C} (logged) and already-registered
+    acquisitions (logged), and return the new products as ``{tile, orbit, product_id, datetime, date,
+    platform, date_start, date_end}``."""
     tiles = [t.strip() for t in args.tiles.split(",") if t.strip()]
     new_products: list[dict[str, str]] = []
     for tile in tiles:
-        products = query_products(
-            CDSE_STAC_URL, tile_bbox(tile), args.orbit_direction, args.lookback_days
+        products = collapse_same_pass(
+            query_products(CDSE_STAC_URL, tile_bbox(tile), args.orbit_direction, args.lookback_days)
         )
         for product in products:
             platform = product["platform"]

--- a/tests/unit/test_trigger_cdse.py
+++ b/tests/unit/test_trigger_cdse.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(scripts_dir))
 
 from trigger_cdse import (  # noqa: E402
     build_parser,
+    collapse_same_pass,
     expected_item_id,
     is_enabled_platform,
     item_exists,
@@ -169,6 +170,44 @@ def _product(product_id: str, platform: str, when: str) -> dict[str, str]:
         "datetime": when,
         "date": when[:10],
     }
+
+
+# --- collapse_same_pass (A3 — adjacent frames of one pass -> one product) --------------------
+
+
+def test_collapse_same_pass_keeps_earliest_frame_per_date_platform() -> None:
+    """Two adjacent frames of one pass (same date+platform) collapse to the earliest-datetime frame."""
+    frames = [
+        _product("S1C_f2", "S1C", "2026-06-06T06:00:12+00:00"),
+        _product("S1C_f1", "S1C", "2026-06-06T05:59:47+00:00"),
+    ]
+    assert [p["product_id"] for p in collapse_same_pass(frames)] == ["S1C_f1"]
+
+
+def test_collapse_same_pass_keeps_distinct_dates_and_platforms() -> None:
+    """Distinct acquisitions (different date OR platform) are NOT collapsed."""
+    products = [
+        _product("S1C_a", "S1C", "2026-06-06T06:00:12+00:00"),
+        _product("S1A_a", "S1A", "2026-06-06T06:00:12+00:00"),  # same date, different platform
+        _product("S1C_b", "S1C", "2026-06-07T06:00:00+00:00"),  # different date
+    ]
+    assert len(collapse_same_pass(products)) == 3
+
+
+def test_select_collapses_same_pass_frames_to_one() -> None:
+    """End-to-end: 2 same-pass S1C frames -> the trigger emits ONE product (the earliest frame)."""
+    products = [
+        _product("S1C_f2", "S1C", "2026-06-06T06:00:12+00:00"),
+        _product("S1C_f1", "S1C", "2026-06-06T05:59:47+00:00"),
+    ]
+    with (
+        patch(f"{_MOD}.query_products", return_value=products),
+        patch(f"{_MOD}.item_exists", return_value=False),
+    ):
+        new = select_new_products(_args())
+    assert len(new) == 1
+    assert new[0]["product_id"] == "S1C_f1"
+    assert new[0]["date"] == "2026-06-06"
 
 
 def test_select_emits_only_unregistered_products() -> None:


### PR DESCRIPTION
## What
`trigger_cdse` now collapses adjacent frames of one satellite pass into a single emitted product, via a
new `collapse_same_pass()` applied to each tile's CDSE query result.

## Why
CDSE returns one product per **frame**; a tile is usually covered by 2+ adjacent frames of the same pass
(same relative orbit + datatake), which s1tiling mosaics into **one** tile `time`. Emitting per frame:
- spawned redundant s1tiling→ingest pipelines for one acquisition, and
- registered only one of the N per-acquisition ids → a re-run re-emitted the sibling frame forever (the
  dedup loop never closed).

Live-observed during the C4 verification (`hzpr6`): two S1C frames `…0103AE_37DC` / `…0103AE_B5ED` (same
datatake) emitted for one pass.

## How
Group by `(date, platform)` — one pass images a tile once per date/platform for a fixed orbit direction —
keeping the **earliest-datetime** frame as the representative. No global re-sort, so distinct acquisitions
keep CDSE query order (a regression the existing dedup test caught).

Resolves **OQ-1**. Part of the dedup-loop work (Workstream A); A1 (platform passthrough) + A2
(register-per-acq Argo step) follow in platform-deploy.

## Tests
3 new unit tests (collapse earliest-per-pass, distinct date/platform preserved, end-to-end select → one).
Full suite: 446 passed, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)