### PR TITLE
build(deps): bump eopf-geozarr pin to bbd18e3 (non-consolidated cube read fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.1",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@f43d567623eca71aa933147428bdca176db98557",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@bbd18e3520deb3a6c736770b82ea5b8dd118ee46",
     "requests==2.34.1",
     "mgrs==1.5.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.1" },
     { name = "click", specifier = "==8.3.3" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=f43d567623eca71aa933147428bdca176db98557" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=bbd18e3520deb3a6c736770b82ea5b8dd118ee46" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mgrs", specifier = "==1.5.4" },
     { name = "morecantile", specifier = "==7.0.3" },
@@ -954,7 +954,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.0"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=f43d567623eca71aa933147428bdca176db98557#f43d567623eca71aa933147428bdca176db98557" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=bbd18e3520deb3a6c736770b82ea5b8dd118ee46#bbd18e3520deb3a6c736770b82ea5b8dd118ee46" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
Bumps the `eopf-geozarr` pin from `f43d567` → **`bbd18e3`** (data-model PR #180).

## Why

The previous geozarr build hard-required consolidated metadata in the S1 RTC STAC builder (`zarr.open_consolidated`). A per-tile cube reaches a **non-consolidated** state after appending a time-slice to an **existing same-orbit** group, so the **2nd+ same-orbit acquisition** for a tile failed STAC registration in the live pipeline (`ValueError: Consolidated metadata ... not found`). This surfaced during the Pyrenees S1 RTC soak and would block the fan-out. See data-model **#188**; fixed in data-model **#180** (`bbd18e3`), which falls back to a direct read when consolidated metadata is absent (with a regression test).

## Verification

- `uv lock` regenerated (eopf-geozarr 0.10.0 f43d5676 → bbd18e35).
- `uv run pytest tests/unit/` — 454 passed.

## Follow-up

Merging this triggers the PR-232 image build; the new pullable image then gets pinned in platform-deploy's ingest template (replacing `sha-e308647`). REVERT the git pin to a tagged release once the s1-rtc builder lands on data-model main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)