### PR TITLE
feat(s1-trigger): --orbit-direction both (asc+desc AOI coverage) — T7 Task 3

### DIFF
--- a/scripts/trigger_cdse.py
+++ b/scripts/trigger_cdse.py
@@ -142,43 +142,53 @@ def select_new_products(args: argparse.Namespace) -> list[dict[str, str]]:
     acquisitions (logged), and return the new products as ``{tile, orbit, product_id, datetime, date,
     platform, date_start, date_end}``."""
     tiles = [t.strip() for t in args.tiles.split(",") if t.strip()]
+    # `both` discovers ascending + descending passes (asc+desc AOI); each is queried separately so
+    # same-pass collapse never merges across directions, and each product carries its own orbit.
+    orbits = (
+        ["ascending", "descending"] if args.orbit_direction == "both" else [args.orbit_direction]
+    )
     new_products: list[dict[str, str]] = []
     for tile in tiles:
-        products = collapse_same_pass(
-            query_products(CDSE_STAC_URL, tile_bbox(tile), args.orbit_direction, args.lookback_days)
-        )
-        for product in products:
-            platform = product["platform"]
-            if not is_enabled_platform(platform):
-                log.info("skip %s: platform %s not enabled", product["product_id"], platform)
-                continue
-            when = dt.datetime.fromisoformat(product["datetime"])
-            item_id = expected_item_id(tile, when)
-            if item_exists(args.stac_api_url, args.acq_collection, item_id):
-                log.info("skip %s: item %s already registered", product["product_id"], item_id)
-                continue
-            # s1tiling window brackets the acquisition day (date∓1, matching the local watcher), so
-            # the CronWorkflow fans out child pipelines with no per-product date-math step.
-            acq_date = dt.date.fromisoformat(product["date"])
-            new_products.append(
-                {
-                    "tile": tile,
-                    "orbit": args.orbit_direction,
-                    "product_id": product["product_id"],
-                    "datetime": product["datetime"],
-                    "date": product["date"],
-                    "date_start": (acq_date - dt.timedelta(days=1)).isoformat(),
-                    "date_end": (acq_date + dt.timedelta(days=1)).isoformat(),
-                    "platform": platform,
-                }
+        bbox = tile_bbox(tile)
+        for orbit in orbits:
+            products = collapse_same_pass(
+                query_products(CDSE_STAC_URL, bbox, orbit, args.lookback_days)
             )
+            for product in products:
+                platform = product["platform"]
+                if not is_enabled_platform(platform):
+                    log.info("skip %s: platform %s not enabled", product["product_id"], platform)
+                    continue
+                when = dt.datetime.fromisoformat(product["datetime"])
+                item_id = expected_item_id(tile, when)
+                if item_exists(args.stac_api_url, args.acq_collection, item_id):
+                    log.info("skip %s: item %s already registered", product["product_id"], item_id)
+                    continue
+                # s1tiling window brackets the acquisition day (date∓1, matching the local watcher),
+                # so the CronWorkflow fans out child pipelines with no per-product date-math step.
+                acq_date = dt.date.fromisoformat(product["date"])
+                new_products.append(
+                    {
+                        "tile": tile,
+                        "orbit": orbit,
+                        "product_id": product["product_id"],
+                        "datetime": product["datetime"],
+                        "date": product["date"],
+                        "date_start": (acq_date - dt.timedelta(days=1)).isoformat(),
+                        "date_end": (acq_date + dt.timedelta(days=1)).isoformat(),
+                        "platform": platform,
+                    }
+                )
     return new_products
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--tiles", required=True, help="Comma-separated MGRS tile IDs (e.g. 31TCH)")
-    parser.add_argument("--orbit-direction", required=True, choices=["ascending", "descending"])
+    parser.add_argument(
+        "--orbit-direction", required=True, choices=["ascending", "descending", "both"],
+        help="single direction, or 'both' to discover ascending + descending passes (asc+desc AOI)",
+    )  # fmt: skip
     parser.add_argument("--lookback-days", required=True, type=int, help="CDSE query window (days)")
     parser.add_argument(
         "--stac-api-url", required=True, help="EOPF target STAC API (per-acquisition dedup)"

--- a/tests/unit/test_trigger_cdse.py
+++ b/tests/unit/test_trigger_cdse.py
@@ -304,6 +304,50 @@ def test_select_iterates_multiple_tiles() -> None:
     assert {p["tile"] for p in new} == {"31TCH", "30TXM"}
 
 
+# --- asc+desc coverage (T7) -----------------------------------------------------------------
+
+
+def test_parser_orbit_direction_accepts_both() -> None:
+    """`--orbit-direction both` is a valid choice (asc+desc AOI coverage, T7)."""
+    ns = build_parser().parse_args(
+        ["--tiles", "31TCH", "--orbit-direction", "both",
+         "--lookback-days", "7", "--stac-api-url", "https://eopf/stac"]
+    )  # fmt: skip
+    assert ns.orbit_direction == "both"
+
+
+def test_select_orbit_both_queries_both_directions_and_tags_each() -> None:
+    """`both` runs discover for ascending AND descending, tagging each product with its own orbit."""
+
+    def _q(_stac: str, _bbox: list, orbit: str, _lookback: int) -> list[dict]:
+        # asc/desc passes image a tile at different times -> distinct datetimes
+        when = "2026-06-07T05:52:48+00:00" if orbit == "descending" else "2026-06-07T17:10:00+00:00"
+        return [_product(f"S1A_{orbit}", "S1A", when)]
+
+    with (
+        patch(f"{_MOD}.query_products", side_effect=_q) as q,
+        patch(f"{_MOD}.item_exists", return_value=False),
+    ):
+        new = select_new_products(_args(orbit_direction="both"))
+    assert {call.args[2] for call in q.call_args_list} == {"ascending", "descending"}
+    assert {p["orbit"] for p in new} == {"ascending", "descending"}
+    assert len(new) == 2
+
+
+def test_select_single_orbit_unchanged() -> None:
+    """A single direction still queries once and tags that direction (no behaviour change)."""
+    with (
+        patch(
+            f"{_MOD}.query_products",
+            return_value=[_product("S1A", "S1A", "2026-06-07T05:52:48+00:00")],
+        ) as q,
+        patch(f"{_MOD}.item_exists", return_value=False),
+    ):
+        new = select_new_products(_args(orbit_direction="ascending"))
+    assert q.call_count == 1 and q.call_args.args[2] == "ascending"
+    assert [p["orbit"] for p in new] == ["ascending"]
+
+
 def test_select_queries_cdse_catalogue_not_target_stac() -> None:
     """The acquisition query hits the CDSE source catalogue, not the EOPF target STAC."""
     from trigger_cdse import CDSE_STAC_URL


### PR DESCRIPTION
## What
`trigger_cdse --orbit-direction both` discovers **ascending AND descending** passes. `select_new_products`
queries each direction separately and tags every emitted product with its own `orbit`.

## Why
T7 (multi-tile AOI) covers both orbit directions. Querying per-direction keeps same-pass frame collapse
(A3) from merging across directions, and the cron fan-out already consumes `{{item.orbit}}` per product —
so no downstream change. The per-tile cube stores asc/desc as separate groups.

## Design (per the reviewed T7 plan, D3)
- `--orbit-direction` choices gain `both`; single-direction behaviour is unchanged.
- `both` → `["ascending","descending"]`, each queried + collapsed independently, products tagged per orbit.

## Tests (TDD)
3 new: parser accepts `both`; `both` queries asc+desc and tags each; single-orbit unchanged.
Full suite **454 passed**, ruff + mypy clean.

First slice of **T7 Task 3** (foundation). Tasks 0/1/2 (download hardening, per-tile mutex, on-demand DEM)
follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)