### PR TITLE
feat(s1-register): env-split per-acquisition collection (tests/staging/prod)

### DIFF
--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -2,7 +2,8 @@
 
 The cube (`s1-rtc-{tile}.zarr`, collection `sentinel-1-grd-rtc-staging`) holds all acquisitions on a
 `time` axis. This emits **one queryable STAC item per `time` slice** (`s1-rtc-{tile}-{datetime}`,
-single `datetime`) into the `sentinel-1-grd-rtc-acquisitions` collection, each pointing at the cube
+single `datetime`) into the env-split per-acquisition collection (`--collection`, default `…-tests`,
+the cron passes `…-staging`), each pointing at the cube
 via asset href and carrying `sel=time` preview links (tilejson + xyz) and a thumbnail asset, so a
 per-acquisition item renders in the Explorer like the cube item — scoped to its own slice.
 
@@ -19,7 +20,9 @@ import datetime as dt
 import urllib.parse
 from typing import Any
 
-DEFAULT_ACQ_COLLECTION = "sentinel-1-grd-rtc-acquisitions"
+# Per-acquisition collections are env-split like the cube collections (…-tests/-staging/-prod). The
+# code default targets the test env (local/CP-A runs); the Argo cron passes --collection …-staging.
+DEFAULT_ACQ_COLLECTION = "sentinel-1-grd-rtc-acquisitions-tests"
 
 
 def acquisition_id(tile_id: str, when: dt.datetime) -> str:

--- a/scripts/trigger_cdse.py
+++ b/scripts/trigger_cdse.py
@@ -1,8 +1,9 @@
 """Data-driven CDSE trigger for the S1 GRD RTC pipeline (Phase-6 Task 6).
 
 Queries CDSE for new S1 GRD products over a tile+window, keeps only ``{S1A, S1C}`` (S1D skipped,
-logged), drops acquisitions whose **per-acquisition STAC item already exists** in
-``sentinel-1-grd-rtc-acquisitions``, and emits the remaining NEW products as a JSON array (to
+logged), drops acquisitions whose **per-acquisition STAC item already exists** in the env-split
+per-acquisition collection (``--acq-collection``; cron passes ``…-staging``), and emits the remaining
+NEW products as a JSON array (to
 ``--output`` or stdout). The Argo CronWorkflow consumes that array to fan out one child Workflow per
 product (decision B); the **cube-time-present** dedup arm runs downstream in ingest (T4). This is a
 pure query -> filter -> dedup -> emit step: no subprocess, no S3, no submission.

--- a/tests/unit/test_trigger_cdse.py
+++ b/tests/unit/test_trigger_cdse.py
@@ -316,8 +316,9 @@ def test_select_queries_cdse_catalogue_not_target_stac() -> None:
     assert q.call_args.args[0] == CDSE_STAC_URL
 
 
-def test_parser_acq_collection_defaults_to_acquisitions() -> None:
-    assert _args().acq_collection == "sentinel-1-grd-rtc-acquisitions"
+def test_parser_acq_collection_defaults_to_tests() -> None:
+    # env-split: code default is the test env; the cron passes --acq-collection …-staging
+    assert _args().acq_collection == "sentinel-1-grd-rtc-acquisitions-tests"
 
 
 def test_main_writes_json_array_to_output(tmp_path: Path) -> None:


### PR DESCRIPTION
## What
Make the per-acquisition collection **env-split** like the cube collections — `…-tests` / `…-staging`
(`…-prod` later). `DEFAULT_ACQ_COLLECTION` moves from the (now retired) base `sentinel-1-grd-rtc-acquisitions`
to `sentinel-1-grd-rtc-acquisitions-tests` (local/CP-A target); the cron passes `…-staging` explicitly.

## Why
Staging and prod need separate per-acquisition collections (parallel to `sentinel-1-grd-rtc-staging`/`-prod`).

## Companion
- platform-deploy #225 — ingest `acq_collection` → `…-staging`; cron discover `--acq-collection …-staging`.
- STAC: `…-staging` + `…-tests` created; base `sentinel-1-grd-rtc-acquisitions` retired.

## Tests
`test_parser_acq_collection_defaults_to_tests` updated; trigger+register tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)