### PR TITLE
feat(s1-rtc): render per-acquisition items from the shared cube via sel=time={index} (no duplication)

### DIFF
--- a/claude-docs/plans/s1_per_acquisition_render_stores.md
+++ b/claude-docs/plans/s1_per_acquisition_render_stores.md
@@ -1,0 +1,76 @@
+# Plan: per-acquisition items render from the shared cube via `sel=time={index}` (NO duplication)
+
+**Goal**: Per-acquisition STAC items render **now** on the deployed TiTiler with **zero data duplication** — by pointing their render links at the **cube's** TiTiler endpoint with `sel=time={index}` (+ the composite render), instead of writing a store per acquisition. Remove the per-acquisition-store bridge from PR #267.
+
+**Constraint**: No per-acquisition stores anywhere. Reuse `register_v1._select_render` / `_render_to_query`. Touch `register_per_acquisition.py` + `run_ingest_register.py`; remove the bridge files.
+
+## Context — the key finding that changes everything
+
+PR #267 wrote a single-acquisition GeoZarr per acquisition (≈2× storage) because we believed the deployed TiTiler couldn't render a per-acquisition item from the shared cube. **That belief was wrong.** Verified this session on `s1-rtc-30TXM` (a 2-slice cube):
+
+- TiTiler-eopf **supports `sel` by integer index**: `sel=time=0` and `sel=time=1` → **200** and render **distinct** slices (mean 106 vs 166, abs-diff 75); out-of-range `sel=time=2/99` → 500; the `nearest::<datetime>` *method syntax* → 500. tilejson + preview both 200 with `sel=time={index}`.
+
+So a per-acquisition item can render **its slice of the shared cube** by linking to the **cube's** render endpoint with `sel=time={index}` — TiTiler reconstructs the cube path (which exists) and `isel`s the slice. **No store, no copy, renders today, and now verifiable.** This supersedes both the per-acquisition-store bridge (duplication, rejected) and the "defer rendering" fallback (which was premised on the wrong `sel` belief).
+
+**Index robustness**: the index is positional (`isel`-like — confirmed: `sel=time=0/1` work, out-of-range 500s, and the time *labels* are ns-epoch ints so `0` can't be a label). The cube only ever **appends** (T4: new slice at the end; backfill also appends at the end), so an item's index is stable; and `register_per_acquisition` re-registers **all** items every ingest run, re-deriving indices from the current cube — self-healing even if the cube is ever rebuilt. **Requirement**: compute the index from the cube's **physical** time order (NOT sorted — `read_times_ns` sorts today, which would silently mis-map).
+
+**Forward-risk + upgrade path**: baking `sel=time={index}` couples to TiTiler's *current* integer-`isel` semantics. If a future titiler reinterprets `sel` (label-based / `nearest::{datetime}`), `sel=time=0` could change meaning — mitigated by the re-bake-every-run above, but the cleaner long-term form is **`sel=time=nearest::{datetime}`** (reorder-proof, label-based). Today that syntax 500s, so we use the index; **switch to the datetime form when the deployed titiler supports it** (track as a follow-up).
+
+**Independent of #246**: the acquisition links point at the *cube* endpoint, so they render via whatever serves the cube — the #246 path workaround now, or titiler#108 href-resolution later. This approach is **not** itself a #246 bridge and survives the #246 revert untouched (it only needs the cube to render).
+
+## Current state (PR #267)
+
+| Piece | Action |
+|---|---|
+| `write_per_acquisition_stores.py` + test; `ingest_v1_s1_rtc.write_single_acquisition_store` + tests; `run_ingest_register` Step 3 | **delete / revert** — already done in the working tree (uncommitted): files restored to baseline + bridge removed |
+| `register_per_acquisition` render links | **rework**: point at the **cube** endpoint (`{cube_collection}/items/s1-rtc-{tile}`) with the composite render + `sel=time={physical index}`. (Baseline used the acq endpoint + `variables=/orbit:vh` + `sel=time=nearest::…`, which 500s.) |
+| `register_per_acquisition._reorient_item_to_orbit` | **keep** (orbit metadata + asset orbit group) — added in working tree |
+| `-tests` validation store `s1-rtc-31TCH-20260605t060907.zarr` | **delete** (no longer needed; this approach writes no store) |
+| data-pipeline #246 per-acq-store extension | **revert** that section; note the no-dup `sel=index` approach |
+
+## Tasks
+
+### Task A — Remove the per-acquisition store machinery (no duplication)  <status: DONE in working tree>
+Bridge files deleted; `ingest_v1_s1_rtc` / `run_ingest_register` / their tests restored to the 3-subprocess baseline. **Verify**: `grep -rn "write_per_acquisition\|write_single_acquisition_store" scripts tests` → none; `uv run pytest tests/unit/test_run_ingest_register.py test_ingest_v1_s1_rtc.py` green.
+
+### Task B — `register_per_acquisition`: render links → cube endpoint + `sel=time={index}`  <status: NEXT>
+**What**:
+- Add `--cube-collection` arg (the collection whose TiTiler endpoint hosts the cube store, e.g. `sentinel-1-grd-rtc-staging`). The render links target `{raster}/collections/{cube_collection}/items/s1-rtc-{tile_id}/…`.
+- Read the orbit group's `time` axis in **physical order** (new/changed helper; `read_times_ns` currently sorts — keep a physical-order read for indexing). For each `(index, t_ns)` emit one item.
+- Build the render query from the item's **reoriented `renders.rgb`** by calling `register_v1._render_to_query(item["properties"]["renders"]["rgb"], include_tilesize=…)` **directly on the dict** (don't use `_select_render`, which is pystac-`Item`-based — `register_per_acquisition` is dict-based). Composite expression for the run orbit + `rescale 0,0.1` + `bidx`; `tilesize` for tiles/tilejson, not preview. Then append `&sel=time={index}`. Build `tilejson` + `xyz` + `thumbnail` links/asset against the cube endpoint.
+- Keep `_reorient_item_to_orbit` (sat:orbit_state / renders orbit / vv,vh asset group → run orbit). Items stay **references** (asset href → cube; **no store**).
+**Verify**: unit — a per-acq item's links point at `{cube_collection}/items/s1-rtc-{tile}`, carry the composite expression (run orbit) + `rescale=0,0.1` + `sel=time={index}` (index = physical position), and **no per-acquisition store path** appears anywhere.
+**Acceptance**:
+- [ ] Links target the cube endpoint + `sel=time={physical index}` + composite render
+- [ ] No per-acquisition store path in any item; asset href → cube
+- [ ] Orbit reconciliation retained; unit tests updated/green
+
+### Task C — `run_ingest_register`: pass `--cube-collection`  <status: blocked on B>
+**What**: the per-acq register step passes `--cube-collection {collection}` (the cube collection) alongside the existing `--collection {acquisitions_collection}`. 3-subprocess flow unchanged.
+**Verify**: `test_run_ingest_register` asserts the per-acq step receives both the acquisitions collection and `--cube-collection`.
+
+### Task D — Live validation on `-tests` (renders now)  <status: blocked on C>
+**What**: Register the `31TCH` acquisition item(s) into `…-acquisitions-tests` with cube-endpoint+`sel=index` links (cube collection `sentinel-1-grd-rtc-tests`, item `s1-rtc-31TCH`). The 31TCH cube has 1 slice → `sel=time=0`.
+**Verify**:
+- The item's own `tilejson` + `preview` (+ an `xyz` tile at a **realistic zoom** over the tile, not `0/0/0`) → **200**, rendering the composite; confirm **no** `…-acquisitions-tests/*.zarr` store exists.
+- **Index↔datetime mapping** (the core assumption): on a 2-slice cube (`30TXM` staging), for the item whose physical index is `i`, confirm its rendered slice equals the cube's `sel=time={i}` render **and** that index `i` corresponds to that item's `datetime` (read the cube's physical `time[i]` and check it matches the item id's stamp). Not just "distinct."
+**Acceptance**:
+- [ ] `-tests` acquisition item renders (tilejson + preview + real-zoom xyz 200) from the cube, no store
+- [ ] Physical index `i` ↔ item datetime ↔ rendered slice verified on a multi-slice tile
+
+### Task E — Cleanup + tracking  <status: blocked on D>
+**What**: Delete the `-tests` per-acquisition **store** I created earlier (`…/tests-output/sentinel-1-grd-rtc-acquisitions-tests/s1-rtc-31TCH-20260605t060907.zarr`, OVH `de` endpoint) — this approach writes none. Revert the "Extension: per-acquisition render stores" section in data-pipeline **#246** and replace with a one-liner: per-acq items render from the shared cube via `sel=time={index}` (no dup, no titiler change needed). Update **PR #267** title/description to the `sel=index` approach. Record the `sel`-by-index finding in memory.
+**Verify**: store path → 404; #246 + PR #267 updated; memory note written.
+**Acceptance**:
+- [ ] `-tests` store removed; #246 + PR description corrected; finding recorded
+
+## Verification (end-to-end)
+1. `uv run pytest tests/unit` + `uv run ruff check` green.
+2. Run `register_per_acquisition` against the `31TCH` `-tests` cube → item renders (tilejson + preview 200) with **no** per-acq store present.
+3. On a 2-slice cube (`30TXM`), confirm `sel=time=0` vs `=1` via the acquisition items' links render **distinct** correct slices.
+
+## Done definition
+Per-acquisition items render on the deployed TiTiler from the **single shared cube** via cube-endpoint links + `sel=time={physical index}` + composite render — **zero data duplication, no per-acquisition stores, no TiTiler change**. The store bridge is removed; orbit metadata is reconciled; `-tests` store + #246 + PR #267 cleaned up; the `sel`-by-index finding is recorded.
+
+## Lesson recorded (memory)
+Deployed **titiler-eopf supports `sel=time={integer index}`** (isel-like) but **not** the `nearest::<datetime>` syntax, and it **reconstructs the store path from `{collection}/{item_id}`, ignoring the asset href**. ⇒ render a per-acquisition slice from the shared multi-time cube by linking to the **cube** item's endpoint + `sel=time={physical index}`; **never** create per-acquisition stores (no dual storage). Earlier "titiler doesn't support sel / rendering must be deferred" was wrong.

--- a/claude-docs/plans/s1_rtc_remaining_work.md
+++ b/claude-docs/plans/s1_rtc_remaining_work.md
@@ -1,0 +1,179 @@
+# Implementation Plan: S1 RTC — remaining work (margin fix · #246 closure · CP-A · cleanup)
+
+## Overview
+Close out the open S1 RTC threads from this session: (1) the **31TCG DEM-coverage** bug (margin too
+tight), (2) the **#246 tests-output** workaround (PRs raised — needs merge + orphan cleanup + acceptance),
+(3) **T7 Phase-1 CP-A** closure (2/3 tiles passed; 31TCG blocked on the margin fix), and (4) **cleanup** of
+the throwaway test scaffolding. Each code change ships as its own revertable, tracked PR.
+
+## Current state (2026-06-15)
+- **Merged:** data-pipeline **#261** (#246 direct-write) merged into `feat--s1_grd_phase6` (HEAD `6f32275`,
+  2026-06-15). **Open:** platform-deploy #240 (DEM→workspace handoff), #241 (#246 ingest path).
+  data-model `f43d567` on `feat/s1-rtc-stac-builder` (#180).
+- **Images:** the current integration build (with #261's direct-write) is **`sha-6f32275`** — use this for
+  go-forward pin bumps. ⚠ `sha-b629416` and `sha-4c1b942` are **pre-#261** (no direct-write) — do NOT use for
+  #246. A3 uses `sha-e83f83c` (the #261 PR build, same direct-write code).
+- **Validated:** workspace DEM handoff (single-tile CP-A green; 2/3 scale-up). #246 direct-write (unit-tested;
+  A3 live preview in progress).
+- **Broken/pending:** 31TCG (DEM margin); STAC orphans `s1-rtc-31TCJ`/`s1-rtc-31TDH`; in-cluster scaffolding.
+
+## Architecture decisions (already taken, for context)
+- DEM staged into the per-workflow **workspace RWO PVC** (not the S3-FUSE cache) — reliable handoff (#240).
+- #246: **direct-write** the cube at titiler's render path (not #250 auto-copy) — couples store/item, no orphans.
+- Margin fix is a **permanent** bug fix (not TEMPORARY); footprint-derived DEM is the deferred robust follow-up.
+
+## Dependency graph
+```
+A3 (#246 preview test, #261 image) — independent, validates #246 PRE-merge ──┐ (de-risks Phase B)
+                                                                             │
+Phase A: A1 margin fix ─► CI image ─► A2 prove (test image) ─► A2b pin bump ─┤
+                                                                             ├─► Phase C (CP-A 3-tile, needs #240 merge + A)
+#240 merge (DEM workspace) ──────────────────────────────────────────────────┘
+#261 MERGED ✓ ; #241 + data-model merge ─► Flux sync ─► Phase B (B2 orphan cleanup ─► B3 re-ingest orphans + preview-200)
+                                                                             │
+All of A/B/C green ───────────────────────────────────────────────────────────► Phase D (cleanup test scaffolding)
+```
+
+---
+
+## Phase A — 31TCG DEM coverage (margin fix)  *(data-pipeline, own PR)*
+
+### Task A1: Widen the DEM swath latitude margin
+**Description:** `ensure_dem.py` derives DEM cells from `tile_bbox ± (MARGIN_LON, MARGIN_LAT)`. `MARGIN_LAT=1.5`
+covers 31TCH but is 1° short for 31TCG (swath needs N44 from a 42.45°N tile). Widen to 3.0 (N45 headroom).
+**Acceptance criteria:**
+- [ ] `MARGIN_LAT = 3.0`; comment explains the swath-vs-tile span (31TCG needed N44 from 42.45°N).
+- [ ] unit test: `tiles_to_fetch("31TCG", …)` includes the full **N44** row (incl. `N44_W001/W002`).
+- [ ] existing margin/ocean/idempotency tests still pass.
+**Verification:** `uv run python -m pytest tests/unit/test_ensure_dem.py -q` green.
+**Dependencies:** None. **Files:** `scripts/ensure_dem.py`, `tests/unit/test_ensure_dem.py`. **Scope:** S
+
+### Task A2: Prove it end-to-end (the real gate)
+**Description:** s1tiling reports DEM gaps incrementally and aborts, so the unit test isn't sufficient proof —
+a live render is. Re-run 31TCG and confirm OTB succeeds with the wider margin.
+**⚠ Image dependency (Gap 1):** `ensure_dem.py` runs in the s1tiling `ensure-dem` step via
+`pipeline_image_version` — the working-tree change is NOT exercised until it's in a *built image*. So A2 must
+run against the **A1-PR-branch CI build** (`sha-<A1 commit>`), set on a throwaway test s1tiling template
+(same pattern A3 uses with `sha-e83f83c`). Do NOT test against `main`/integration — that has the old margin.
+**Acceptance criteria:**
+- [ ] 31TCG workflow **Succeeds**, `aggFail=0`, GeoTIFFs produced — running the **A1-image** (verify the tag).
+- [ ] if a *new* gap appears, widen/iterate (don't declare fixed on a green unit test alone).
+**Verification:** confirm CI built the A1 commit; submit 31TCG (desc, 2026-06-05→07) on a test template pinned
+to that image; monitor to terminal; capture `argo` evidence.
+**Dependencies:** A1 + its CI image build. **Files:** none (live run). **Scope:** S
+
+### Task A2b: Deploy the margin fix (post-merge pin bump)
+**Description:** Once A1 merges, the integration build carries the fix, but the deployed s1tiling template still
+pins the old `pipeline_image_version`. Bump it so cron/sensor runs use the margin fix.
+**Acceptance criteria:**
+- [ ] `eopf-explorer-s1tiling-template` `pipeline_image_version` bumped to the post-merge integration build
+      (`sha-<merged commit>`, e.g. the `6f32275`-lineage build that also carries #261) — own platform-deploy PR.
+**Verification:** deployed template references the new tag; `argo lint` clean.
+**Dependencies:** A1 merged + CI image. **Files:** `eopf-explorer-s1tiling-template.yaml`. **Scope:** XS
+
+### Task A3: Validate the #246 titiler workaround pre-merge (independent of A1/A2)
+**Description:** Prove the #246 direct-write actually makes titiler render, *before* merging #261/#241. Uses an
+already-rendering tile (31TCH) so it needs no margin fix. Mirrors the test-template pattern: a throwaway test
+ingest template carrying #241's path + the #261 image (`sha-e83f83c`, has direct-write + the `f43d567` parse),
+run against 31TCH's existing GeoTIFFs → cube at `tests-output/sentinel-1-grd-rtc-tests/s1-rtc-31TCH.zarr` →
+register (no auto-copy) → titiler preview.
+**Acceptance criteria — DONE ✅ (2026-06-15, image `sha-b629416`):**
+- [x] ingest+register Succeeded; cube present at `…-fra/tests-output/sentinel-1-grd-rtc-tests/s1-rtc-31TCH.zarr`.
+- [x] STAC item `s1-rtc-31TCH` registered in `sentinel-1-grd-rtc-tests` (no `_titiler_render_copy`).
+- [x] titiler `/info` + `tilejson` + `/preview` → **HTTP 200** (`/preview` = image/jpeg 42 926 B). Recorded on #246.
+**Image note:** the correct integration image is the PR-merge sha **`sha-b629416`** (= `pr-232`), NOT the
+branch-head `sha-6f32275` (not pushed) nor the PR-head `sha-e83f83c` (not found). See memory
+`reference_datapipeline_image_tags`.
+**Note:** disposable `-tests` data; cleaned up in Phase D.
+
+### Checkpoint A
+- [ ] A1 unit test green; A2 live render Succeeds; **A3 preview HTTP 200** → open the margin-fix PR; #246 de-risked.
+
+---
+
+## Phase B — #246 closure  *(after #261 + #241 + data-model merge)*
+
+### Task B1: Merge + Flux-sync the direct-write workaround
+**Status:** data-pipeline **#261 MERGED** (integration `6f32275`). Remaining: platform-deploy **#241** + the
+data-model commit reachable from the pinned branch.
+**Acceptance criteria:**
+- [x] #261 merged; data-model `f43d567` on `feat/s1-rtc-stac-builder`.
+- [ ] #241 merged; Flux reconciles the ingest template; cron/sensor unchanged.
+**Verification:** deployed ingest template `s3_zarr_store` == `…/tests-output/{collection}/s1-rtc-{tile}.zarr`.
+**Dependencies:** #241 review. **Scope:** XS (review/merge)
+
+### Task B2: Clean up orphaned STAC items + stale stores
+**Description:** `s1-rtc-31TCJ`, `s1-rtc-31TDH` are registered with no store at the render path; a misplaced
+copy sits under `tests-output/…-staging/`. Remove the orphan items + stale/misplaced stores so STAC matches S3.
+**Acceptance criteria:**
+- [ ] orphan items deleted from STAC (`sentinel-1-grd-rtc-tests`); stale `tests-output/…-staging/` copies removed.
+- [ ] no STAC item points at a non-existent store.
+**Verification:** STAC list vs S3 `tests-output/sentinel-1-grd-rtc-tests/` reconcile (every item has a store).
+**Dependencies:** B1. **Scope:** S (cluster/S3 ops)
+
+### Task B3: Re-ingest the orphaned tiles on the merged path (Gap 2: scope narrowed)
+**Description:** A3 already proves the #246 preview path end-to-end (31TCH, pre-merge), so this is **not** a
+re-test of the mechanism — it's re-ingesting the *orphans* (`31TCJ`, `31TDH`) through the merged pipeline so
+they resolve, plus a post-merge confirmation on one tile. (31TCJ has GeoTIFFs from the scale-up; 31TDH may need
+a fresh s1tiling run — and if so, the margin fix A, since 31TDH is in the same swath family as 31TCG.)
+**Acceptance criteria:**
+- [ ] `31TCJ` (and `31TDH`) re-ingested; each store present at `…-fra/tests-output/sentinel-1-grd-rtc-tests/s1-rtc-{tile}.zarr`.
+- [ ] their `/preview` returns **HTTP 200** with no manual copy → #246 acceptance boxes ticked + comment on #246.
+**Verification:** curl titiler `/preview` for each → 200.
+**Dependencies:** B1 (#241 merge), B2 (cleanup first), and A for 31TDH if it lacks DEM coverage.
+**Dependencies:** B1, B2, and A (if a re-ingested tile needs the margin fix). **Scope:** S
+
+### Checkpoint B
+- [ ] Preview 200 with no copy → #246 acceptance met (issue stays open only for the titiler-eopf#108 revert).
+
+---
+
+## Phase C — T7 Phase-1 CP-A closure  *(after A + #240 merge)*
+
+### Task C1: Merge #240 (DEM→workspace) + re-run the 3-tile scale-up
+**Description:** Scale-up was 2/3 (31TCG failed on the margin bug). With A merged, re-run 31TCH+31TCJ+31TCG
+concurrently to get **3/3** on the real (merged) template.
+**Acceptance criteria:**
+- [ ] #240 merged + Flux-synced (real `eopf-explorer-s1tiling` template carries the workspace handoff).
+- [ ] 3 concurrent tiles all **Succeed** (`aggFail=0`, diff-tile parallel, per-tile DEM).
+- [ ] CP-A marked done in `claude-docs/plans/subissue_T7_multitile_aoi.md`.
+**Verification:** submit 3 tiles via the merged template; monitor to 3× Succeeded.
+**Dependencies:** A (margin), #240. **Scope:** S (live run)
+
+---
+
+## Phase D — Cleanup test scaffolding  *(after A/B/C green)*
+
+### Task D1: Tear down throwaway in-cluster test resources
+**Acceptance criteria:**
+- [ ] delete test templates: `workflowtemplate/eopf-explorer-s1tiling-test`,
+      `workflowtemplate/eopf-explorer-ingest-v1-s1rtc-test` (A3), `configmap/s1grd-rtc-cfg-base-test`.
+- [ ] delete the test/failed workflows (`cpa-31tch-desc-*`, `diag-31tcg-*`, `scale-31tc*`, `t246-ingest-*` (A3)).
+- [ ] A3 leftovers: if the A3 test wrote `tests-output/sentinel-1-grd-rtc-tests/s1-rtc-31TCH.zarr` + a STAC
+      item that B3 doesn't keep, remove them (disposable `-tests` data).
+- [ ] resolve the `s1-dem-cache` SealedSecret/PVC/Secret: #240 removes them from git — confirm Flux prunes
+      them, else delete the manually-applied in-cluster objects; remove the `s3://…/dem-cache` test objects.
+- [ ] restore the stashed data-pipeline `uv.lock` + `claude-docs/`/`tasks/` when returning to the query-stac branch.
+**Verification:** `kubectl get workflowtemplate,configmap,sealedsecret,pvc -n devseed-staging | grep -iE 'test|dem-cache'` empty.
+**Dependencies:** A/B/C (don't delete scaffolding still in use). **Scope:** S
+
+---
+
+## Phase E — Follow-up (separate issue, not now)
+- **Footprint-derived DEM** — **filed as #264.** Replace the tile+margin heuristic: derive cells from the
+  actual S1 product footprint (thread the geometry from the trigger, which already queries CDSE) and fetch
+  exactly `footprint ∩ GLO-30 ∩ land-gpkg`. Eliminates per-tile margin guessing + over-fetch. Not urgent
+  (lat±3° works — CP-A 3/3).
+
+## Risks & mitigations
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Margin 3.0 still short / a new gap on 31TCG | Med | A2 live re-run is the gate; iterate before declaring fixed |
+| Orphan cleanup deletes a still-referenced store | High | B2 reconciles STAC↔S3 first; delete only items with no store |
+| Flux doesn't prune the removed `s1-dem-cache` PVC | Low | D1 explicitly checks + manually deletes if prune is off |
+| Re-ingest needs the margin fix for some tiles | Med | sequence B3 after A; pick tiles with known DEM coverage |
+
+## Open questions
+1. Should the data-model `f43d567` be split into its own PR (vs the commit on #180)? Needs a force-push of the
+   shared branch — only if you want strict per-change PR symmetry.
+2. Which tiles for the B3 re-ingest acceptance — reuse 31TCH (known-good) or a fresh `-tests` tile?

--- a/claude-docs/plans/t7_phase2_pyrenees_alps.md
+++ b/claude-docs/plans/t7_phase2_pyrenees_alps.md
@@ -76,7 +76,7 @@ expected tiles; ocean→empty; every emitted tile resolvable in `DEM_Union.gpkg`
 - [x] generator tests green (10 passed); lists committed (Pyrenees 14, Alps 72) + map-reviewed.
       **⏸ Awaiting human sign-off before Task 3 starts any live processing.**
 
-### Task 3 — Pyrenees starter soak (CP-B-lite)  *(live, staging)* — M  ⏳ IN PROGRESS
+### Task 3 — Pyrenees starter soak (CP-B-lite)  *(live, staging)* — M  ⏸ STOPPED EARLY (partial)
 **Description:** Drive the Pyrenees list (14 tiles) through the pipeline at N=3, **both orbits**, a recent
 window — via controlled manual batches against the deployed templates (not the cron yet). Watch render
 success, per-tile DEM, throughput, CDSE throttle, dedup (re-run → 0 new).
@@ -85,15 +85,27 @@ success, per-tile DEM, throughput, CDSE throttle, dedup (re-run → 0 new).
 `lookback_days=14`, `trigger_image_version=sha-0ecdafc` (overridden: the pinned `v0.3.0-s1rtc` predates the
 `both` support #254; `sha-0ecdafc` carries both #254 + the #262 margin fix `MARGIN_LAT=3.0`, both verified by
 `docker run`). s1tiling template already pins `sha-0ecdafc`. Lands in `sentinel-1-grd-rtc-staging` (OQ-2).
-**Acceptance criteria:**
-- [ ] all land tiles render (or cleanly skip empty-data days); per-tile DEM self-provisions; `aggDEMfail=0`.
-- [ ] cubes + per-acq items appear for the tiles in `sentinel-1-grd-rtc-staging` (see OQ-2); previews 200.
-- [ ] a re-run processes **only new** products (no dup slices).
-**Verification:** monitor batches to terminal; STAC + titiler spot-check a few tiles; re-run shows 0 new.
-**Dependencies:** Task 2, deployed pipeline. **Files:** none (live). **Scope:** M (soak)
+**Outcome — STOPPED EARLY by user (2026-06-16):** discover found **66 products** (14 tiles × both orbits ×
+14 d); at N=3 (~2.3 products/h) the full soak ETA was ~23 h, so the user chose to stop after the in-flight
+batch ingested. Suspended → drained the running ingests → terminated. **13 products fully ingested, 0
+failures**, landing in **5 distinct tile cubes** in `sentinel-1-grd-rtc-staging`: `30TWM`, `30TWN`, `30TXM`,
+`31TCH`, `31TEH` (multiple per-acquisition products append per tile cube). All 5 cubes' titiler thumbnails →
+**HTTP 200** (real PNGs, 17 KB–1.16 MB). The remaining ~52 products + the rest of the 14 tiles (incl.
+**`31TCG`, the #262 margin-fix tile — NOT reached**) were not processed. Dedup re-run **not** exercised.
+**Acceptance criteria (partial — proven only on the 5 completed cubes):**
+- [x] completed tiles render; per-tile DEM self-provisioned; `aggDEMfail=0` on the 13 ingested products.
+      *(Not all 14 land tiles — 31TCG/31TDG/31TBG/31TBH/31TDH/31TEG/31TCG-row not reached.)*
+- [x] cubes + per-acq items in `sentinel-1-grd-rtc-staging` for 5 tiles (see OQ-2); previews **200** (5/5).
+- [ ] a re-run processes **only new** products (no dup slices). — **not run** (stopped early).
+**Verification:** STAC list = 5 cubes; titiler `/preview` 200 for all 5; `argo terminate` clean (13 ingests
+Succeeded). **Dependencies:** Task 2, deployed pipeline. **Files:** none (live). **Scope:** M (soak)
+**To finish the gate:** re-run the soak to completion (all 14 tiles incl. 31TCG) and do the dedup re-run,
+or accept the partial proof and move to Task 4/5 with the cron driving full coverage over time.
 
-### Checkpoint B (after 3): starter region proven
-- [ ] Pyrenees soak clean (renders, dedup, cost within budget). **Review before scaling to the Alps.**
+### Checkpoint B (after 3): starter region proven  ⚠ PARTIAL
+- [~] Pyrenees soak **partially** proven: 13 products / 5 tile cubes rendered + ingested + previews 200, 0
+      failures — the region flow works end-to-end via the real cron. **Not** clean-complete: full 14-tile
+      coverage (incl. 31TCG), cost-over-full-run, and the dedup re-run are still owed. **Review before Alps.**
 
 ### Task 4 — Alps expansion soak  *(live, staging)* — L
 **Description:** Same as Task 3 for the Alps list (~60–90 tiles) — the larger soak (~1–2 days at N=3).

--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -3,13 +3,17 @@
 The cube (`s1-rtc-{tile}.zarr`, collection `sentinel-1-grd-rtc-staging`) holds all acquisitions on a
 `time` axis. This emits **one queryable STAC item per `time` slice** (`s1-rtc-{tile}-{datetime}`,
 single `datetime`) into the env-split per-acquisition collection (`--collection`, default `…-tests`,
-the cron passes `…-staging`), each pointing at the cube
-via asset href and carrying `sel=time` preview links (tilejson + xyz) and a thumbnail asset, so a
-per-acquisition item renders in the Explorer like the cube item — scoped to its own slice.
+the cron passes `…-staging`). **No data duplication**: the item's render links point at the **cube's**
+TiTiler endpoint (`--cube-collection`/items/`s1-rtc-{tile}`) with `sel=time={physical index}` — TiTiler
+reconstructs the shared cube store and `isel`s this acquisition's slice. (The deployed titiler-eopf
+supports `sel` by integer index, not the `nearest::{datetime}` syntax; switch to the datetime form when
+it does — more reorder-proof.) The index is the slice's **physical** position in the cube's `time`
+axis; it's re-derived every run, so it stays correct as the cube appends.
 
 Usage:
     uv run python scripts/register_per_acquisition.py --store <cube-uri> --tile-id 31TCH \
-      --orbit-direction descending --stac-api-url <url> --raster-api-url <url>
+      --orbit-direction descending --collection <acq-coll> --cube-collection <cube-coll> \
+      --stac-api-url <url> --raster-api-url <url>
 """
 
 from __future__ import annotations
@@ -17,8 +21,9 @@ from __future__ import annotations
 import argparse
 import copy
 import datetime as dt
-import urllib.parse
 from typing import Any
+
+from register_v1 import _render_to_query
 
 # Per-acquisition collections are env-split like the cube collections (…-tests/-staging/-prod). The
 # code default targets the test env (local/CP-A runs); the Argo cron passes --collection …-staging.
@@ -30,59 +35,61 @@ def acquisition_id(tile_id: str, when: dt.datetime) -> str:
     return f"s1-rtc-{tile_id}-{when.strftime('%Y%m%dt%H%M%S')}"
 
 
-def _sel_time_query(when: dt.datetime, orbit: str, var: str) -> str:
-    """Shared TiTiler query selecting this acquisition's slice (``sel=time``) + the VH render params."""
-    sel = urllib.parse.quote(f"time=nearest::{when.isoformat()}", safe="")
-    variables = urllib.parse.quote(f"/{orbit}:{var}", safe="")
-    return f"variables={variables}&bidx=1&rescale=0%2C219&assets={var}&sel={sel}"
+def _cube_item_base(raster_api: str, cube_collection: str, tile_id: str) -> str:
+    """TiTiler endpoint of the shared **cube** item (``s1-rtc-{tile}`` in the cube collection).
+
+    The per-acquisition item's render links point here — not at the acquisition item's own endpoint —
+    because TiTiler reconstructs the store path from ``{collection}/{item_id}`` and only the cube path
+    exists. ``sel=time={index}`` then selects this acquisition's slice.
+    """
+    return f"{raster_api}/collections/{cube_collection}/items/s1-rtc-{tile_id}"
 
 
-def _item_raster_base(raster_api: str, collection: str, item_id: str) -> str:
-    return f"{raster_api}/collections/{collection}/items/{item_id}"
-
-
-def sel_time_tilejson(
-    raster_api: str,
-    collection: str,
-    item_id: str,
-    when: dt.datetime,
-    orbit: str,
-    *,
-    var: str = "vh",
+def render_tilejson(
+    raster_api: str, cube_collection: str, tile_id: str, render: dict, index: int
 ) -> str:
-    """TiTiler tilejson URL that renders this acquisition's slice of the cube (``sel=time``)."""
-    base = _item_raster_base(raster_api, collection, item_id)
-    return f"{base}/WebMercatorQuad/tilejson.json?{_sel_time_query(when, orbit, var)}"
+    """tilejson URL for the cube's slice ``index`` (composite render from ``renders.rgb`` + ``sel``)."""
+    base = _cube_item_base(raster_api, cube_collection, tile_id)
+    return f"{base}/WebMercatorQuad/tilejson.json?{_render_to_query(render, include_tilesize=True)}&sel=time={index}"
 
 
-def sel_time_xyz(
-    raster_api: str,
-    collection: str,
-    item_id: str,
-    when: dt.datetime,
-    orbit: str,
-    *,
-    var: str = "vh",
+def render_xyz(
+    raster_api: str, cube_collection: str, tile_id: str, render: dict, index: int
 ) -> str:
-    """TiTiler XYZ tile template (``{z}/{x}/{y}.png``) for this acquisition's slice — the map preview,
-    mirroring the cube item's ``xyz`` link (register_v0.add_visualization_links)."""
-    base = _item_raster_base(raster_api, collection, item_id)
-    return f"{base}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{_sel_time_query(when, orbit, var)}"
+    """XYZ tile template (``{z}/{x}/{y}.png``) for the cube's slice ``index`` — the map preview."""
+    base = _cube_item_base(raster_api, cube_collection, tile_id)
+    q = _render_to_query(render, include_tilesize=True)
+    return f"{base}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{q}&sel=time={index}"
 
 
-def sel_time_thumbnail(
-    raster_api: str,
-    collection: str,
-    item_id: str,
-    when: dt.datetime,
-    orbit: str,
-    *,
-    var: str = "vh",
+def render_thumbnail(
+    raster_api: str, cube_collection: str, tile_id: str, render: dict, index: int
 ) -> str:
-    """TiTiler ``preview`` PNG for this acquisition's slice — the static thumbnail, mirroring the cube
-    item's thumbnail asset (register_v0.add_thumbnail_asset)."""
-    base = _item_raster_base(raster_api, collection, item_id)
-    return f"{base}/preview?format=png&{_sel_time_query(when, orbit, var)}"
+    """``preview`` PNG for the cube's slice ``index`` — the static thumbnail."""
+    base = _cube_item_base(raster_api, cube_collection, tile_id)
+    return f"{base}/preview?format=png&{_render_to_query(render, include_tilesize=False)}&sel=time={index}"
+
+
+def _reorient_item_to_orbit(item: dict, orbit: str) -> None:
+    """Fix the base item's orbit-dependent **STAC metadata** to this acquisition's run ``orbit``.
+
+    ``eopf_geozarr.build_s1_rtc_stac_item`` derives ``sat:orbit_state``, the ``renders.rgb`` orbit, and
+    the ``vv``/``vh`` asset groups from the cube's *preferred* orbit (it prefers ascending), so a
+    both-orbits cube mislabels a descending acquisition as ascending. Correct them so the queryable
+    metadata matches the run orbit. The ``vv``/``vh`` hrefs stay on the **cube** store — only the orbit
+    group changes. (Render-param tuning beyond the orbit is deferred to titiler-eopf#108.)
+    """
+    props = item["properties"]
+    props["sat:orbit_state"] = orbit
+    rgb = props.get("renders", {}).get("rgb")
+    if rgb is not None:
+        vv, vh = f"/{orbit}:vv", f"/{orbit}:vh"
+        rgb["expression"] = f"{vv};{vh};({vv})/({vh})"
+    cube_href = item.get("assets", {}).get("zarr-store", {}).get("href")
+    if cube_href:
+        for pol in ("vv", "vh"):
+            if pol in item["assets"]:
+                item["assets"][pol]["href"] = f"{cube_href}/{orbit}"
 
 
 def per_acquisition_items(
@@ -92,16 +99,20 @@ def per_acquisition_items(
     tile_id: str,
     orbit: str,
     collection: str,
+    cube_collection: str,
     raster_api: str,
 ) -> list[dict]:
     """Clone the per-tile ``base_item`` into one item per `time` slice.
 
-    Each clone keeps the base geometry/assets/SAR+proj properties, sets a single ``datetime`` (drops
-    the start/end range), targets ``collection``, and carries ``sel=time`` preview links + a thumbnail
-    asset (tilejson + xyz + thumbnail) so it renders like the cube item. ``base_item`` is not mutated.
+    ``times_ns`` must be in the cube's **physical** order — each item's ``sel=time={index}`` uses its
+    position here. Each clone keeps the base geometry/assets/SAR+proj properties, sets a single
+    ``datetime`` (drops the start/end range), targets the acquisition ``collection``, reorients the
+    orbit-dependent metadata to the run ``orbit``, and gets tilejson/xyz/thumbnail links pointing at the
+    **cube** endpoint (``cube_collection``/``s1-rtc-{tile}``) with the composite render + ``sel=time``.
+    ``base_item`` is not mutated.
     """
     items: list[dict] = []
-    for t_ns in times_ns:
+    for index, t_ns in enumerate(times_ns):
         when = dt.datetime.fromtimestamp(t_ns / 1e9, tz=dt.UTC)
         item_id = acquisition_id(tile_id, when)
         item = copy.deepcopy(base_item)
@@ -114,25 +125,29 @@ def per_acquisition_items(
         }
         props["datetime"] = when.isoformat()
         item["properties"] = props
+        _reorient_item_to_orbit(item, orbit)
+        render = item["properties"]["renders"][
+            "rgb"
+        ]  # reoriented composite (build always emits it)
         item["links"] = [
             {
                 "rel": "tilejson",
                 "type": "application/json",
-                "href": sel_time_tilejson(raster_api, collection, item_id, when, orbit),
-                "title": "tilejson (sel=time)",
+                "href": render_tilejson(raster_api, cube_collection, tile_id, render, index),
+                "title": "tilejson",
             },
             {
                 "rel": "xyz",
                 "type": "image/png",
-                "href": sel_time_xyz(raster_api, collection, item_id, when, orbit),
-                "title": "Sentinel-1 GRD VH (sel=time)",
+                "href": render_xyz(raster_api, cube_collection, tile_id, render, index),
+                "title": "Sentinel-1 GRD RGB composite",
             },
         ]
         item.setdefault("assets", {})["thumbnail"] = {
-            "href": sel_time_thumbnail(raster_api, collection, item_id, when, orbit),
+            "href": render_thumbnail(raster_api, cube_collection, tile_id, render, index),
             "type": "image/png",
             "roles": ["thumbnail"],
-            "title": "Sentinel-1 GRD VH Preview (sel=time)",
+            "title": "Sentinel-1 GRD RGB composite preview",
         }
         items.append(item)
     return items
@@ -152,12 +167,14 @@ def _open_root(store: str) -> Any:
 
 
 def read_times_ns(store: str, orbit: str) -> list[int]:
-    """Sorted `time` values (ns since epoch) from the cube's native (r10m) level."""
+    """`time` values (ns since epoch) from the cube's native (r10m) level, in **physical** (stored)
+    order — NOT sorted. The list position is the slice's index, which the render links bake as
+    ``sel=time={index}``; it must match TiTiler's `isel` over the same stored array."""
     import numpy as np
 
     root = _open_root(store)
     times = np.asarray(root[orbit]["r10m"]["time"]).astype("datetime64[ns]").astype("int64")
-    return sorted(int(t) for t in times)
+    return [int(t) for t in times]
 
 
 def _upsert_items(stac_api_url: str, collection: str, items: list[dict]) -> None:
@@ -181,7 +198,14 @@ def main() -> None:
     ap.add_argument("--store", required=True, help="per-tile cube URI (https/s3)")
     ap.add_argument("--tile-id", required=True)
     ap.add_argument("--orbit-direction", required=True, choices=["descending", "ascending"])
-    ap.add_argument("--collection", default=DEFAULT_ACQ_COLLECTION)
+    ap.add_argument(
+        "--collection", default=DEFAULT_ACQ_COLLECTION, help="per-acquisition collection"
+    )
+    ap.add_argument(
+        "--cube-collection",
+        required=True,
+        help="cube collection (its TiTiler endpoint serves the shared store the render links point at)",
+    )
     ap.add_argument("--stac-api-url", required=True)
     ap.add_argument("--raster-api-url", required=True)
     args = ap.parse_args()
@@ -203,6 +227,7 @@ def main() -> None:
         tile_id=args.tile_id,
         orbit=args.orbit_direction,
         collection=args.collection,
+        cube_collection=args.cube_collection,
         raster_api=args.raster_api_url,
     )
     _upsert_items(args.stac_api_url, args.collection, items)

--- a/scripts/run_ingest_register.py
+++ b/scripts/run_ingest_register.py
@@ -150,6 +150,8 @@ def run_pipeline(
         orbit_direction,
         "--collection",
         acquisitions_collection,
+        "--cube-collection",
+        collection,
         "--stac-api-url",
         stac_api_url,
         "--raster-api-url",

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -1,11 +1,15 @@
 """Unit tests for scripts/register_per_acquisition.py — per-acquisition STAC items (plan T5).
 
-One STAC item per cube `time` slice, id `s1-rtc-{tile}-{datetime}`, with `sel=time` preview links
-(tilejson + xyz) and a thumbnail asset. Pure builders tested here; store I/O + upsert in main().
+One STAC item per cube `time` slice, id `s1-rtc-{tile}-{datetime}`. Render links point at the **cube**
+TiTiler endpoint with the composite render + `sel=time={physical index}` (no data duplication; the
+acquisition item is a reference into the shared cube). Pure builders tested here; store I/O + upsert in
+main().
 """
 
 import datetime as dt
+import json
 import sys
+import urllib.parse
 from pathlib import Path
 
 SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "register_per_acquisition.py"
@@ -18,13 +22,21 @@ def _mod():
     return register_per_acquisition
 
 
+CUBE = "sentinel-1-grd-rtc-staging"  # cube collection (render endpoint)
+ACQ = "sentinel-1-grd-rtc-acquisitions"  # per-acquisition collection (items go here)
+RASTER = "https://api.explorer.eopf.copernicus.eu/raster"
+# two acquisitions; passed in PHYSICAL (append) order — deliberately NOT chronological
+_T_LATER = int(dt.datetime(2026, 6, 7, 5, 52, 48, tzinfo=dt.UTC).timestamp() * 1e9)
+_T_EARLY = int(dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC).timestamp() * 1e9)
+
+
 def _base_item() -> dict:
-    """A per-tile base item (as build_s1_rtc_stac_item would emit) to clone per acquisition."""
+    """Per-tile base item as build_s1_rtc_stac_item emits: a temporal range, a `renders.rgb` composite,
+    and vv/vh/zarr-store assets — preferring **ascending** so reorientation to a descending run shows."""
     return {
         "type": "Feature",
-        "stac_version": "1.0.0",
         "id": "s1-rtc-31TCH",
-        "collection": "sentinel-1-grd-rtc-staging",
+        "collection": CUBE,
         "geometry": {
             "type": "Polygon",
             "coordinates": [[[0, 42], [2, 42], [2, 43], [0, 43], [0, 42]]],
@@ -35,138 +47,126 @@ def _base_item() -> dict:
             "end_datetime": "2026-06-07T05:52:48Z",
             "sar:product_type": "GRD",
             "proj:code": "EPSG:32631",
+            "sat:orbit_state": "ascending",
+            "renders": {
+                "rgb": {
+                    "title": "VV, VH, VV/VH composite",
+                    "expression": "/ascending:vv;/ascending:vh;(/ascending:vv)/(/ascending:vh)",
+                    "rescale": [[0.0, 0.1]],
+                    "bidx": [1],
+                    "tilesize": 256,
+                }
+            },
         },
         "assets": {
-            "vh": {"href": "https://gw/.../s1-rtc-31TCH.zarr/descending", "roles": ["data"]},
-            "zarr-store": {"href": "https://gw/.../s1-rtc-31TCH.zarr", "roles": ["data"]},
+            "vv": {"href": "https://gw/x/s1-rtc-31TCH.zarr/ascending", "roles": ["data"]},
+            "vh": {"href": "https://gw/x/s1-rtc-31TCH.zarr/ascending", "roles": ["data"]},
+            "zarr-store": {"href": "https://gw/x/s1-rtc-31TCH.zarr", "roles": ["data"]},
         },
         "links": [],
     }
 
 
-# two acquisitions on the cube's time axis (ns since epoch)
-_T0 = int(dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC).timestamp() * 1e9)
-_T1 = int(dt.datetime(2026, 6, 7, 5, 52, 48, tzinfo=dt.UTC).timestamp() * 1e9)
-RASTER = "https://api.explorer.eopf.copernicus.eu/raster"
-ACQ = "sentinel-1-grd-rtc-acquisitions"
+def _items(orbit: str = "descending", times=None):
+    return _mod().per_acquisition_items(
+        _base_item(),
+        times if times is not None else [_T_EARLY],
+        tile_id="31TCH",
+        orbit=orbit,
+        collection=ACQ,
+        cube_collection=CUBE,
+        raster_api=RASTER,
+    )
+
+
+def _links(item):
+    return {link["rel"]: link["href"] for link in item["links"]}
 
 
 # --- acquisition_id ----------------------------------------------------------
 
 
 def test_acquisition_id_format():
-    m = _mod()
     when = dt.datetime(2026, 6, 7, 5, 52, 48, tzinfo=dt.UTC)
-    assert m.acquisition_id("31TCH", when) == "s1-rtc-31TCH-20260607t055248"
+    assert _mod().acquisition_id("31TCH", when) == "s1-rtc-31TCH-20260607t055248"
 
 
-# --- sel_time_tilejson -------------------------------------------------------
+# --- identity + datetime -----------------------------------------------------
 
 
-def test_sel_time_tilejson_carries_sel_and_item():
-    m = _mod()
-    when = dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC)
-    url = m.sel_time_tilejson(RASTER, ACQ, "s1-rtc-31TCH-20260605t060907", when, "descending")
-    assert ACQ in url and "s1-rtc-31TCH-20260605t060907" in url
-    assert "sel=" in url and "time%3Dnearest" in url  # url-encoded "time=nearest"
-    assert "tilejson.json" in url
-
-
-# --- sel_time_xyz / sel_time_thumbnail (preview parity with the cube item) ----
-
-
-def test_sel_time_xyz_is_png_tile_template_with_sel():
-    m = _mod()
-    when = dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC)
-    url = m.sel_time_xyz(RASTER, ACQ, "s1-rtc-31TCH-20260605t060907", when, "descending")
-    # XYZ tile template (titiler {z}/{x}/{y}.png), scoped to this acquisition's slice
-    assert "/tiles/WebMercatorQuad/{z}/{x}/{y}.png" in url
-    assert "s1-rtc-31TCH-20260605t060907" in url
-    assert "sel=" in url and "time%3Dnearest" in url
-    assert "rescale=0%2C219" in url and "assets=vh" in url
-
-
-def test_sel_time_thumbnail_is_png_preview_with_sel():
-    m = _mod()
-    when = dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC)
-    url = m.sel_time_thumbnail(RASTER, ACQ, "s1-rtc-31TCH-20260605t060907", when, "descending")
-    assert "/preview" in url and "format=png" in url
-    assert "sel=" in url and "time%3Dnearest" in url
-
-
-# --- per_acquisition_items ---------------------------------------------------
-
-
-def test_per_acquisition_items_one_per_time():
-    m = _mod()
-    items = m.per_acquisition_items(
-        _base_item(),
-        [_T0, _T1],
-        tile_id="31TCH",
-        orbit="descending",
-        collection=ACQ,
-        raster_api=RASTER,
-    )
-    assert [i["id"] for i in items] == [
-        "s1-rtc-31TCH-20260605t060907",
-        "s1-rtc-31TCH-20260607t055248",
-    ]
-
-
-def test_per_acquisition_items_single_datetime_no_range():
-    m = _mod()
-    items = m.per_acquisition_items(
-        _base_item(), [_T0], tile_id="31TCH", orbit="descending", collection=ACQ, raster_api=RASTER
-    )
-    props = items[0]["properties"]
+def test_single_datetime_no_range_and_targets_acq_collection():
+    item = _items()[0]
+    props = item["properties"]
+    assert item["collection"] == ACQ  # item lives in the per-acquisition collection
     assert props["datetime"] == "2026-06-05T06:09:07+00:00"
     assert "start_datetime" not in props and "end_datetime" not in props
-    assert props["sar:product_type"] == "GRD"  # base properties preserved
+    assert props["sar:product_type"] == "GRD"
 
 
-def test_per_acquisition_items_collection_and_sel_link():
-    m = _mod()
-    items = m.per_acquisition_items(
-        _base_item(), [_T0], tile_id="31TCH", orbit="descending", collection=ACQ, raster_api=RASTER
-    )
-    item = items[0]
-    assert item["collection"] == ACQ
-    tilejson = [link for link in item["links"] if link["rel"] == "tilejson"]
-    assert len(tilejson) == 1
-    assert "sel=" in tilejson[0]["href"] and item["id"] in tilejson[0]["href"]
+# --- render links point at the CUBE endpoint + sel=index (no duplication) -----
 
 
-def test_per_acquisition_items_has_xyz_link_and_thumbnail_asset():
-    """Preview parity with the cube item: each per-acq item carries an xyz link + a thumbnail
-    asset, both scoped to the acquisition's slice (sel=time)."""
-    m = _mod()
-    items = m.per_acquisition_items(
-        _base_item(), [_T0], tile_id="31TCH", orbit="descending", collection=ACQ, raster_api=RASTER
-    )
-    item = items[0]
-    rels = {link["rel"] for link in item["links"]}
-    assert {"tilejson", "xyz"} <= rels
-    xyz = next(link for link in item["links"] if link["rel"] == "xyz")
-    assert "{z}/{x}/{y}.png" in xyz["href"] and "sel=" in xyz["href"]
-    thumb = item["assets"]["thumbnail"]
+def test_render_links_point_at_cube_endpoint_with_sel_index():
+    """tilejson + xyz target the CUBE item's endpoint (not the acquisition item's), carry the
+    composite render (reoriented to the run orbit) + rescale 0,0.1 + sel=time={index}; no store path,
+    no hardcoded 0,219, no nearest:: syntax."""
+    links = _links(_items()[0])
+    for rel in ("tilejson", "xyz"):
+        href = links[rel]
+        assert f"/collections/{CUBE}/items/s1-rtc-31TCH" in href  # cube endpoint, not the acq item
+        assert ACQ not in href  # the render link never points at the acquisitions collection
+        assert "expression=" in href
+        assert "rescale=0.0%2C0.1" in href and "rescale=0%2C219" not in href
+        assert "sel=time=0" in href and "nearest" not in href
+        assert "/descending:vv" in urllib.parse.unquote(href)  # reoriented to the run orbit
+    assert "tilejson.json" in links["tilejson"] and "{z}/{x}/{y}.png" in links["xyz"]
+
+
+def test_thumbnail_asset_points_at_cube_endpoint_with_sel_index():
+    thumb = _items()[0]["assets"]["thumbnail"]
     assert thumb["type"] == "image/png" and thumb["roles"] == ["thumbnail"]
-    assert "sel=" in thumb["href"] and item["id"] in thumb["href"]
+    href = thumb["href"]
+    assert f"/collections/{CUBE}/items/s1-rtc-31TCH/preview" in href
+    assert "expression=" in href and "rescale=0.0%2C0.1" in href and "sel=time=0" in href
 
 
-def test_per_acquisition_items_does_not_add_thumbnail_to_base():
-    m = _mod()
-    base = _base_item()
-    m.per_acquisition_items(
-        base, [_T0], tile_id="31TCH", orbit="descending", collection=ACQ, raster_api=RASTER
+def test_sel_index_follows_physical_order_not_chronology():
+    """sel=time={index} uses the slice's PHYSICAL position in the passed list (cube append order),
+    NOT chronological order — index 0 maps to the first-appended slice even if it's later in time."""
+    items = _items(times=[_T_LATER, _T_EARLY])  # physical/append order (later appended first)
+    assert items[0]["properties"]["datetime"] == "2026-06-07T05:52:48+00:00"
+    assert "sel=time=0" in _links(items[0])["tilejson"]
+    assert items[1]["properties"]["datetime"] == "2026-06-05T06:09:07+00:00"
+    assert "sel=time=1" in _links(items[1])["tilejson"]
+
+
+# --- orbit metadata reconciliation -------------------------------------------
+
+
+def test_reorients_orbit_metadata_to_run_orbit():
+    """A descending run's item carries /descending metadata (sat:orbit_state, renders.rgb orbit, vv/vh
+    asset group) — never the cube's preferred /ascending. vv/vh hrefs stay on the cube (group only)."""
+    item = _items(orbit="descending")[0]
+    props = item["properties"]
+    assert props["sat:orbit_state"] == "descending"
+    assert props["renders"]["rgb"]["expression"] == (
+        "/descending:vv;/descending:vh;(/descending:vv)/(/descending:vh)"
     )
-    assert "thumbnail" not in base["assets"]  # base assets untouched
+    for pol in ("vv", "vh"):
+        assert item["assets"][pol]["href"] == "https://gw/x/s1-rtc-31TCH.zarr/descending"
+    assert "ascending" not in urllib.parse.unquote(json.dumps(item))
 
 
-def test_per_acquisition_items_does_not_mutate_base():
-    m = _mod()
+# --- base item is never mutated ----------------------------------------------
+
+
+def test_does_not_mutate_base():
     base = _base_item()
-    m.per_acquisition_items(
-        base, [_T0, _T1], tile_id="31TCH", orbit="descending", collection=ACQ, raster_api=RASTER
-    )
-    assert base["id"] == "s1-rtc-31TCH"  # base untouched
+    _mod().per_acquisition_items(
+        base, [_T_EARLY, _T_LATER], tile_id="31TCH", orbit="descending",
+        collection=ACQ, cube_collection=CUBE, raster_api=RASTER,
+    )  # fmt: skip
+    assert base["id"] == "s1-rtc-31TCH"
     assert "start_datetime" in base["properties"]
+    assert base["properties"]["sat:orbit_state"] == "ascending"  # not reoriented in place
+    assert "thumbnail" not in base["assets"]

--- a/tests/unit/test_run_ingest_register.py
+++ b/tests/unit/test_run_ingest_register.py
@@ -90,10 +90,12 @@ def test_registers_both_cube_item_and_per_acquisition_items() -> None:
     assert any(
         s.endswith("register_per_acquisition.py") for s in scripts_called
     ), "per-acquisition items not registered"
-    # per-acq register (3rd call) targets the acquisitions collection with the same s3 store
+    # per-acq register (3rd call) targets the acquisitions collection with the same s3 store, and
+    # passes the cube collection so the render links point at the cube's TiTiler endpoint (sel=index)
     peracq_cmd = mock_run.call_args_list[2][0][0]
     assert "sentinel-1-grd-rtc-acquisitions" in peracq_cmd
     assert _S3_CUBE in peracq_cmd
+    assert peracq_cmd[peracq_cmd.index("--cube-collection") + 1] == _KWARGS["collection"]
 
 
 def test_per_acquisition_skipped_when_cube_register_fails() -> None:


### PR DESCRIPTION
## Why
Per-acquisition STAC items (`sentinel-1-grd-rtc-acquisitions-*`) didn't render in the Explorer. They're references into the one per-tile cube, but the deployed TiTiler **reconstructs the store path from `{collection}/{item_id}` and ignores the asset href**, so an acquisition item's name maps to a path with no store → 500.

## What (zero data duplication)
**Key finding** (verified live on `s1-rtc-30TXM`): the deployed titiler-eopf **supports `sel` by integer index** (`sel=time=0/1` → 200, distinct slices; the `nearest::{datetime}` syntax → 500). So a per-acquisition item renders **its slice of the shared cube** by pointing its render links at the **cube** item's endpoint + `sel=time={index}` — no per-acquisition store, no TiTiler change.

- **`register_per_acquisition`**: tilejson/xyz/thumbnail → `{cube_collection}/items/s1-rtc-{tile}` + the composite `renders.rgb` (reusing `register_v1._render_to_query`) + `sel=time={physical index}`. The index is the slice's **physical** position in the cube `time` axis, re-derived every run (stable under append).
- **`_reorient_item_to_orbit`**: fix `sat:orbit_state` / `renders` orbit / `vv,vh` asset group to the run orbit (`build_s1_rtc_stac_item` hardcodes the cube's preferred `/ascending`).
- **`run_ingest_register`**: pass `--cube-collection` to the per-acq register step (3-subprocess flow otherwise unchanged).

> Supersedes this PR's first cut (a single-acquisition GeoZarr **store per acquisition**, ≈2× per-tile storage) — that approach was dropped: **no dual storage**.

## Robustness
Positional index is stable because the cube only appends, and indices are re-baked every register run. Upgrade path: switch to `sel=time=nearest::{datetime}` (reorder-proof) once the deployed titiler supports it. Independent of #246 / titiler-eopf#108 — renders via whatever serves the cube.

## Validation (`sentinel-1-grd-rtc-acquisitions-tests`, 31TCH)
Item `tilejson` + `thumbnail` → **200**, rendering the cube's slice via `sel=time=0`; index↔datetime mapping confirmed (physical `time[0]` == item stamp); **no** per-acquisition store present. 466 unit tests + ruff green.

## Tests
`register_per_acquisition`: links target the cube endpoint + `sel=time={index}` + composite (no store path, no `0,219`, no `nearest`); `sel` index follows physical (append) order, not chronology; orbit metadata reconciled. `run_ingest_register`: passes `--cube-collection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)