### PR TITLE
fix(s1tiling): raise eodag stream read timeout 60s→300s (T7 Task 0)

### DIFF
--- a/analysis/s1tiling_eodag4_patch.py
+++ b/analysis/s1tiling_eodag4_patch.py
@@ -11,9 +11,14 @@ EODAG 4.0.0 introduced several breaking changes for S1Tiling:
 4. cop_dataspace requires UPPERCASE orbit direction ("DESCENDING" not "descending").
 5. `relativeOrbitNumber` search param silently returns 0 results on cop_dataspace.
 
+It also raises eodag's hardcoded 60 s stream read timeout to 300 s so a throttled
+CDSE download survives a transient stall instead of failing the product pass
+(exit 68) — T7 Task 0.
+
 This script patches:
 - S1FileManager.py: fixes the search() call (issues 1, 3, 4, 5)
 - s1/product.py: adds legacy→STAC property name fallback (issue 2)
+- eodag/utils/__init__.py: raises the stream read timeout 60 s → 300 s
 
 Usage (inside the Docker container):
     python3 /patch/s1tiling_eodag4_patch.py
@@ -23,6 +28,18 @@ import pathlib
 import re
 
 S1T_PKG = pathlib.Path("/opt/S1TilingEnv/lib/python3.10/site-packages/s1tiling/libs")
+EODAG_PKG = pathlib.Path("/opt/S1TilingEnv/lib/python3.10/site-packages/eodag")
+
+# eodag streams downloads with a hardcoded per-read socket timeout
+# (DEFAULT_STREAM_REQUESTS_TIMEOUT, defined in eodag/utils/__init__.py and reused
+# at every stream call-site in http.py / api/product/_product.py). Under CDSE
+# throttle the server stalls past 60 s, requests raises "Read timed out", eodag
+# does not catch/retry it, and s1tiling fails the whole product pass (exit 68).
+# The value is a constant (not config), so it can only be raised on disk. We
+# rewrite the single definition so all call-sites pick up the new value at once.
+# Verified in-image against s1tiling:1.4.0 / eodag 4.0.0 (T7 Task 0).
+_STREAM_TIMEOUT_OLD = "DEFAULT_STREAM_REQUESTS_TIMEOUT = 60"
+_STREAM_TIMEOUT_NEW = "DEFAULT_STREAM_REQUESTS_TIMEOUT = 300"
 
 
 def patch_s1filemanager() -> None:
@@ -126,8 +143,40 @@ def patch_product_property() -> None:
     print(f"  Patched {fpath.name}")
 
 
+def _rewrite_stream_timeout(src: str) -> str:
+    """Raise eodag's hardcoded stream read timeout 60 s -> 300 s.
+
+    Pure transform (no file IO) so it can be unit-tested on a fixture. Three
+    states, checked in order:
+      1. already patched -> return unchanged (idempotent no-op; re-running the
+         patch in a fresh container must not error).
+      2. anchor present  -> replace and return.
+      3. neither present -> raise (eodag version/layout drift). This deliberately
+         diverges from the silent-skip style of patch_product_property() above:
+         a silent no-op here would ship a stale fix in-cluster, which is the
+         exact failure mode this guard exists to prevent.
+    """
+    if _STREAM_TIMEOUT_NEW in src:
+        return src
+    if _STREAM_TIMEOUT_OLD not in src:
+        raise RuntimeError(
+            f"eodag stream-timeout anchor {_STREAM_TIMEOUT_OLD!r} not found; "
+            "eodag layout may have changed -- refusing to silently skip."
+        )
+    return src.replace(_STREAM_TIMEOUT_OLD, _STREAM_TIMEOUT_NEW, 1)
+
+
+def patch_eodag_stream_timeout() -> None:
+    """Raise eodag's stream read timeout so a throttled CDSE download rides out a
+    transient stall instead of failing the product pass (exit 68) — T7 Task 0."""
+    fpath = EODAG_PKG / "utils" / "__init__.py"
+    fpath.write_text(_rewrite_stream_timeout(fpath.read_text()))
+    print(f"  Patched eodag stream timeout -> 300s in {fpath.name}")
+
+
 if __name__ == "__main__":
     print("Applying S1Tiling EODAG 4.0.0 compatibility patches...")
     patch_s1filemanager()
     patch_product_property()
+    patch_eodag_stream_timeout()
     print("Done.")

--- a/tests/unit/test_s1tiling_eodag4_patch.py
+++ b/tests/unit/test_s1tiling_eodag4_patch.py
@@ -1,0 +1,67 @@
+"""Unit tests for the S1Tiling/EODAG-4 on-disk patch.
+
+The patch (`analysis/s1tiling_eodag4_patch.py`) rewrites installed site-packages
+source at container start. It is a standalone script (not an importable package),
+so it is loaded here via importlib from the analysis/ directory (same dir the
+container mounts at /patch — see test_run_s1tiling.py).
+
+These tests cover the stream-timeout patch (T7 Task 0): eodag's hardcoded 60 s
+stream read timeout is raised to 300 s so a throttled CDSE download rides out a
+transient stall instead of failing the whole product pass (exit 68).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ANALYSIS_DIR = Path(__file__).parent.parent.parent / "analysis"
+_MODULE_PATH = ANALYSIS_DIR / "s1tiling_eodag4_patch.py"
+
+
+def _load_patch_module():
+    spec = importlib.util.spec_from_file_location("s1tiling_eodag4_patch", _MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+patch_mod = _load_patch_module()
+
+
+class TestRewriteStreamTimeout:
+    """The pure string transform `_rewrite_stream_timeout` (no file IO)."""
+
+    # Mirrors the real eodag/utils/__init__.py neighbourhood (verified in-image
+    # against s1tiling:1.4.0 / eodag 4.0.0): the search timeouts sit right above
+    # the stream timeout and must NOT be touched.
+    FIXTURE = (
+        "HTTP_REQ_TIMEOUT = 5\n"
+        "DEFAULT_SEARCH_TIMEOUT = 20\n"
+        "#: default timeout for stream requests (in seconds)\n"
+        "DEFAULT_STREAM_REQUESTS_TIMEOUT = 60\n"
+    )
+
+    def test_rewrites_stream_timeout_60_to_300(self):
+        out = patch_mod._rewrite_stream_timeout(self.FIXTURE)
+        assert "DEFAULT_STREAM_REQUESTS_TIMEOUT = 300" in out
+        assert "DEFAULT_STREAM_REQUESTS_TIMEOUT = 60" not in out
+
+    def test_leaves_search_timeouts_untouched(self):
+        out = patch_mod._rewrite_stream_timeout(self.FIXTURE)
+        assert "HTTP_REQ_TIMEOUT = 5" in out
+        assert "DEFAULT_SEARCH_TIMEOUT = 20" in out
+
+    def test_idempotent_on_already_patched(self):
+        already = self.FIXTURE.replace(
+            "DEFAULT_STREAM_REQUESTS_TIMEOUT = 60",
+            "DEFAULT_STREAM_REQUESTS_TIMEOUT = 300",
+        )
+        # Re-running over already-patched source is a no-op, not an error.
+        assert patch_mod._rewrite_stream_timeout(already) == already
+
+    def test_raises_when_anchor_absent(self):
+        # eodag version/layout drift: anchor gone and never patched -> fail loud
+        # rather than silently shipping a stale fix in-cluster.
+        with pytest.raises(RuntimeError):
+            patch_mod._rewrite_stream_timeout("HTTP_REQ_TIMEOUT = 5\n")


### PR DESCRIPTION
## What

Adds `patch_eodag_stream_timeout()` to the s1tiling/eodag on-disk patch so eodag's hardcoded **60 s** stream read timeout is raised to **300 s**.

## Why

A throttled CDSE download stalls one product's socket past eodag's hardcoded `DEFAULT_STREAM_REQUESTS_TIMEOUT` (60 s). `requests` raises `Read timed out`, eodag does **not** catch/retry it on the stream path, and s1tiling fails the **whole product pass** (exit 68) — even though sibling products downloaded fine. Observed in a live T7 Task 0 run: all 3 products (~3.86 GB) downloaded in ~30 min, 0 restarts, then one product's socket stalled → exit 68.

The value is a **constant** (`eodag/utils/__init__.py`), not config, so it cannot be raised via `eodag.yml`/env — only on disk, via the patch already run at container start.

## How

- Rewrite the **single constant definition** `DEFAULT_STREAM_REQUESTS_TIMEOUT = 60 → = 300`. This covers all ~5 stream call-sites across `http.py` (×3) and `api/product/_product.py` (×1) at once. Search timeouts (`DEFAULT_SEARCH_TIMEOUT`, `HTTP_REQ_TIMEOUT`) are separate and untouched.
- Pure transform `_rewrite_stream_timeout()` is split out for unit testing; three-way in order: **already-patched → no-op** (idempotent), **anchor present → replace**, **neither → raise** (version-drift guard — deliberately *not* the silent-skip of the sibling patch fns, since a silent no-op would ship a stale fix in-cluster).

## Verification

- 4 new unit tests (rewrite / search-untouched / idempotent / raises-on-missing) — green.
- `tests/unit/test_run_s1tiling.py` — no regression.
- **End-to-end in the real `s1tiling:1.4.0` / eodag 4.0.0 image**: running the full patch rewrites `eodag/utils/__init__.py:129` to `= 300`, and a 2nd run is idempotent (no error).

## Follow-up (separate PR)

Regenerate the platform-deploy configmap `s1tiling-eodag4-patch-configmap.yaml` from this updated source so the deployed patch picks up the change, then re-run the T7 Task 0 CP-1 product to confirm no `Read timed out` / exit 68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)