### PR TITLE
fix(s1-rtc): render per-acquisition previews by datetime + incremental registration

### DIFF
--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -4,11 +4,14 @@ The cube (`s1-rtc-{tile}.zarr`, collection `sentinel-1-grd-rtc-staging`) holds a
 `time` axis. This emits **one queryable STAC item per `time` slice** (`s1-rtc-{tile}-{datetime}`,
 single `datetime`) into the env-split per-acquisition collection (`--collection`, default `…-tests`,
 the cron passes `…-staging`). **No data duplication**: the item's render links point at the **cube's**
-TiTiler endpoint (`--cube-collection`/items/`s1-rtc-{tile}`) with `sel=time={physical index}` — TiTiler
-reconstructs the shared cube store and `isel`s this acquisition's slice. (The deployed titiler-eopf
-supports `sel` by integer index, not the `nearest::{datetime}` syntax; switch to the datetime form when
-it does — more reorder-proof.) The index is the slice's **physical** position in the cube's `time`
-axis; it's re-derived every run, so it stays correct as the cube appends.
+TiTiler endpoint (`--cube-collection`/items/`s1-rtc-{tile}`) with `sel=time={datetime}` — TiTiler
+reconstructs the shared cube store and selects this acquisition's slice by its **datetime** (exact
+label `.sel`, since the cube's `time` is CF-encoded; see data-model #192). Selecting by datetime instead
+of a positional index makes each item self-contained: it renders the correct slice regardless of the
+cube's physical slice order (which can go non-monotonic on out-of-order appends), so no slice ever needs
+re-registering when the cube grows. Registration is therefore **incremental** — only acquisitions not
+already in the collection are written (use `--reregister-all` for the one-time migration of items that
+still carry the old index-based `sel`).
 
 Usage:
     uv run python scripts/register_per_acquisition.py --store <cube-uri> --tile-id 31TCH \
@@ -21,6 +24,7 @@ from __future__ import annotations
 import argparse
 import copy
 import datetime as dt
+import urllib.parse
 from typing import Any
 
 from register_v1 import _render_to_query
@@ -40,34 +44,43 @@ def _cube_item_base(raster_api: str, cube_collection: str, tile_id: str) -> str:
 
     The per-acquisition item's render links point here — not at the acquisition item's own endpoint —
     because TiTiler reconstructs the store path from ``{collection}/{item_id}`` and only the cube path
-    exists. ``sel=time={index}`` then selects this acquisition's slice.
+    exists. ``sel=time={datetime}`` then selects this acquisition's slice.
     """
     return f"{raster_api}/collections/{cube_collection}/items/s1-rtc-{tile_id}"
 
 
+def _sel_time(sel_time: str) -> str:
+    """The ``sel`` query fragment selecting a slice by datetime (exact label ``.sel`` in TiTiler).
+
+    The ``:`` in the timestamp is percent-encoded so the href is unambiguous; TiTiler decodes it before
+    parsing ``time=<value>``.
+    """
+    return f"sel=time={urllib.parse.quote(sel_time, safe='')}"
+
+
 def render_tilejson(
-    raster_api: str, cube_collection: str, tile_id: str, render: dict, index: int
+    raster_api: str, cube_collection: str, tile_id: str, render: dict, sel_time: str
 ) -> str:
-    """tilejson URL for the cube's slice ``index`` (composite render from ``renders.rgb`` + ``sel``)."""
+    """tilejson URL for the cube slice at ``sel_time`` (composite render from ``renders.rgb`` + ``sel``)."""
     base = _cube_item_base(raster_api, cube_collection, tile_id)
-    return f"{base}/WebMercatorQuad/tilejson.json?{_render_to_query(render, include_tilesize=True)}&sel=time={index}"
+    return f"{base}/WebMercatorQuad/tilejson.json?{_render_to_query(render, include_tilesize=True)}&{_sel_time(sel_time)}"
 
 
 def render_xyz(
-    raster_api: str, cube_collection: str, tile_id: str, render: dict, index: int
+    raster_api: str, cube_collection: str, tile_id: str, render: dict, sel_time: str
 ) -> str:
-    """XYZ tile template (``{z}/{x}/{y}.png``) for the cube's slice ``index`` — the map preview."""
+    """XYZ tile template (``{z}/{x}/{y}.png``) for the cube slice at ``sel_time`` — the map preview."""
     base = _cube_item_base(raster_api, cube_collection, tile_id)
     q = _render_to_query(render, include_tilesize=True)
-    return f"{base}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{q}&sel=time={index}"
+    return f"{base}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{q}&{_sel_time(sel_time)}"
 
 
 def render_thumbnail(
-    raster_api: str, cube_collection: str, tile_id: str, render: dict, index: int
+    raster_api: str, cube_collection: str, tile_id: str, render: dict, sel_time: str
 ) -> str:
-    """``preview`` PNG for the cube's slice ``index`` — the static thumbnail."""
+    """``preview`` PNG for the cube slice at ``sel_time`` — the static thumbnail."""
     base = _cube_item_base(raster_api, cube_collection, tile_id)
-    return f"{base}/preview?format=png&{_render_to_query(render, include_tilesize=False)}&sel=time={index}"
+    return f"{base}/preview?format=png&{_render_to_query(render, include_tilesize=False)}&{_sel_time(sel_time)}"
 
 
 def _reorient_item_to_orbit(item: dict, orbit: str) -> None:
@@ -104,17 +117,20 @@ def per_acquisition_items(
 ) -> list[dict]:
     """Clone the per-tile ``base_item`` into one item per `time` slice.
 
-    ``times_ns`` must be in the cube's **physical** order — each item's ``sel=time={index}`` uses its
-    position here. Each clone keeps the base geometry/assets/SAR+proj properties, sets a single
-    ``datetime`` (drops the start/end range), targets the acquisition ``collection``, reorients the
-    orbit-dependent metadata to the run ``orbit``, and gets tilejson/xyz/thumbnail links pointing at the
-    **cube** endpoint (``cube_collection``/``s1-rtc-{tile}``) with the composite render + ``sel=time``.
-    ``base_item`` is not mutated.
+    Each clone keeps the base geometry/assets/SAR+proj properties, sets a single ``datetime`` (drops the
+    start/end range), targets the acquisition ``collection``, reorients the orbit-dependent metadata to
+    the run ``orbit``, and gets tilejson/xyz/thumbnail links pointing at the **cube** endpoint
+    (``cube_collection``/``s1-rtc-{tile}``) with the composite render + ``sel=time={datetime}``. The
+    render selects the slice by its **datetime**, so the order of ``times_ns`` is irrelevant — each item
+    is correct on its own regardless of the cube's physical slice order. ``base_item`` is not mutated.
     """
     items: list[dict] = []
-    for index, t_ns in enumerate(times_ns):
+    for t_ns in times_ns:
         when = dt.datetime.fromtimestamp(t_ns / 1e9, tz=dt.UTC)
         item_id = acquisition_id(tile_id, when)
+        # Exact value TiTiler matches against the CF-decoded datetime64 `time` index (second precision,
+        # the resolution S1 acquisition stamps carry); same instant as `when` / the item id.
+        sel_time = when.strftime("%Y-%m-%dT%H:%M:%S")
         item = copy.deepcopy(base_item)
         item["id"] = item_id
         item["collection"] = collection
@@ -133,18 +149,18 @@ def per_acquisition_items(
             {
                 "rel": "tilejson",
                 "type": "application/json",
-                "href": render_tilejson(raster_api, cube_collection, tile_id, render, index),
+                "href": render_tilejson(raster_api, cube_collection, tile_id, render, sel_time),
                 "title": "tilejson",
             },
             {
                 "rel": "xyz",
                 "type": "image/png",
-                "href": render_xyz(raster_api, cube_collection, tile_id, render, index),
+                "href": render_xyz(raster_api, cube_collection, tile_id, render, sel_time),
                 "title": "Sentinel-1 GRD RGB composite",
             },
         ]
         item.setdefault("assets", {})["thumbnail"] = {
-            "href": render_thumbnail(raster_api, cube_collection, tile_id, render, index),
+            "href": render_thumbnail(raster_api, cube_collection, tile_id, render, sel_time),
             "type": "image/png",
             "roles": ["thumbnail"],
             "title": "Sentinel-1 GRD RGB composite preview",
@@ -167,14 +183,26 @@ def _open_root(store: str) -> Any:
 
 
 def read_times_ns(store: str, orbit: str) -> list[int]:
-    """`time` values (ns since epoch) from the cube's native (r10m) level, in **physical** (stored)
-    order — NOT sorted. The list position is the slice's index, which the render links bake as
-    ``sel=time={index}``; it must match TiTiler's `isel` over the same stored array."""
+    """`time` values (ns since epoch) from the cube's native (r10m) level. Each value becomes one
+    per-acquisition item whose render selects by that datetime, so the order is irrelevant (no longer a
+    positional index). ``r10m/time`` stays a raw int64 array even after the CF attrs are added, so this
+    read is unchanged."""
     import numpy as np
 
     root = _open_root(store)
     times = np.asarray(root[orbit]["r10m"]["time"]).astype("datetime64[ns]").astype("int64")
     return [int(t) for t in times]
+
+
+def existing_item_ids(stac_api_url: str, collection: str, candidate_ids: list[str]) -> set[str]:
+    """Of ``candidate_ids``, those already present in ``collection`` (one STAC search, not N lookups)."""
+    from pystac_client import Client
+
+    if not candidate_ids:
+        return set()
+    client = Client.open(stac_api_url)
+    search = client.search(collections=[collection], ids=candidate_ids, limit=len(candidate_ids))
+    return {it["id"] for it in search.items_as_dicts()}
 
 
 def _upsert_items(stac_api_url: str, collection: str, items: list[dict]) -> None:
@@ -208,6 +236,12 @@ def main() -> None:
     )
     ap.add_argument("--stac-api-url", required=True)
     ap.add_argument("--raster-api-url", required=True)
+    ap.add_argument(
+        "--reregister-all",
+        action="store_true",
+        help="re-upsert every slice's item (one-time migration of items still on the old index sel); "
+        "default registers only acquisitions not already in the collection",
+    )
     args = ap.parse_args()
 
     from eopf_geozarr.stac.s1_rtc import build_s1_rtc_stac_item
@@ -230,6 +264,14 @@ def main() -> None:
         cube_collection=args.cube_collection,
         raster_api=args.raster_api_url,
     )
+    # Incremental by default: each item's datetime `sel` is correct for the life of the cube, so only
+    # acquisitions not yet in the collection need writing (scales as the cube grows). --reregister-all
+    # forces all (migrating items that still carry the old index-based sel).
+    if not args.reregister_all:
+        existing = existing_item_ids(args.stac_api_url, args.collection, [i["id"] for i in items])
+        skipped = len(items)
+        items = [i for i in items if i["id"] not in existing]
+        print(f"{skipped - len(items)} already registered, {len(items)} new")
     _upsert_items(args.stac_api_url, args.collection, items)
     print(f"registered {len(items)} per-acquisition item(s) in {args.collection}")
 

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -1,8 +1,9 @@
 """Unit tests for scripts/register_per_acquisition.py — per-acquisition STAC items (plan T5).
 
 One STAC item per cube `time` slice, id `s1-rtc-{tile}-{datetime}`. Render links point at the **cube**
-TiTiler endpoint with the composite render + `sel=time={physical index}` (no data duplication; the
-acquisition item is a reference into the shared cube). Pure builders tested here; store I/O + upsert in
+TiTiler endpoint with the composite render + `sel=time={datetime}` (no data duplication; the acquisition
+item is a reference into the shared cube). Selecting by datetime (not a positional index) makes each item
+correct regardless of the cube's physical slice order. Pure builders tested here; store I/O + upsert in
 main().
 """
 
@@ -103,13 +104,17 @@ def test_single_datetime_no_range_and_targets_acq_collection():
     assert props["sar:product_type"] == "GRD"
 
 
-# --- render links point at the CUBE endpoint + sel=index (no duplication) -----
+# --- render links point at the CUBE endpoint + sel=datetime (no duplication) --
+
+# _T_EARLY = 2026-06-05T06:09:07 → the encoded sel fragment TiTiler matches by datetime
+_SEL_EARLY = "sel=time=2026-06-05T06%3A09%3A07"
+_SEL_LATER = "sel=time=2026-06-07T05%3A52%3A48"
 
 
-def test_render_links_point_at_cube_endpoint_with_sel_index():
+def test_render_links_point_at_cube_endpoint_with_sel_datetime():
     """tilejson + xyz target the CUBE item's endpoint (not the acquisition item's), carry the
-    composite render (reoriented to the run orbit) + rescale 0,0.1 + sel=time={index}; no store path,
-    no hardcoded 0,219, no nearest:: syntax."""
+    composite render (reoriented to the run orbit) + rescale 0,0.1 + sel=time={datetime} (colons
+    percent-encoded); no store path, no hardcoded 0,219, no integer index, no nearest:: syntax."""
     links = _links(_items()[0])
     for rel in ("tilejson", "xyz"):
         href = links[rel]
@@ -117,27 +122,28 @@ def test_render_links_point_at_cube_endpoint_with_sel_index():
         assert ACQ not in href  # the render link never points at the acquisitions collection
         assert "expression=" in href
         assert "rescale=0.0%2C0.1" in href and "rescale=0%2C219" not in href
-        assert "sel=time=0" in href and "nearest" not in href
+        assert _SEL_EARLY in href and "nearest" not in href
+        assert "sel=time=0" not in href  # not a positional index
         assert "/descending:vv" in urllib.parse.unquote(href)  # reoriented to the run orbit
     assert "tilejson.json" in links["tilejson"] and "{z}/{x}/{y}.png" in links["xyz"]
 
 
-def test_thumbnail_asset_points_at_cube_endpoint_with_sel_index():
+def test_thumbnail_asset_points_at_cube_endpoint_with_sel_datetime():
     thumb = _items()[0]["assets"]["thumbnail"]
     assert thumb["type"] == "image/png" and thumb["roles"] == ["thumbnail"]
     href = thumb["href"]
     assert f"/collections/{CUBE}/items/s1-rtc-31TCH/preview" in href
-    assert "expression=" in href and "rescale=0.0%2C0.1" in href and "sel=time=0" in href
+    assert "expression=" in href and "rescale=0.0%2C0.1" in href and _SEL_EARLY in href
 
 
-def test_sel_index_follows_physical_order_not_chronology():
-    """sel=time={index} uses the slice's PHYSICAL position in the passed list (cube append order),
-    NOT chronological order — index 0 maps to the first-appended slice even if it's later in time."""
+def test_sel_follows_datetime_not_physical_position():
+    """Each item's sel is ITS OWN datetime, independent of position in the passed (physical) list —
+    so a non-monotonic cube still renders every slice correctly without reordering or re-registering."""
     items = _items(times=[_T_LATER, _T_EARLY])  # physical/append order (later appended first)
     assert items[0]["properties"]["datetime"] == "2026-06-07T05:52:48+00:00"
-    assert "sel=time=0" in _links(items[0])["tilejson"]
+    assert _SEL_LATER in _links(items[0])["tilejson"]  # index 0 but its OWN (later) datetime
     assert items[1]["properties"]["datetime"] == "2026-06-05T06:09:07+00:00"
-    assert "sel=time=1" in _links(items[1])["tilejson"]
+    assert _SEL_EARLY in _links(items[1])["tilejson"]  # index 1 but its OWN (earlier) datetime
 
 
 # --- orbit metadata reconciliation -------------------------------------------


### PR DESCRIPTION
The data-pipeline half of the datetime-rendering fix. Tracking issue: EOPF-Explorer/data-model#192. Pairs with the data-model CF-`time` change (in EOPF-Explorer/data-model#180).

## Problem
Per-acquisition items render via titiler `sel=time={INTEGER index}` — a positional index that mis-targets or 400s once a cube's time axis goes **non-monotonic** (an out-of-order cross-run append; e.g. 31TEH `[06-08, 06-07]`, leaving the 06-07 item with no preview). Keeping it correct would need cube reorder **and re-registering every item on every append** — not scalable.

## Change
- **Render by datetime:** links now use `sel=time={YYYY-MM-DDThh:mm:ss}` (colons percent-encoded) instead of a positional index. With the cube's `time` CF-encoded (data-model#192), titiler's existing label `.sel` matches by **exact datetime**, which works **even on a non-monotonic axis**. Each item is self-contained — correct regardless of physical slice order, never needs re-registering when the cube grows. (Verified the exact value round-trips through titiler's `np.datetime64(v)` cast + `.sel`.)
- **Incremental registration:** by default only acquisitions not already in the collection are written (one STAC search to diff candidate ids), instead of re-upserting every slice each run. `--reregister-all` forces a full re-upsert for the one-time migration of items still carrying the old index sel.
- `read_times_ns` / `per_acquisition_items` no longer depend on physical order.

## Tests
Updated `test_register_per_acquisition.py`: sel follows each item's **own datetime** independent of its position in the (physical) list; thumbnail/tilejson/xyz carry the encoded datetime, not an index. **18 passed** (register + gen_aoi); ruff + mypy clean.

## ⚠️ Deploy ordering
Must deploy **after** the data-model CF-`time` fix is live **and** cubes are CF-encoded (re-ingested/backfilled) — datetime `sel` against a bare-int64 `time` 500s. See #192 rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)