### PR TITLE
fix(s1-rtc): TEMPORARY direct-write to titiler render path; drop #250 auto-copy (#246)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.1",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@8c8ee8142b90fd98e0f8f8deea31148d40b729ed",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@f43d567623eca71aa933147428bdca176db98557",
     "requests==2.34.1",
     "mgrs==1.5.4",
 ]

--- a/scripts/register_v1_s1_rtc.py
+++ b/scripts/register_v1_s1_rtc.py
@@ -35,40 +35,6 @@ from run_ingest_register import check_env_consistency
 log = logging.getLogger(__name__)
 
 
-# --- TEMPORARY (data-pipeline#246; revert when titiler-eopf#108 lands) ----------------------
-def _titiler_render_copy(store: str, collection: str, item_id: str, s3_endpoint: str) -> None:
-    """Copy the store to titiler's reconstructed render path so new tiles preview.
-
-    titiler-eopf ignores the STAC asset href and opens
-    ``s3://{bucket}/tests-output/{collection}/{item_id}.zarr``. Until titiler-eopf#108 (resolve
-    the store from the href) lands and deploys, place a server-side copy there. Same-bucket so the
-    copy is a server-side S3 operation, not a download/upload. Best-effort: a failure logs a
-    warning but does NOT fail registration (mirrors ``warm_thumbnail_cache``). Revert = delete this
-    function and its call.
-    """
-    parsed = urlparse(store)
-    if parsed.scheme != "s3":
-        return
-    bucket = parsed.netloc
-    src = f"{bucket}{parsed.path}"  # s3fs addresses bucket/key (no scheme)
-    dst = f"{bucket}/tests-output/{collection}/{item_id}.zarr"
-    try:
-        import s3fs
-
-        fs = s3fs.S3FileSystem(client_kwargs={"endpoint_url": s3_endpoint} if s3_endpoint else None)
-        if fs.exists(dst):
-            fs.rm(dst, recursive=True)  # idempotent overwrite
-        fs.copy(src, dst, recursive=True)
-        log.info("titiler render-copy: s3://%s -> s3://%s", src, dst)
-    except Exception:
-        log.warning(
-            "titiler render-copy failed (item still registered): s3://%s", dst, exc_info=True
-        )
-
-
-# --- end TEMPORARY --------------------------------------------------------------------------
-
-
 def register(
     store: str,
     collection: str,
@@ -111,7 +77,9 @@ def register(
         log.exception("Failed to upsert item %s to %s", item.id, stac_api_url)
         return 1
 
-    _titiler_render_copy(store, collection, item.id, s3_endpoint)  # TEMPORARY #246
+    # TEMPORARY (#246): no render-copy needed — run_ingest_register writes the cube directly at
+    # titiler's reconstructed path (tests-output/{collection}/s1-rtc-{tile}.zarr). Revert when
+    # titiler-eopf#108 lands.
     return 0
 
 

--- a/scripts/run_ingest_register.py
+++ b/scripts/run_ingest_register.py
@@ -75,14 +75,17 @@ def run_pipeline(
     raster_api_url: str,
     acquisitions_collection: str = "sentinel-1-grd-rtc-acquisitions",
 ) -> int:
-    # Store key prefix is the STAC collection, so per-mission/per-env buckets stay
-    # self-describing: s3://{bucket}/{collection}/s1-grd-rtc-{tile}.zarr
     if not collection or "/" in collection:
         raise ValueError(
             f"collection must be a non-empty single path segment (no '/'), got: {collection!r}"
         )
     check_env_consistency(collection, s3_output_bucket)
-    s3_zarr = f"s3://{s3_output_bucket}/{collection}/s1-grd-rtc-{tile_id}.zarr"
+    # TEMPORARY (#246): write the cube directly at titiler-eopf's reconstructed render path
+    # — s3://{bucket}/tests-output/{collection}/{item_id}.zarr where item_id == s1-rtc-{tile} —
+    # so new tiles preview without a copy (titiler ignores the asset href). Replaces the #250
+    # auto-copy. Revert to s3://{bucket}/{collection}/s1-grd-rtc-{tile}.zarr when titiler-eopf#108
+    # (resolve store from href) lands.
+    s3_zarr = f"s3://{s3_output_bucket}/tests-output/{collection}/s1-rtc-{tile_id}.zarr"
 
     # Step 1 — ingest directly into the s3:// cube. run_ingest fetches any existing cube, appends the
     # new scene as a time slice (T4), and uploads via s3fs — so the per-tile cube accumulates across

--- a/tests/unit/test_register_v1_s1_rtc.py
+++ b/tests/unit/test_register_v1_s1_rtc.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pystac
 import pytest
@@ -87,7 +87,6 @@ def test_upserts_item_with_correct_id() -> None:
         patch(f"{_MOD}.warm_thumbnail_cache"),
         patch(f"{_MOD}.upsert_item") as mock_upsert,
         patch(f"{_MOD}.Client"),
-        patch(f"{_MOD}._titiler_render_copy"),  # TEMPORARY #246
     ):
         result = register(
             _STORE,
@@ -107,95 +106,6 @@ def test_upserts_item_with_correct_id() -> None:
     assert called_item.id == "s1-rtc-31TCH"
 
 
-# --- TEMPORARY #246: titiler render-copy (revert when titiler-eopf#108 lands) ---------------
-# titiler-eopf reconstructs the store path as {bucket}/tests-output/{collection}/{item_id}.zarr
-# and ignores the asset href, so register() copies the store there. These tests pin that contract.
-
-
-def test_render_copy_targets_reconstructed_path() -> None:
-    """Copy lands the store at {bucket}/tests-output/{collection}/{item_id}.zarr (item-id name)."""
-    import register_v1_s1_rtc as m
-
-    fs = MagicMock()
-    fs.exists.return_value = False
-    with patch("s3fs.S3FileSystem", return_value=fs):
-        m._titiler_render_copy(
-            "s3://esa-zarr-sentinel-explorer-fra/sentinel-1-grd-rtc-tests/s1-grd-rtc-32TLR.zarr",
-            "sentinel-1-grd-rtc-tests",
-            "s1-rtc-32TLR",
-            "https://s3.example.com",
-        )
-    fs.copy.assert_called_once_with(
-        "esa-zarr-sentinel-explorer-fra/sentinel-1-grd-rtc-tests/s1-grd-rtc-32TLR.zarr",
-        "esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-tests/s1-rtc-32TLR.zarr",
-        recursive=True,
-    )
-    fs.rm.assert_not_called()
-
-
-def test_render_copy_overwrites_existing() -> None:
-    """Idempotent: an existing dst is removed before the copy."""
-    import register_v1_s1_rtc as m
-
-    fs = MagicMock()
-    fs.exists.return_value = True
-    with patch("s3fs.S3FileSystem", return_value=fs):
-        m._titiler_render_copy(
-            "s3://b/sentinel-1-grd-rtc-tests/s1-grd-rtc-32TLR.zarr",
-            "sentinel-1-grd-rtc-tests",
-            "s1-rtc-32TLR",
-            "https://s3.example.com",
-        )
-    fs.rm.assert_called_once_with(
-        "b/tests-output/sentinel-1-grd-rtc-tests/s1-rtc-32TLR.zarr", recursive=True
-    )
-    fs.copy.assert_called_once()
-
-
-def test_render_copy_best_effort_on_failure() -> None:
-    """A copy failure must NOT raise -- the item is already registered."""
-    import register_v1_s1_rtc as m
-
-    fs = MagicMock()
-    fs.exists.return_value = False
-    fs.copy.side_effect = OSError("boom")
-    with patch("s3fs.S3FileSystem", return_value=fs):
-        m._titiler_render_copy(
-            "s3://b/c/s1-grd-rtc-32TLR.zarr", "c", "s1-rtc-32TLR", "https://s3.example.com"
-        )  # must not raise
-
-
-def test_render_copy_skips_non_s3_store() -> None:
-    """A local (non-s3) store is a no-op -- s3fs is never constructed."""
-    import register_v1_s1_rtc as m
-
-    with patch("s3fs.S3FileSystem") as mock_fs:
-        m._titiler_render_copy("local-store/s1-grd-rtc-32TLR.zarr", "c", "s1-rtc-32TLR", "")
-    mock_fs.assert_not_called()
-
-
-def test_register_invokes_render_copy_after_upsert() -> None:
-    """register() calls the render-copy once with (store, collection, item.id, endpoint)."""
-    with (
-        patch(f"{_MOD}.build_s1_rtc_stac_item", return_value=_make_item()),
-        patch(f"{_MOD}.warm_thumbnail_cache"),
-        patch(f"{_MOD}.upsert_item"),
-        patch(f"{_MOD}.Client"),
-        patch(f"{_MOD}._titiler_render_copy") as mock_copy,
-    ):
-        register(
-            _STORE,
-            _COLLECTION,
-            "https://stac.example.com",
-            "https://raster.example.com",
-            "https://s3.example.com",
-        )
-    mock_copy.assert_called_once_with(_STORE, _COLLECTION, "s1-rtc-31TCH", "https://s3.example.com")
-
-
-# --- end TEMPORARY #246 --------------------------------------------------------------------
-
-
 def test_visualization_links_called() -> None:
     """add_visualization_links must be called once with correct raster URL and collection."""
     with (
@@ -203,7 +113,6 @@ def test_visualization_links_called() -> None:
         patch(f"{_MOD}.warm_thumbnail_cache"),
         patch(f"{_MOD}.upsert_item"),
         patch(f"{_MOD}.Client"),
-        patch(f"{_MOD}._titiler_render_copy"),  # TEMPORARY #246
         patch(f"{_MOD}.add_visualization_links") as mock_viz,
     ):
         register(
@@ -284,7 +193,6 @@ def test_matched_env_store_allowed() -> None:
         patch(f"{_MOD}.warm_thumbnail_cache"),
         patch(f"{_MOD}.upsert_item") as mock_upsert,
         patch(f"{_MOD}.Client"),
-        patch(f"{_MOD}._titiler_render_copy"),  # TEMPORARY #246
     ):
         result = register(
             good_store,

--- a/tests/unit/test_run_ingest_register.py
+++ b/tests/unit/test_run_ingest_register.py
@@ -33,8 +33,9 @@ _KWARGS = {
     "raster_api_url": "https://raster.example.com",
 }
 
-# The derived per-tile cube URI: s3://{bucket}/{collection}/s1-grd-rtc-{tile}.zarr
-_S3_CUBE = "s3://my-bucket/sentinel-1-grd-rtc-staging/s1-grd-rtc-31TCH.zarr"
+# TEMPORARY (#246): the cube is written at titiler's reconstructed render path
+# s3://{bucket}/tests-output/{collection}/s1-rtc-{tile}.zarr (revert when titiler-eopf#108 lands).
+_S3_CUBE = "s3://my-bucket/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-31TCH.zarr"
 
 
 def _mock_proc(returncode: int) -> MagicMock:
@@ -149,7 +150,8 @@ def test_store_prefix_tracks_collection() -> None:
     and the cube register --store).
     """
     kwargs = {**_KWARGS, "collection": "sentinel-1-grd-rtc-tests"}
-    expected_store = "s3://my-bucket/sentinel-1-grd-rtc-tests/s1-grd-rtc-31TCH.zarr"
+    # TEMPORARY (#246): tests-output render path + s1-rtc- filename (revert with titiler-eopf#108).
+    expected_store = "s3://my-bucket/tests-output/sentinel-1-grd-rtc-tests/s1-rtc-31TCH.zarr"
     with patch(f"{_MOD}.subprocess.run", side_effect=[_mock_proc(0)] * 3) as mock_run:
         run_pipeline(**kwargs)
     ingest_cmd: list[str] = mock_run.call_args_list[0][0][0]

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.1" },
     { name = "click", specifier = "==8.3.3" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=8c8ee8142b90fd98e0f8f8deea31148d40b729ed" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=f43d567623eca71aa933147428bdca176db98557" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mgrs", specifier = "==1.5.4" },
     { name = "morecantile", specifier = "==7.0.3" },
@@ -954,7 +954,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.0"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=8c8ee8142b90fd98e0f8f8deea31148d40b729ed#8c8ee8142b90fd98e0f8f8deea31148d40b729ed" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=f43d567623eca71aa933147428bdca176db98557#f43d567623eca71aa933147428bdca176db98557" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
## What
Writes the S1 RTC GeoZarr cube **directly** at titiler's reconstructed render path and removes #250's auto-copy. Part of the #246 workaround (3 repos).

## Why
titiler-eopf ignores the STAC href and reconstructs `s3://{bucket}/tests-output/{collection}/{item_id}.zarr`, so new tiles 500 in preview. #250 server-side-**copied** the store there after registration, but that **duplicated** the store and — being best-effort — **silently left orphaned items** (31TCJ/31TDH: STAC item registered, no store at the render path). Dev phase, no consumers, disposable data → write once at the render path instead of copying.

## Changes
- `run_ingest_register.py`: `s3_zarr` → `s3://{bucket}/tests-output/{collection}/s1-rtc-{tile}.zarr`
- `register_v1_s1_rtc.py`: **remove** `_titiler_render_copy` (now a redundant self-copy) + its tests
- `pyproject.toml`: bump data-model pin → `f43d567` (parse store filename `s1-grd-rtc-` → `s1-rtc-`)
- tests updated to the new path contract

Store-exists ⇄ item-exists are now **coupled** (register reads the store it wrote) → no orphan window, no silent failure, no duplication.

## Verification
516 passed (full suite via pre-commit), ruff/mypy clean.

## Revert contract (when titiler-eopf#108 lands & deploys)
Revert this PR + the data-model commit (`git revert f43d567` on feat/s1-rtc-stac-builder) + platform-deploy `fix/s1-rtc-tests-output-path`. All changes carry `TEMPORARY (#246)` markers. Then point output back to the per-mission bucket and re-verify preview HTTP 200 with no copy.

## Companion PRs
- data-model: commit `f43d567` on `feat/s1-rtc-stac-builder` (PR #180)
- platform-deploy: `fix/s1-rtc-tests-output-path` (ingest template)

🤖 Generated with [Claude Code](https://claude.com/claude-code)