### PR TITLE
feat(query-stac): batched fan-out + newest-first ordering + acquisition-age filter

### DIFF
--- a/scripts/query_stac.py
+++ b/scripts/query_stac.py
@@ -54,21 +54,26 @@ def _validate_bbox(bbox: object) -> None:
             sys.exit(f"Error: AOI_BBOX[{i}] must be a number, got: {v!r}")
 
 
+def _to_utc(dt: datetime) -> datetime:
+    """Normalize a datetime to UTC-aware so comparisons/sorts never mix naive and aware.
+
+    Naive datetimes are assumed UTC (pystac preserves naive inputs); aware ones are
+    converted to UTC. Centralizing this keeps the sort key and the acquisition filter
+    using identical semantics.
+    """
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)
+
+
 def _acquisition_sort_key(item: dict) -> datetime:
     """Sort key for ordering processing items by acquisition datetime (newest first).
 
     Parses the stored ISO timestamp so the comparison is chronological (not lexicographic,
-    which would break across mixed UTC offsets). Naive timestamps are treated as UTC and
-    items with no datetime sort oldest, so the key is always tz-aware and never raises on
-    mixed naive/aware comparisons.
+    which would break across mixed UTC offsets). Items with no datetime sort oldest.
     """
     raw = item.get("datetime")
     if not raw:
         return datetime.min.replace(tzinfo=UTC)
-    parsed = datetime.fromisoformat(raw)
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
-    return parsed
+    return _to_utc(datetime.fromisoformat(raw))
 
 
 def discover(args: argparse.Namespace) -> None:
@@ -80,10 +85,13 @@ def discover(args: argparse.Namespace) -> None:
     SCHEDULED_END_TIME = args.scheduled_end_time
     WINDOW_HOURS = args.window_hours
     AOI_BBOX = args.aoi_bbox
+    MAX_ACQUISITION_AGE_DAYS = args.max_acquisition_age_days
 
     _require_https(SOURCE_STAC_API_URL, "SOURCE_STAC_API_URL")
     _require_https(TARGET_STAC_API_URL, "TARGET_STAC_API_URL")
     _validate_bbox(AOI_BBOX)
+    if MAX_ACQUISITION_AGE_DAYS is not None and MAX_ACQUISITION_AGE_DAYS <= 0:
+        sys.exit(f"Error: --max-acquisition-age-days must be > 0, got: {MAX_ACQUISITION_AGE_DAYS}")
 
     # Parse scheduled end time and calculate start time
     end_time = datetime.fromisoformat(SCHEDULED_END_TIME.replace("Z", "+00:00"))
@@ -93,6 +101,16 @@ def discover(args: argparse.Namespace) -> None:
     start_time_str = start_time.isoformat().replace("+00:00", "Z")
     end_time_str = end_time.isoformat().replace("+00:00", "Z")
 
+    # Acquisition-date floor for real-time processing: keep only items observed within the
+    # last N days of the window end, so a reingestion that re-stamps `updated` on old
+    # acquisitions doesn't flood the queue. Floor only (open upper bound) — never drop the
+    # freshest data. Unset → no acquisition filter (original behaviour).
+    min_acquisition_dt = (
+        end_time - timedelta(days=MAX_ACQUISITION_AGE_DAYS)
+        if MAX_ACQUISITION_AGE_DAYS is not None
+        else None
+    )
+
     logger.info(f"Querying source STAC API: {SOURCE_STAC_API_URL}")
     logger.info(f"Source collection: {SOURCE_COLLECTION}")
     logger.info(f"Target STAC API: {TARGET_STAC_API_URL}")
@@ -101,6 +119,11 @@ def discover(args: argparse.Namespace) -> None:
     logger.info(f"Time window: {WINDOW_HOURS} hours")
     logger.info(f"Query time range: {start_time_str} to {end_time_str}")
     logger.info(f"Area of Interest (bbox): {AOI_BBOX}")
+    if min_acquisition_dt is not None:
+        logger.info(
+            f"Acquisition floor: {min_acquisition_dt.isoformat().replace('+00:00', 'Z')} "
+            f"(max age {MAX_ACQUISITION_AGE_DAYS} days)"
+        )
 
     # Connect to source STAC catalog
     source_catalog = Client.open(SOURCE_STAC_API_URL)
@@ -110,20 +133,26 @@ def discover(args: argparse.Namespace) -> None:
 
     # Search for items by updated time (for harvesting use case)
     # Query items that were updated within the time window, not by acquisition date
-    search = source_catalog.search(
-        collections=[SOURCE_COLLECTION],
-        filter={
+    search_kwargs: dict[str, object] = {
+        "collections": [SOURCE_COLLECTION],
+        "filter": {
             "op": "between",
             "args": [{"property": "updated"}, start_time_str, end_time_str],
         },
-        filter_lang="cql2-json",
-        bbox=AOI_BBOX,
-        limit=100,  # Items per page for efficient pagination
-    )
+        "filter_lang": "cql2-json",
+        "bbox": AOI_BBOX,
+        "limit": 100,  # Items per page for efficient pagination
+    }
+    # Narrow by acquisition datetime server-side too (open upper bound), so the flood is
+    # trimmed before pagination. The client-side guard below remains authoritative.
+    if min_acquisition_dt is not None:
+        search_kwargs["datetime"] = f"{min_acquisition_dt.isoformat().replace('+00:00', 'Z')}/.."
+    search = source_catalog.search(**search_kwargs)
 
     # Collect items to process
     items_to_process = []
     checked_count = 0
+    skipped_old_count = 0
     page_count = 0
 
     logger.info("Starting pagination through search results...")
@@ -141,6 +170,15 @@ def discover(args: argparse.Namespace) -> None:
 
         for item in page_items:
             checked_count += 1
+
+            # Acquisition-date filter (real-time): drop items observed before the floor, or
+            # with no datetime (can't be proven recent). Done before the per-item dedup
+            # search below so filtered items cost no target-API call.
+            if min_acquisition_dt is not None and (
+                item.datetime is None or _to_utc(item.datetime) < min_acquisition_dt
+            ):
+                skipped_old_count += 1
+                continue
 
             # Get item URL
             item_url = next(
@@ -178,7 +216,9 @@ def discover(args: argparse.Namespace) -> None:
             )
 
     logger.info(
-        f"📊 Summary: Processed {page_count} pages, checked {checked_count} items, {len(items_to_process)} to process"
+        f"📊 Summary: Processed {page_count} pages, checked {checked_count} items, "
+        f"{skipped_old_count} skipped (out of acquisition window), "
+        f"{len(items_to_process)} to process"
     )
 
     # Process most-recent-first: during a large reingestion backlog, order the queue by
@@ -228,6 +268,13 @@ def main() -> None:
         "--out-dir", required=True, help="Directory to write items.json/count/num_batches."
     )
     d.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    d.add_argument(
+        "--max-acquisition-age-days",
+        type=int,
+        default=None,
+        help="Real-time filter: keep only items whose acquisition datetime is within the last "
+        "N days of the scheduled window end. Omit for no acquisition filter (default).",
+    )
     d.set_defaults(func=discover)
 
     r = sub.add_parser("read-batch", help="Print one bounded slice of an items file.")

--- a/scripts/query_stac.py
+++ b/scripts/query_stac.py
@@ -5,17 +5,31 @@ Query STAC API for new items to process.
 This script searches for items in a source collection that were updated within
 a specified time window and checks if they already exist in the target collection
 to avoid reprocessing. Uses the 'updated' property for harvesting use cases.
+
+Two modes (subcommands):
+
+- ``discover``: run the STAC query and write the full item list to ``items.json``
+  in ``--out-dir`` (Argo ships it as an output artifact), plus ``count`` and
+  ``num_batches`` files for the workflow to fan out over. The list is NOT written
+  to stdout: Argo caps a step's stdout/result at ~256 KB, and a large window would
+  truncate it and break the downstream ``withParam`` loop.
+- ``read-batch``: print one bounded slice ``[index*size : (index+1)*size]`` of a
+  previously written items file as a JSON list — small enough for ``withParam``.
 """
 
 import argparse
 import json
 import logging
+import math
 import os
 import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 from urllib.parse import urlparse
 
 from pystac_client import Client
+
+DEFAULT_BATCH_SIZE = 200
 
 # Configure logging
 logging.basicConfig(
@@ -40,18 +54,8 @@ def _validate_bbox(bbox: object) -> None:
             sys.exit(f"Error: AOI_BBOX[{i}] must be a number, got: {v!r}")
 
 
-def main() -> None:
-    """Main entry point for STAC query script."""
-    parser = argparse.ArgumentParser(description="Query STAC API for new items to process.")
-    parser.add_argument("source_stac_api_url", metavar="SOURCE_STAC_API_URL")
-    parser.add_argument("source_collection", metavar="SOURCE_COLLECTION")
-    parser.add_argument("target_stac_api_url", metavar="TARGET_STAC_API_URL")
-    parser.add_argument("target_collection", metavar="TARGET_COLLECTION")
-    parser.add_argument("scheduled_end_time", metavar="SCHEDULED_END_TIME")
-    parser.add_argument("window_hours", metavar="WINDOW_HOURS", type=int)
-    parser.add_argument("aoi_bbox", metavar="AOI_BBOX", type=json.loads)
-    args = parser.parse_args()
-
+def discover(args: argparse.Namespace) -> None:
+    """Query STAC and write the item manifest files for the workflow to fan out over."""
     SOURCE_STAC_API_URL = args.source_stac_api_url
     SOURCE_COLLECTION = args.source_collection
     TARGET_STAC_API_URL = args.target_stac_api_url
@@ -159,9 +163,57 @@ def main() -> None:
         f"📊 Summary: Processed {page_count} pages, checked {checked_count} items, {len(items_to_process)} to process"
     )
 
-    # Output ONLY JSON to stdout (for Argo withParam)
-    sys.stdout.write(json.dumps(items_to_process))
+    # Write the full list as files: items.json becomes an Argo output artifact; count
+    # and num_batches drive the workflow's batch fan-out. Nothing large goes to stdout,
+    # so we never hit Argo's ~256 KB result cap regardless of how many items match.
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "items.json").write_text(json.dumps(items_to_process))
+    (out_dir / "count").write_text(str(len(items_to_process)))
+    num_batches = math.ceil(len(items_to_process) / args.batch_size)
+    (out_dir / "num_batches").write_text(str(num_batches))
+    logger.info(
+        f"Wrote {len(items_to_process)} items to {out_dir / 'items.json'} "
+        f"(batch_size={args.batch_size}, num_batches={num_batches})"
+    )
+
+
+def read_batch(args: argparse.Namespace) -> None:
+    """Print one bounded slice ``[index*size : (index+1)*size]`` of an items file."""
+    items = json.loads(Path(args.items_file).read_text())
+    start = args.index * args.batch_size
+    batch = items[start : start + args.batch_size]
+    sys.stdout.write(json.dumps(batch))
     sys.stdout.flush()
+
+
+def main() -> None:
+    """Dispatch to the ``discover`` or ``read-batch`` subcommand."""
+    parser = argparse.ArgumentParser(description="Query STAC API for new items to process.")
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    d = sub.add_parser("discover", help="Run the STAC query and write the item manifest.")
+    d.add_argument("source_stac_api_url", metavar="SOURCE_STAC_API_URL")
+    d.add_argument("source_collection", metavar="SOURCE_COLLECTION")
+    d.add_argument("target_stac_api_url", metavar="TARGET_STAC_API_URL")
+    d.add_argument("target_collection", metavar="TARGET_COLLECTION")
+    d.add_argument("scheduled_end_time", metavar="SCHEDULED_END_TIME")
+    d.add_argument("window_hours", metavar="WINDOW_HOURS", type=int)
+    d.add_argument("aoi_bbox", metavar="AOI_BBOX", type=json.loads)
+    d.add_argument(
+        "--out-dir", required=True, help="Directory to write items.json/count/num_batches."
+    )
+    d.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    d.set_defaults(func=discover)
+
+    r = sub.add_parser("read-batch", help="Print one bounded slice of an items file.")
+    r.add_argument("items_file", metavar="ITEMS_FILE")
+    r.add_argument("index", metavar="INDEX", type=int)
+    r.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    r.set_defaults(func=read_batch)
+
+    args = parser.parse_args()
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/scripts/query_stac.py
+++ b/scripts/query_stac.py
@@ -23,7 +23,7 @@ import logging
 import math
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -52,6 +52,23 @@ def _validate_bbox(bbox: object) -> None:
     for i, v in enumerate(bbox):
         if not isinstance(v, int | float):
             sys.exit(f"Error: AOI_BBOX[{i}] must be a number, got: {v!r}")
+
+
+def _acquisition_sort_key(item: dict) -> datetime:
+    """Sort key for ordering processing items by acquisition datetime (newest first).
+
+    Parses the stored ISO timestamp so the comparison is chronological (not lexicographic,
+    which would break across mixed UTC offsets). Naive timestamps are treated as UTC and
+    items with no datetime sort oldest, so the key is always tz-aware and never raises on
+    mixed naive/aware comparisons.
+    """
+    raw = item.get("datetime")
+    if not raw:
+        return datetime.min.replace(tzinfo=UTC)
+    parsed = datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
 
 
 def discover(args: argparse.Namespace) -> None:
@@ -156,12 +173,19 @@ def discover(args: argparse.Namespace) -> None:
                     "source_url": item_url,
                     "collection": TARGET_COLLECTION,
                     "item_id": item.id,
+                    "datetime": item.datetime.isoformat() if item.datetime else None,
                 }
             )
 
     logger.info(
         f"📊 Summary: Processed {page_count} pages, checked {checked_count} items, {len(items_to_process)} to process"
     )
+
+    # Process most-recent-first: during a large reingestion backlog, order the queue by
+    # acquisition datetime descending so the freshest observations are converted before the
+    # long tail drains. The stable sort preserves pagination order within equal datetimes;
+    # items lacking a datetime sort last.
+    items_to_process.sort(key=_acquisition_sort_key, reverse=True)
 
     # Write the full list as files: items.json becomes an Argo output artifact; count
     # and num_batches drive the workflow's batch fan-out. Nothing large goes to stdout,

--- a/tests/unit/test_query_stac.py
+++ b/tests/unit/test_query_stac.py
@@ -1,6 +1,7 @@
 """Simple tests for query_stac.py script."""
 
 import json
+import tempfile
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
@@ -114,9 +115,12 @@ class FakeStacClient:
 
 
 def run_script(
-    source_items: list[Item], target_items: list[Item], raise_error_on_target: bool = False
+    source_items: list[Item],
+    target_items: list[Item],
+    raise_error_on_target: bool = False,
+    batch_size: int = 200,
 ) -> dict:
-    """Helper to run the script with test data."""
+    """Helper to run `discover` mode with test data and read back the manifest files."""
     source_client = FakeStacClient(
         items=source_items,
         collection=SOURCE_COLLECTION,
@@ -135,12 +139,14 @@ def run_script(
             return source_client
         return target_client
 
+    out_dir = tempfile.mkdtemp()
     with (
         patch("scripts.query_stac.Client.open", side_effect=mock_client_open),
         patch(
             "sys.argv",
             [
                 "query_stac.py",
+                "discover",
                 "https://source-stac.example.com/",
                 SOURCE_COLLECTION,
                 "https://target-stac.example.com/",
@@ -148,6 +154,10 @@ def run_script(
                 "2024-01-01T12:00:00Z",  # ISO timestamp instead of "0"
                 "3",
                 "[-5.14, 41.33, 9.56, 51.09]",
+                "--out-dir",
+                out_dir,
+                "--batch-size",
+                str(batch_size),
             ],
         ),
         patch("sys.stdout", StringIO()) as stdout,
@@ -157,12 +167,43 @@ def run_script(
 
         main()
 
-        return {
-            "output": json.loads(stdout.getvalue()),
-            "stderr": stderr.getvalue(),
-            "source_client": source_client,
-            "target_client": target_client,
-        }
+    return {
+        "output": json.loads((Path(out_dir) / "items.json").read_text()),
+        "count": int((Path(out_dir) / "count").read_text()),
+        "num_batches": int((Path(out_dir) / "num_batches").read_text()),
+        "stdout": stdout.getvalue(),
+        "stderr": stderr.getvalue(),
+        "out_dir": out_dir,
+        "source_client": source_client,
+        "target_client": target_client,
+    }
+
+
+def run_read_batch(items: list[dict], index: int, batch_size: int = 200) -> list[dict]:
+    """Run `read-batch` mode against a temp items file; return the emitted slice."""
+    out_dir = tempfile.mkdtemp()
+    items_file = Path(out_dir) / "items.json"
+    items_file.write_text(json.dumps(items))
+
+    with (
+        patch(
+            "sys.argv",
+            [
+                "query_stac.py",
+                "read-batch",
+                str(items_file),
+                str(index),
+                "--batch-size",
+                str(batch_size),
+            ],
+        ),
+        patch("sys.stdout", StringIO()) as stdout,
+    ):
+        from scripts.query_stac import main
+
+        main()
+
+    return json.loads(stdout.getvalue())
 
 
 class TestQueryStac:
@@ -315,3 +356,83 @@ class TestQueryStac:
 
         # Should use CQL2 filter language
         assert result["source_client"].searches[0]["filter_lang"] == "cql2-json"
+
+
+class TestBatchedOutput:
+    """`discover` writes a manifest + items file; `read-batch` emits bounded slices."""
+
+    def test_discover_writes_manifest_files(self):
+        """discover writes items.json, count, and num_batches = ceil(count/batch_size)."""
+        source = [create_stac_item(f"item-{i:03d}", SOURCE_COLLECTION) for i in range(5)]
+
+        result = run_script(source, [], batch_size=2)
+
+        assert result["count"] == 5
+        assert len(result["output"]) == 5
+        assert result["num_batches"] == 3  # ceil(5/2)
+
+    def test_discover_does_not_emit_list_to_stdout(self):
+        """The full list must NOT go to stdout — that was the 256 KB withParam gate."""
+        source = [create_stac_item(f"item-{i:04d}", SOURCE_COLLECTION) for i in range(300)]
+
+        result = run_script(source, [], batch_size=200)
+
+        assert "source_url" not in result["stdout"]
+
+    def test_num_batches_boundaries(self):
+        """Exactly-full and one-over batch counts compute the right num_batches."""
+        s4 = [create_stac_item(f"i{n:02d}", SOURCE_COLLECTION) for n in range(4)]
+        s5 = [create_stac_item(f"i{n:02d}", SOURCE_COLLECTION) for n in range(5)]
+
+        assert run_script(s4, [], batch_size=2)["num_batches"] == 2
+        assert run_script(s5, [], batch_size=2)["num_batches"] == 3
+
+    def test_empty_discovery_zero_batches(self):
+        """No items → count 0, num_batches 0, empty items file."""
+        result = run_script([], [], batch_size=200)
+
+        assert result["count"] == 0
+        assert result["num_batches"] == 0
+        assert result["output"] == []
+
+    def test_read_batch_slices_within_bounds(self):
+        """read-batch returns exactly items [index*size : (index+1)*size]."""
+        items = [
+            {"source_url": f"u{i}", "collection": "c", "item_id": f"item-{i:03d}"} for i in range(5)
+        ]
+
+        assert [i["item_id"] for i in run_read_batch(items, 0, 2)] == ["item-000", "item-001"]
+        assert [i["item_id"] for i in run_read_batch(items, 1, 2)] == ["item-002", "item-003"]
+        assert [i["item_id"] for i in run_read_batch(items, 2, 2)] == ["item-004"]
+
+    def test_read_batch_is_lossless_across_all_batches(self):
+        """The union of every batch equals the full list — nothing dropped or duplicated."""
+        items = [
+            {"source_url": f"u{i}", "collection": "c", "item_id": f"item-{i:04d}"}
+            for i in range(450)
+        ]
+        batch_size = 200
+        num_batches = (len(items) + batch_size - 1) // batch_size
+
+        union: list[dict] = []
+        for idx in range(num_batches):
+            batch = run_read_batch(items, idx, batch_size)
+            assert len(batch) <= batch_size
+            union += batch
+
+        assert union == items
+
+    def test_read_batch_out_of_range_is_empty(self):
+        """An index past the end yields an empty list (clean short-circuit)."""
+        items = [{"source_url": "u", "collection": "c", "item_id": "x"}]
+
+        assert run_read_batch(items, 5, 2) == []
+
+    def test_read_batch_bound_is_count_based_not_byte_based(self):
+        """Large/unicode payloads don't change the per-batch item count bound."""
+        items = [
+            {"source_url": "u" * 500, "collection": "c", "item_id": "💧" * 50 + str(i)}
+            for i in range(10)
+        ]
+
+        assert len(run_read_batch(items, 0, 4)) == 4

--- a/tests/unit/test_query_stac.py
+++ b/tests/unit/test_query_stac.py
@@ -2,11 +2,12 @@
 
 import json
 import tempfile
-from datetime import datetime
+from datetime import UTC, datetime
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from pystac import Item, Link
 
 # Test collection names
@@ -130,8 +131,13 @@ def run_script(
     target_items: list[Item],
     raise_error_on_target: bool = False,
     batch_size: int = 200,
+    max_acquisition_age_days: int | None = None,
 ) -> dict:
-    """Helper to run `discover` mode with test data and read back the manifest files."""
+    """Helper to run `discover` mode with test data and read back the manifest files.
+
+    The hardcoded scheduled end time is 2024-01-01T12:00:00Z, so an acquisition floor of
+    N days lands at 2024-01-01 − N days — pick item datetimes relative to that.
+    """
     source_client = FakeStacClient(
         items=source_items,
         collection=SOURCE_COLLECTION,
@@ -151,26 +157,26 @@ def run_script(
         return target_client
 
     out_dir = tempfile.mkdtemp()
+    argv = [
+        "query_stac.py",
+        "discover",
+        "https://source-stac.example.com/",
+        SOURCE_COLLECTION,
+        "https://target-stac.example.com/",
+        TARGET_COLLECTION,
+        "2024-01-01T12:00:00Z",  # ISO timestamp instead of "0"
+        "3",
+        "[-5.14, 41.33, 9.56, 51.09]",
+        "--out-dir",
+        out_dir,
+        "--batch-size",
+        str(batch_size),
+    ]
+    if max_acquisition_age_days is not None:
+        argv += ["--max-acquisition-age-days", str(max_acquisition_age_days)]
     with (
         patch("scripts.query_stac.Client.open", side_effect=mock_client_open),
-        patch(
-            "sys.argv",
-            [
-                "query_stac.py",
-                "discover",
-                "https://source-stac.example.com/",
-                SOURCE_COLLECTION,
-                "https://target-stac.example.com/",
-                TARGET_COLLECTION,
-                "2024-01-01T12:00:00Z",  # ISO timestamp instead of "0"
-                "3",
-                "[-5.14, 41.33, 9.56, 51.09]",
-                "--out-dir",
-                out_dir,
-                "--batch-size",
-                str(batch_size),
-            ],
-        ),
+        patch("sys.argv", argv),
         patch("sys.stdout", StringIO()) as stdout,
         patch("sys.stderr", StringIO()) as stderr,
     ):
@@ -236,7 +242,10 @@ class TestQueryStac:
             "item-002",
             "item-003",
         }
-        assert "Processed 1 pages, checked 3 items, 3 to process" in caplog.text
+        assert (
+            "Processed 1 pages, checked 3 items, 0 skipped (out of acquisition window), "
+            "3 to process" in caplog.text
+        )
 
     def test_excludes_items_already_in_target(self, caplog):
         """Items already in target collection should be excluded."""
@@ -250,7 +259,10 @@ class TestQueryStac:
         assert len(result["output"]) == 2
         assert {item["item_id"] for item in result["output"]} == {"item-001", "item-003"}
         assert "Already converted" in caplog.text
-        assert "Processed 1 pages, checked 3 items, 2 to process" in caplog.text
+        assert (
+            "Processed 1 pages, checked 3 items, 0 skipped (out of acquisition window), "
+            "2 to process" in caplog.text
+        )
 
     def test_skips_items_without_self_link(self, caplog):
         """Items without a self link should be skipped."""
@@ -280,8 +292,12 @@ class TestQueryStac:
         assert result["output"] == []
         # Allow for either 0 or 1 pages depending on STAC client behavior
         assert (
-            "Processed 0 pages, checked 0 items, 0 to process" in caplog.text
-            or "Processed 1 pages, checked 0 items, 0 to process" in caplog.text
+            "Processed 0 pages, checked 0 items, 0 skipped (out of acquisition window), "
+            "0 to process"
+            in caplog.text
+            or "Processed 1 pages, checked 0 items, 0 skipped (out of acquisition window), "
+            "0 to process"
+            in caplog.text
         )
 
     def test_handles_error_checking_target(self, caplog):
@@ -501,3 +517,107 @@ class TestProcessingOrder:
         result = run_script(source, [])
 
         assert result["output"][0]["datetime"] == "2024-01-01T00:00:00"
+
+
+class TestAcquisitionFilter:
+    """`--max-acquisition-age-days` keeps only recently-acquired items (scheduled end 2024-01-01)."""
+
+    def test_drops_items_older_than_floor(self):
+        """With a 7-day floor, an item acquired 31 days earlier is excluded; a recent one kept."""
+        source = [
+            create_stac_item("recent", SOURCE_COLLECTION, dt=datetime(2023, 12, 28, 12, 0, 0)),
+            create_stac_item("stale", SOURCE_COLLECTION, dt=datetime(2023, 12, 1, 12, 0, 0)),
+        ]
+
+        result = run_script(source, [], max_acquisition_age_days=7)
+
+        assert [it["item_id"] for it in result["output"]] == ["recent"]
+
+    def test_boundary_item_at_floor_is_kept(self):
+        """An item acquired exactly at the floor (end − N days) is kept (>= boundary)."""
+        # floor = 2024-01-01T12:00:00Z − 7d = 2023-12-25T12:00:00Z
+        source = [create_stac_item("edge", SOURCE_COLLECTION, dt=datetime(2023, 12, 25, 12, 0, 0))]
+
+        result = run_script(source, [], max_acquisition_age_days=7)
+
+        assert [it["item_id"] for it in result["output"]] == ["edge"]
+
+    def test_naive_and_aware_datetimes_filter_without_raising(self):
+        """Mixed naive (default factory) and tz-aware item datetimes compare safely."""
+        source = [
+            create_stac_item(
+                "naive-recent", SOURCE_COLLECTION, dt=datetime(2023, 12, 28, 12, 0, 0)
+            ),
+            create_stac_item(
+                "aware-recent",
+                SOURCE_COLLECTION,
+                dt=datetime(2023, 12, 27, 12, 0, 0, tzinfo=UTC),
+            ),
+            create_stac_item("aware-stale", SOURCE_COLLECTION, dt=datetime(2023, 11, 1, 12, 0, 0)),
+        ]
+
+        result = run_script(source, [], max_acquisition_age_days=7)
+
+        assert {it["item_id"] for it in result["output"]} == {"naive-recent", "aware-recent"}
+
+    def test_undated_item_excluded_when_filter_active(self):
+        """An item with no acquisition datetime can't be proven recent → dropped when active."""
+        source = [
+            create_stac_item("dated", SOURCE_COLLECTION, dt=datetime(2023, 12, 28, 12, 0, 0)),
+            create_stac_item("no-date", SOURCE_COLLECTION, dt=None),
+        ]
+
+        result = run_script(source, [], max_acquisition_age_days=7)
+
+        assert [it["item_id"] for it in result["output"]] == ["dated"]
+
+    def test_inactive_filter_passes_no_datetime_kwarg(self):
+        """Without the flag, the search carries no `datetime` param (only the updated filter)."""
+        source = [create_stac_item("a", SOURCE_COLLECTION, dt=datetime(2020, 1, 1, 0, 0, 0))]
+
+        result = run_script(source, [])
+
+        assert "datetime" not in result["source_client"].searches[0]["kwargs"]
+        assert [it["item_id"] for it in result["output"]] == ["a"]  # old item still kept
+
+    def test_active_filter_passes_datetime_floor_to_search(self):
+        """When active, the source search is narrowed server-side with an open-ended floor."""
+        source = [create_stac_item("a", SOURCE_COLLECTION, dt=datetime(2023, 12, 28, 12, 0, 0))]
+
+        result = run_script(source, [], max_acquisition_age_days=7)
+
+        assert (
+            result["source_client"].searches[0]["kwargs"]["datetime"] == "2023-12-25T12:00:00Z/.."
+        )
+
+    def test_filtered_items_do_not_trigger_dedup_search(self):
+        """Items dropped by the filter cost no target/dedup API call (filter runs before dedup)."""
+        source = [
+            create_stac_item("recent", SOURCE_COLLECTION, dt=datetime(2023, 12, 28, 12, 0, 0)),
+            create_stac_item("stale", SOURCE_COLLECTION, dt=datetime(2023, 1, 1, 12, 0, 0)),
+        ]
+
+        result = run_script(source, [], max_acquisition_age_days=7)
+
+        # Only the surviving item is checked against the target collection.
+        assert len(result["target_client"].searches) == 1
+
+    def test_survivors_remain_newest_first(self):
+        """Filter then sort: kept items are still ordered most-recent acquisition first."""
+        source = [
+            create_stac_item("mid", SOURCE_COLLECTION, dt=datetime(2023, 12, 27, 12, 0, 0)),
+            create_stac_item("stale", SOURCE_COLLECTION, dt=datetime(2023, 10, 1, 12, 0, 0)),
+            create_stac_item("newest", SOURCE_COLLECTION, dt=datetime(2023, 12, 30, 12, 0, 0)),
+        ]
+
+        result = run_script(source, [], max_acquisition_age_days=14)
+
+        assert [it["item_id"] for it in result["output"]] == ["newest", "mid"]
+
+    def test_non_positive_age_is_rejected(self):
+        """N must be > 0; a non-positive value exits rather than silently dropping everything."""
+        source = [create_stac_item("a", SOURCE_COLLECTION)]
+
+        for bad in (0, -5):
+            with pytest.raises(SystemExit):
+                run_script(source, [], max_acquisition_age_days=bad)

--- a/tests/unit/test_query_stac.py
+++ b/tests/unit/test_query_stac.py
@@ -14,14 +14,25 @@ SOURCE_COLLECTION = "test"
 TARGET_COLLECTION = "test-staging"
 
 
-def create_stac_item(item_id: str, collection_id: str, has_self_link: bool = True) -> Item:
+def create_stac_item(
+    item_id: str,
+    collection_id: str,
+    has_self_link: bool = True,
+    dt: datetime | None = datetime(2023, 12, 8, 10, 0, 0),
+) -> Item:
     """Create a minimal STAC item for testing."""
+    # pystac requires start/end when datetime is None; item.datetime still resolves to None.
+    properties = (
+        {}
+        if dt is not None
+        else {"start_datetime": "2024-01-01T00:00:00Z", "end_datetime": "2024-01-02T00:00:00Z"}
+    )
     item = Item(
         id=item_id,
         geometry={"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
         bbox=[0, 0, 1, 1],
-        datetime=datetime(2023, 12, 8, 10, 0, 0),
-        properties={},
+        datetime=dt,
+        properties=properties,
     )
 
     if has_self_link:
@@ -436,3 +447,57 @@ class TestBatchedOutput:
         ]
 
         assert len(run_read_batch(items, 0, 4)) == 4
+
+
+class TestProcessingOrder:
+    """`discover` orders the queue most-recent-first (acquisition datetime, descending)."""
+
+    def test_items_sorted_most_recent_first(self):
+        """Items are emitted newest acquisition datetime first, regardless of arrival order."""
+        source = [
+            create_stac_item("old", SOURCE_COLLECTION, dt=datetime(2024, 1, 1, 0, 0, 0)),
+            create_stac_item("newest", SOURCE_COLLECTION, dt=datetime(2024, 6, 1, 0, 0, 0)),
+            create_stac_item("middle", SOURCE_COLLECTION, dt=datetime(2024, 3, 1, 0, 0, 0)),
+        ]
+
+        result = run_script(source, [])
+
+        assert [it["item_id"] for it in result["output"]] == ["newest", "middle", "old"]
+
+    def test_sort_is_chronological_across_utc_offsets(self):
+        """Sorting parses timestamps, so a later instant wins even with a larger offset.
+
+        09:00+02:00 (07:00Z) is earlier than 08:00+00:00 (08:00Z); a lexicographic
+        string sort would get this wrong, a chronological one ranks 08:00Z first.
+        """
+        source = [
+            create_stac_item(
+                "plus2", SOURCE_COLLECTION, dt=datetime.fromisoformat("2024-05-01T09:00:00+02:00")
+            ),
+            create_stac_item(
+                "utc", SOURCE_COLLECTION, dt=datetime.fromisoformat("2024-05-01T08:00:00+00:00")
+            ),
+        ]
+
+        result = run_script(source, [])
+
+        assert [it["item_id"] for it in result["output"]] == ["utc", "plus2"]
+
+    def test_items_without_datetime_sort_last(self):
+        """An item with no acquisition datetime drains after dated items."""
+        source = [
+            create_stac_item("no-date", SOURCE_COLLECTION, dt=None),
+            create_stac_item("dated", SOURCE_COLLECTION, dt=datetime(2024, 1, 1, 0, 0, 0)),
+        ]
+
+        result = run_script(source, [])
+
+        assert [it["item_id"] for it in result["output"]] == ["dated", "no-date"]
+
+    def test_output_carries_datetime_field(self):
+        """Each record exposes the acquisition datetime used for ordering."""
+        source = [create_stac_item("item-001", SOURCE_COLLECTION, dt=datetime(2024, 1, 1, 0, 0, 0))]
+
+        result = run_script(source, [])
+
+        assert result["output"][0]["datetime"] == "2024-01-01T00:00:00"


### PR DESCRIPTION
Three related improvements to `query_stac.py` discovery, in order of commit:

### 1. Batched fan-out — escape Argo's 256 KB result cap
`discover` writes the full item list to `items.json` (Argo output artifact) + `count`/`num_batches`, instead of dumping it to stdout. `read-batch` emits one bounded `<256 KB` slice for the workflow's `withParam` fan-out. Lossless at any volume.

### 2. Process most-recent items first
Sort the queue by acquisition `datetime` descending so the freshest observations convert before a large backlog drains. In-process (no Sort-extension dependency), chronological across UTC offsets, undated last.

### 3. Acquisition-age filter for real-time runs (`--max-acquisition-age-days N`)
During a bulk **reingestion**, upstream re-stamps `updated` on *old* acquisitions, flooding the harvesting window. Optional floor (`datetime ≥ end − N days`, open top — never drops the freshest data) keeps only recent observations. Client-side guard runs **before** the per-item dedup search (dropped items cost no target-API call) + a server-side STAC `datetime=<floor>/..` to trim pagination (verified it combines with the CQL2 `updated` filter on EODC). Unset ⇒ off; `N > 0` validated. `_to_utc` helper shared with the sort key so naive/aware datetimes never raise.

### Tests
`tests/unit/test_query_stac.py` — 30 passing: batched-output losslessness/boundaries, ordering (incl. mixed UTC offsets, undated-last), and the acquisition filter (floor/boundary, naive+aware, undated exclusion, server-param presence/absence, dedup-skip, filter∘sort, non-positive-N rejection). `ruff` clean.

> Note: the convert empty-`zarr.json` fix (#263) that briefly stacked on this branch (PR #258) was **closed** — decision is to let malformed historical products fail and raise to the provider; the acquisition filter excludes that old data from real-time runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)