### PR TITLE
feat(s1-rtc): cube preview defaults to the best-recent acquisition slice

### DIFF
--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -212,15 +212,33 @@ def _render_to_query(render: dict, *, include_tilesize: bool) -> str:
     return "&".join(parts)
 
 
-def add_visualization_links(item: Item, raster_base: str, collection_id: str) -> None:
-    """Add viewer/xyz/tilejson links for TiTiler visualization."""
+def _with_sel_time(query: str, sel_time: str | None) -> str:
+    """Append the ``sel=time={datetime}`` selector to a titiler query when a slice is pinned.
+
+    Used for the S1 RTC cube item so its preview defaults to a chosen acquisition; ``None`` leaves the
+    query unchanged (other callers/missions render the default slice). Colons are percent-encoded so the
+    href is unambiguous (TiTiler decodes before parsing ``time=<value>``).
+    """
+    if not sel_time:
+        return query
+    return f"{query}&sel=time={urllib.parse.quote(sel_time, safe='')}"
+
+
+def add_visualization_links(
+    item: Item, raster_base: str, collection_id: str, sel_time: str | None = None
+) -> None:
+    """Add viewer/xyz/tilejson links for TiTiler visualization.
+
+    ``sel_time`` (when set) pins the render to one cube slice by datetime — the cube item passes the
+    best-recent acquisition so its preview isn't the default (oldest) slice.
+    """
     base_url = f"{raster_base}/collections/{collection_id}/items/{item.id}"
     item.add_link(Link("viewer", f"{base_url}/viewer", "text/html", f"Viewer for {item.id}"))
 
     # Prefer a producer-declared render config (STAC render extension) over the
     # hardcoded mission defaults below.
     if render := _select_render(item):
-        query = _render_to_query(render, include_tilesize=True)
+        query = _with_sel_time(_render_to_query(render, include_tilesize=True), sel_time)
         title = render.get("title") or f"Visualization for {item.id}"
         item.add_link(
             Link(
@@ -302,8 +320,14 @@ def _add_explorer_link(item: Item, collection_id: str) -> None:
     )
 
 
-def add_thumbnail_asset(item: Item, raster_base: str, collection_id: str) -> None:
-    """Add thumbnail preview asset for STAC browsers."""
+def add_thumbnail_asset(
+    item: Item, raster_base: str, collection_id: str, sel_time: str | None = None
+) -> None:
+    """Add thumbnail preview asset for STAC browsers.
+
+    ``sel_time`` (when set) pins the preview image to one cube slice by datetime — the actual image the
+    STAC browser shows, so the cube item passes the best-recent acquisition.
+    """
     if "thumbnail" in item.assets:
         return
 
@@ -312,7 +336,9 @@ def add_thumbnail_asset(item: Item, raster_base: str, collection_id: str) -> Non
 
     # Prefer a producer-declared render config (STAC render extension).
     if render := _select_render(item):
-        params = "format=png&" + _render_to_query(render, include_tilesize=False)
+        params = _with_sel_time(
+            "format=png&" + _render_to_query(render, include_tilesize=False), sel_time
+        )
         title = render.get("title") or f"{item.id} preview"
         item.add_asset(
             "thumbnail",

--- a/scripts/register_v1_s1_rtc.py
+++ b/scripts/register_v1_s1_rtc.py
@@ -12,15 +12,22 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import logging
 import sys
 from pathlib import Path
+from typing import NamedTuple
 from urllib.parse import urlparse
+
+import numpy as np
+import zarr
 
 sys.path.insert(0, str(Path(__file__).parent))
 
 from eopf_geozarr.stac.s1_rtc import build_s1_rtc_stac_item
+from pystac import Item
 from pystac_client import Client
+from register_per_acquisition import _reorient_item_to_orbit
 from register_v1 import (
     add_alternate_s3_assets,
     add_store_link,
@@ -33,6 +40,94 @@ from register_v1 import (
 from run_ingest_register import check_env_consistency
 
 log = logging.getLogger(__name__)
+
+# The cube preview defaults to the most recent acquisition that covers most of the tile, so the browser
+# shows fresh, near-full data rather than the (default-rendered) oldest slice.
+COVERAGE_THRESHOLD = 0.80
+
+
+class Slice(NamedTuple):
+    """One cube time slice: which orbit group it lives in, its acquisition instant, and the fraction of
+    the tile it covers (0..1)."""
+
+    orbit: str
+    dt: dt.datetime
+    coverage: float
+
+
+def pick_slice(slices: list[Slice]) -> Slice | None:
+    """Choose the slice the cube preview should default to.
+
+    The most recent acquisition with coverage strictly above ``COVERAGE_THRESHOLD``; if none clears it,
+    the highest-coverage slice (ties broken by most recent). Spans both orbit groups. Returns ``None``
+    for an empty cube.
+    """
+    if not slices:
+        return None
+    good = [s for s in slices if s.coverage > COVERAGE_THRESHOLD]
+    if good:
+        return max(good, key=lambda s: s.dt)
+    return max(slices, key=lambda s: (s.coverage, s.dt))
+
+
+_ORBITS = ("ascending", "descending")
+
+
+def _open_cube_root(store: str) -> zarr.Group:
+    """Open the cube root, mirroring build_s1_rtc_stac_item: prefer consolidated metadata, fall back to a
+    plain group open (an appended same-orbit cube can lack root consolidated metadata)."""
+    try:
+        return zarr.open_consolidated(store, zarr_format=3)
+    except Exception as exc:  # noqa: BLE001 — only the consolidated-metadata absence is expected
+        if "consolidated metadata" not in str(exc).lower():
+            raise
+        return zarr.open_group(store, mode="r", zarr_format=3)
+
+
+def slice_coverages(store: str) -> list[Slice]:
+    """Per-slice tile coverage from the cube, both orbit groups.
+
+    Reads the ``border_mask`` at the cheap ``r720m`` level only (~150x150). Coverage is the fraction of
+    **valid** pixels; the S1Tiling ``_BorderMask`` is stored with ``fill_value=0`` for the border, so
+    valid = non-zero. ``time`` is raw int64 ns (as build_s1_rtc_stac_item reads it) -> UTC datetime.
+    """
+    root = _open_cube_root(store)
+    out: list[Slice] = []
+    for orbit in _ORBITS:
+        if orbit not in root:
+            continue
+        level = root[orbit]["r720m"]
+        mask = np.asarray(level["border_mask"])  # (time, y, x), uint8
+        times_ns = np.asarray(level["time"]).tolist()  # int64 ns since epoch
+        for i, t_ns in enumerate(times_ns):
+            sl = mask[i]
+            coverage = float(np.count_nonzero(sl) / sl.size)
+            out.append(Slice(orbit, dt.datetime.fromtimestamp(t_ns / 1e9, tz=dt.UTC), coverage))
+    return out
+
+
+def _pin_preview_to_best_recent(item: Item, store: str) -> tuple[Item, str | None]:
+    """Reorient the cube item to its best-recent slice's orbit and return that slice's ``sel=time`` value.
+
+    Picks the slice the preview should default to (``pick_slice`` over ``slice_coverages``), then reuses
+    ``_reorient_item_to_orbit`` so the render expression / orbit metadata target the chosen slice's orbit.
+    Best-effort: any coverage-read failure (or an empty cube) leaves the item unchanged and returns
+    ``None`` → the preview falls back to the default slice rather than failing registration.
+    """
+    try:
+        chosen = pick_slice(slice_coverages(store))
+    except Exception:
+        log.warning(
+            "Could not read slice coverage from %s; preview uses default slice",
+            store,
+            exc_info=True,
+        )
+        return item, None
+    if chosen is None:
+        return item, None
+    item_dict = item.to_dict()
+    _reorient_item_to_orbit(item_dict, chosen.orbit)
+    return Item.from_dict(item_dict), chosen.dt.strftime("%Y-%m-%dT%H:%M:%S")
 
 
 def register(
@@ -59,6 +154,10 @@ def register(
         log.exception("Failed to build STAC item from %s", store)
         return 1
 
+    # Default the cube preview to the best-recent acquisition (most recent >80% coverage, else max
+    # coverage) and reorient the item to that slice's orbit so the render targets the right group.
+    item, sel_time = _pin_preview_to_best_recent(item, store)
+
     # build_s1_rtc_stac_item returns s3:// hrefs; TiTiler needs https:// via the gateway
     for asset in item.assets.values():
         if asset.href and asset.href.startswith("s3://"):
@@ -66,8 +165,8 @@ def register(
 
     add_store_link(item, store)
     add_alternate_s3_assets(item, s3_endpoint)
-    add_visualization_links(item, raster_api_url, collection)
-    add_thumbnail_asset(item, raster_api_url, collection)
+    add_visualization_links(item, raster_api_url, collection, sel_time=sel_time)
+    add_thumbnail_asset(item, raster_api_url, collection, sel_time=sel_time)
     warm_thumbnail_cache(item)
 
     try:

--- a/tests/unit/test_pick_slice.py
+++ b/tests/unit/test_pick_slice.py
@@ -1,0 +1,84 @@
+"""Unit tests for scripts/register_v1_s1_rtc.py::pick_slice — the cube-preview slice selector.
+
+Rule (per plan): pick the **most recent acquisition with coverage > 0.80**; if none clears 0.80,
+pick the one with the **highest coverage** (ties broken by most recent). Spans both orbit groups.
+Pure function — no I/O — so exercised exhaustively here, including the adversarial boundaries.
+"""
+
+import datetime as dt
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "register_v1_s1_rtc.py"
+
+
+def _mod():
+    sys.path.insert(0, str(SCRIPT.parent))
+    import register_v1_s1_rtc
+
+    return register_v1_s1_rtc
+
+
+def _s(orbit: str, day: int, coverage: float):
+    return _mod().Slice(
+        orbit=orbit, dt=dt.datetime(2026, 6, day, 6, 0, tzinfo=dt.UTC), coverage=coverage
+    )
+
+
+def test_most_recent_above_threshold_wins_even_if_older_has_more_coverage():
+    m = _mod()
+    chosen = m.pick_slice(
+        [
+            _s("ascending", 4, 0.99),  # older, higher coverage
+            _s("descending", 7, 0.85),  # most recent above threshold -> winner
+            _s("ascending", 6, 0.90),
+        ]
+    )
+    assert (chosen.orbit, chosen.dt.day, chosen.coverage) == ("descending", 7, 0.85)
+
+
+def test_falls_back_to_max_coverage_when_none_above_threshold():
+    m = _mod()
+    chosen = m.pick_slice(
+        [
+            _s("ascending", 7, 0.40),  # most recent but low coverage
+            _s("descending", 5, 0.75),  # highest coverage (still <= 0.80) -> winner
+            _s("ascending", 4, 0.50),
+        ]
+    )
+    assert (chosen.orbit, chosen.dt.day, chosen.coverage) == ("descending", 5, 0.75)
+
+
+def test_exact_80_percent_is_not_above_threshold():
+    m = _mod()
+    # 0.80 is NOT > 0.80 -> excluded from the "good" set; the 0.81 older slice wins instead.
+    chosen = m.pick_slice(
+        [
+            _s("ascending", 7, 0.80),  # most recent, exactly at threshold -> excluded from "good"
+            _s("descending", 4, 0.81),  # only one strictly above -> winner
+        ]
+    )
+    assert (chosen.dt.day, chosen.coverage) == (4, 0.81)
+
+
+def test_max_coverage_tie_broken_by_most_recent():
+    m = _mod()
+    chosen = m.pick_slice(
+        [
+            _s("ascending", 4, 0.60),
+            _s("descending", 8, 0.60),  # same (max) coverage, more recent -> winner
+            _s("ascending", 6, 0.60),
+        ]
+    )
+    assert chosen.dt.day == 8
+
+
+def test_single_slice_returned():
+    m = _mod()
+    only = _s("ascending", 5, 0.10)
+    assert m.pick_slice([only]) == only
+
+
+def test_empty_returns_none():
+    m = _mod()
+    assert m.pick_slice([]) is None

--- a/tests/unit/test_register_v1.py
+++ b/tests/unit/test_register_v1.py
@@ -250,3 +250,31 @@ class TestVisualizationFromRenders:
         add_thumbnail_asset(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
         # legacy VH grayscale path still applies when no render config present
         assert "thumbnail" in item.assets
+
+
+_SEL = "2026-06-07T05:52:48"
+_SEL_Q = "sel=time=2026-06-07T05%3A52%3A48"  # colons percent-encoded
+
+
+class TestSelTimePinsSlice:
+    """The cube preview pins the best-recent slice via ``sel=time={datetime}`` on its links + thumbnail."""
+
+    def test_thumbnail_asset_carries_sel_time(self):
+        item = _real_item(_s1_rgb_renders())
+        add_thumbnail_asset(item, RASTER_BASE, "sentinel-1-grd-rtc-staging", sel_time=_SEL)
+        assert _SEL_Q in item.assets["thumbnail"].href
+
+    def test_xyz_and_tilejson_carry_sel_time(self):
+        item = _real_item(_s1_rgb_renders())
+        add_visualization_links(item, RASTER_BASE, "sentinel-1-grd-rtc-staging", sel_time=_SEL)
+        for rel in ("xyz", "tilejson"):
+            link = next(link for link in item.links if link.rel == rel)
+            assert _SEL_Q in link.href
+
+    def test_no_sel_time_by_default_backcompat(self):
+        # sel_time omitted (S2 + any other caller) => links/thumbnail unchanged, no sel.
+        item = _real_item(_s1_rgb_renders())
+        add_visualization_links(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
+        add_thumbnail_asset(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
+        hrefs = [link.href for link in item.links] + [item.assets["thumbnail"].href]
+        assert all("sel=time" not in h for h in hrefs)

--- a/tests/unit/test_register_v1_s1_rtc.py
+++ b/tests/unit/test_register_v1_s1_rtc.py
@@ -85,6 +85,7 @@ def test_upserts_item_with_correct_id() -> None:
     with (
         patch(f"{_MOD}.build_s1_rtc_stac_item", return_value=_make_item()),
         patch(f"{_MOD}.warm_thumbnail_cache"),
+        patch(f"{_MOD}.slice_coverages", return_value=[]),  # no store read in these unit tests
         patch(f"{_MOD}.upsert_item") as mock_upsert,
         patch(f"{_MOD}.Client"),
     ):
@@ -111,6 +112,7 @@ def test_visualization_links_called() -> None:
     with (
         patch(f"{_MOD}.build_s1_rtc_stac_item", return_value=_make_item()),
         patch(f"{_MOD}.warm_thumbnail_cache"),
+        patch(f"{_MOD}.slice_coverages", return_value=[]),  # no store read in these unit tests
         patch(f"{_MOD}.upsert_item"),
         patch(f"{_MOD}.Client"),
         patch(f"{_MOD}.add_visualization_links") as mock_viz,
@@ -191,6 +193,7 @@ def test_matched_env_store_allowed() -> None:
     with (
         patch(f"{_MOD}.build_s1_rtc_stac_item", return_value=_make_item()),
         patch(f"{_MOD}.warm_thumbnail_cache"),
+        patch(f"{_MOD}.slice_coverages", return_value=[]),  # no store read in these unit tests
         patch(f"{_MOD}.upsert_item") as mock_upsert,
         patch(f"{_MOD}.Client"),
     ):
@@ -204,3 +207,76 @@ def test_matched_env_store_allowed() -> None:
 
     assert result == 0
     mock_upsert.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Best-recent preview slice: _pin_preview_to_best_recent (reorient + sel_time)
+# ---------------------------------------------------------------------------
+
+import datetime as _dt  # noqa: E402
+
+import numpy as _np  # noqa: E402
+import zarr as _zarr  # noqa: E402
+from register_v1_s1_rtc import _pin_preview_to_best_recent  # noqa: E402
+
+
+def _ns(day: int) -> int:
+    return int(_dt.datetime(2026, 6, day, 6, 0, tzinfo=_dt.UTC).timestamp() * 1e9)
+
+
+def _write_orbit(root, orbit, masks, days):
+    lvl = root.create_group(orbit).create_group("r720m")
+    n, (y, x) = len(masks), masks[0].shape
+    lvl.create_array("border_mask", shape=(n, y, x), dtype="uint8", fill_value=0)[:] = _np.stack(
+        masks
+    )
+    lvl.create_array("time", shape=(n,), dtype="int64")[:] = _np.array(
+        [_ns(d) for d in days], "int64"
+    )
+
+
+def _cube_item(store_href: str) -> pystac.Item:
+    """A cube item as build_s1_rtc_stac_item emits: renders.rgb on the preferred (ascending) orbit."""
+    expr = "/ascending:vv;/ascending:vh;(/ascending:vv)/(/ascending:vh)"
+    item = pystac.Item(
+        id="s1-rtc-31TCH",
+        geometry=None,
+        bbox=None,
+        datetime=_dt.datetime(2026, 6, 7, tzinfo=_dt.UTC),
+        properties={
+            "sat:orbit_state": "ascending",
+            "renders": {"rgb": {"expression": expr, "rescale": [[0.0, 0.1]], "bidx": [1]}},
+        },
+    )
+    item.add_asset("zarr-store", pystac.Asset(href=store_href, roles=["data"]))
+    for pol in ("vv", "vh"):
+        item.add_asset(pol, pystac.Asset(href=f"{store_href}/ascending", roles=["data"]))
+    return item
+
+
+def test_pin_reorients_to_descending_best_recent(tmp_path) -> None:
+    """Best-recent = most recent >80%: descending day-7 (0.81) beats ascending day-4 (1.0)."""
+    store = str(tmp_path / "cube.zarr")
+    root = _zarr.open_group(store, mode="w", zarr_format=3)
+    full = _np.ones((4, 4))  # 1.0
+    over80 = _np.zeros((4, 4))
+    over80.flat[:13] = 1  # 13/16 = 0.8125 (> 0.80)
+    _write_orbit(root, "ascending", [full], [4])
+    _write_orbit(root, "descending", [over80], [7])
+
+    new_item, sel_time = _pin_preview_to_best_recent(_cube_item(store), store)
+
+    assert sel_time == "2026-06-07T06:00:00"
+    assert new_item.properties["sat:orbit_state"] == "descending"
+    assert "/descending:vv" in new_item.properties["renders"]["rgb"]["expression"]
+    assert "/ascending" not in new_item.properties["renders"]["rgb"]["expression"]
+
+
+def test_pin_noop_on_empty_cube(tmp_path) -> None:
+    """No slices -> item unchanged, sel_time None (preview falls back to default)."""
+    store = str(tmp_path / "empty.zarr")
+    _zarr.open_group(store, mode="w", zarr_format=3)  # no orbit groups
+    item = _cube_item(store)
+    new_item, sel_time = _pin_preview_to_best_recent(item, store)
+    assert sel_time is None
+    assert new_item.properties["sat:orbit_state"] == "ascending"  # untouched

--- a/tests/unit/test_slice_coverage.py
+++ b/tests/unit/test_slice_coverage.py
@@ -1,0 +1,78 @@
+"""Unit tests for scripts/register_v1_s1_rtc.py::slice_coverages — per-slice tile coverage from the cube.
+
+Reads ``border_mask`` at the cheap ``r720m`` level (valid = non-zero; ``fill_value=0`` = border) for each
+orbit group and pairs it with that level's ``time``. Mirrors ``build_s1_rtc_stac_item``'s open pattern
+(``zarr.open_*`` + raw int64-ns ``time``). Exercised against a tiny synthetic zarr-v3 cube — this also
+**confirms the border_mask polarity** (T0): a known-full mask must read as coverage 1.0.
+"""
+
+import datetime as dt
+import sys
+from pathlib import Path
+
+import numpy as np
+import zarr
+
+SCRIPT = Path(__file__).parent.parent.parent / "scripts" / "register_v1_s1_rtc.py"
+
+
+def _mod():
+    sys.path.insert(0, str(SCRIPT.parent))
+    import register_v1_s1_rtc
+
+    return register_v1_s1_rtc
+
+
+def _ns(day: int) -> int:
+    return int(dt.datetime(2026, 6, day, 6, 0, tzinfo=dt.UTC).timestamp() * 1e9)
+
+
+def _write_orbit(root, orbit: str, masks: list[np.ndarray], days: list[int]) -> None:
+    """Write {orbit}/r720m with a border_mask (time,y,x) + time (int64 ns), like the real cube."""
+    lvl = root.create_group(orbit).create_group("r720m")
+    n = len(masks)
+    y, x = masks[0].shape
+    bm = lvl.create_array("border_mask", shape=(n, y, x), dtype="uint8", fill_value=0)
+    bm[:] = np.stack(masks).astype("uint8")
+    t = lvl.create_array("time", shape=(n,), dtype="int64")
+    t[:] = np.array([_ns(d) for d in days], dtype="int64")
+
+
+def _make_cube(tmp_path) -> str:
+    store = str(tmp_path / "cube.zarr")
+    root = zarr.open_group(store, mode="w", zarr_format=3)
+    full = np.ones((4, 4))  # coverage 1.0
+    half = np.zeros((4, 4))
+    half[:2, :] = 1  # coverage 0.5
+    quarter = np.zeros((4, 4))
+    quarter[0, :] = 1  # coverage 0.25
+    _write_orbit(root, "ascending", [full, half], [4, 6])
+    _write_orbit(root, "descending", [quarter], [5])
+    return store
+
+
+def test_slice_coverages_reads_both_orbits_with_correct_fractions(tmp_path):
+    m = _mod()
+    store = _make_cube(tmp_path)
+    by_key = {(s.orbit, s.dt.day): s.coverage for s in m.slice_coverages(store)}
+    assert by_key == {
+        ("ascending", 4): 1.0,  # full mask -> polarity check (1 = valid)
+        ("ascending", 6): 0.5,
+        ("descending", 5): 0.25,
+    }
+
+
+def test_slice_coverages_times_are_utc_datetimes(tmp_path):
+    m = _mod()
+    store = _make_cube(tmp_path)
+    s = next(s for s in m.slice_coverages(store) if s.orbit == "descending")
+    assert s.dt == dt.datetime(2026, 6, 5, 6, 0, tzinfo=dt.UTC)
+
+
+def test_slice_coverages_skips_missing_orbit(tmp_path):
+    m = _mod()
+    store = str(tmp_path / "asc_only.zarr")
+    root = zarr.open_group(store, mode="w", zarr_format=3)
+    _write_orbit(root, "ascending", [np.ones((4, 4))], [7])
+    orbits = {s.orbit for s in m.slice_coverages(store)}
+    assert orbits == {"ascending"}


### PR DESCRIPTION
Closes #273.

## What
The S1 RTC **cube** STAC items rendered their preview from a default (oldest) slice because the `xyz`/`tilejson` links and the **thumbnail asset** carried no `sel=time`. This pins the cube preview to the **best-recent** slice.

**Rule:** most recent acquisition with **> 80 % tile coverage**; if none clears 80 %, the most recent with the **highest coverage** (ties → most recent). Across both orbit groups.

## How (data-pipeline only — no ingest/schema/titiler change)
- `pick_slice()` — pure selector for the rule (unit-tested incl. exact-80 boundary, ties, empty).
- `slice_coverages()` — per-slice coverage from the `border_mask` already stored at the cheap `r720m` level (valid = non-zero); mirrors `build_s1_rtc_stac_item`'s open + raw-ns time.
- `_pin_preview_to_best_recent()` in `register-stac`: reorient the item to the chosen slice's orbit (reuse `_reorient_item_to_orbit`) and thread `sel=time` into **both** `add_visualization_links` and `add_thumbnail_asset` (`warm_thumbnail_cache` inherits it). **Best-effort** — a coverage-read failure or empty cube falls back to the default slice, so registration never fails over preview selection. `sel_time=None` keeps S2/other callers unchanged.

Runs on every register → the preview auto-updates as new slices land.

## Verification
- **481 unit tests pass, ruff clean.** New: `test_pick_slice.py`, `test_slice_coverage.py`; extended `test_register_v1.py`, `test_register_v1_s1_rtc.py`.
- End-to-end on the real `30TWP` cube: edge tile, no slice >80% → max-coverage fallback (descending `2026-06-04`, 0.379) → reoriented `/descending` + `sel=time` thumbnail href → **renders HTTP 200, 574 KB PNG**.

## Deploy
New image build + ingest pin bump + **re-register** existing cube items to refresh links/thumbnail. New acquisitions pick it up automatically. (Re-rendering previously-rendered tiles is still gated on EOPF-Explorer/titiler-eopf#118 cache.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
