### PR TITLE
fix(s1-rtc): render at rescale 0.0,0.2 + align per-acquisition items with cube items

### DIFF
--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -27,11 +27,30 @@ import datetime as dt
 import urllib.parse
 from typing import Any
 
+from pystac import Item
 from register_v1 import _render_to_query
 
 # Per-acquisition collections are env-split like the cube collections (…-tests/-staging/-prod). The
 # code default targets the test env (local/CP-A runs); the Argo cron passes --collection …-staging.
 DEFAULT_ACQ_COLLECTION = "sentinel-1-grd-rtc-acquisitions-tests"
+
+# S1 RTC RGB composite rescale (linear gamma0 units), applied to every band. Overrides the upstream
+# build_s1_rtc_stac_item default (0.0,0.1, too bright) at item-build time so the cube item and every
+# per-acquisition item — and the tilejson/xyz/thumbnail queries derived from the render — inherit it.
+# In-pipeline because the data-model pin (16c5f14) can't be bumped to fix it upstream: data-model main
+# was refactored to a src/ layout and the build module moved. Revisit when the pin is migrated.
+S1_RTC_RESCALE = [[0.0, 0.2]]
+
+
+def apply_s1_rtc_rescale(item: Item) -> None:
+    """Set the S1 RTC RGB render rescale on a freshly built item.
+
+    Call right after ``build_s1_rtc_stac_item`` (before any render links are derived) so the
+    tilejson/xyz/thumbnail queries all inherit ``S1_RTC_RESCALE``.
+    """
+    render = item.properties.get("renders", {}).get("rgb")
+    if render is not None:
+        render["rescale"] = [list(pair) for pair in S1_RTC_RESCALE]
 
 
 def acquisition_id(tile_id: str, when: dt.datetime) -> str:
@@ -247,7 +266,9 @@ def main() -> None:
     from eopf_geozarr.stac.s1_rtc import build_s1_rtc_stac_item
     from register_v1 import s3_to_https
 
-    base = build_s1_rtc_stac_item(args.store, args.collection).to_dict()
+    base_item = build_s1_rtc_stac_item(args.store, args.collection)
+    apply_s1_rtc_rescale(base_item)
+    base = base_item.to_dict()
     # build_s1_rtc_stac_item emits s3:// hrefs for an s3 store; rewrite to the https gateway so the
     # per-acquisition items match the cube item (register_v1 does the same). Reading times below
     # still uses the s3 store, which is authoritative and avoids the gateway's read-cache lag.

--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -28,7 +28,7 @@ import urllib.parse
 from typing import Any
 
 from pystac import Item
-from register_v1 import _render_to_query
+from register_v1 import EXPLORER_BASE, _render_to_query
 
 # Per-acquisition collections are env-split like the cube collections (…-tests/-staging/-prod). The
 # code default targets the test env (local/CP-A runs); the Argo cron passes --collection …-staging.
@@ -122,6 +122,17 @@ def _reorient_item_to_orbit(item: dict, orbit: str) -> None:
         for pol in ("vv", "vh"):
             if pol in item["assets"]:
                 item["assets"][pol]["href"] = f"{cube_href}/{orbit}"
+    # When alternate S3 assets are present (per-acquisition path adds them before reorienting), keep the
+    # s3 alternate href on the same orbit group as the primary href. The cube path reorients before
+    # alternates exist, so this is a no-op there.
+    s3_root = (
+        item.get("assets", {}).get("zarr-store", {}).get("alternate", {}).get("s3", {}).get("href")
+    )
+    if s3_root:
+        for pol in ("vv", "vh"):
+            alt = item.get("assets", {}).get(pol, {}).get("alternate", {}).get("s3")
+            if isinstance(alt, dict) and "href" in alt:
+                alt["href"] = f"{s3_root}/{orbit}"
 
 
 def per_acquisition_items(
@@ -136,9 +147,10 @@ def per_acquisition_items(
 ) -> list[dict]:
     """Clone the per-tile ``base_item`` into one item per `time` slice.
 
-    Each clone keeps the base geometry/assets/SAR+proj properties, sets a single ``datetime`` (drops the
+    Each clone keeps the base geometry/assets (incl. the alternate-assets/storage blocks and `store`
+    link added to ``base_item`` upstream)/SAR+proj properties, sets a single ``datetime`` (drops the
     start/end range), targets the acquisition ``collection``, reorients the orbit-dependent metadata to
-    the run ``orbit``, and gets tilejson/xyz/thumbnail links pointing at the **cube** endpoint
+    the run ``orbit``, and gets tilejson/xyz/thumbnail + `via` links pointing at the **cube** endpoint
     (``cube_collection``/``s1-rtc-{tile}``) with the composite render + ``sel=time={datetime}``. The
     render selects the slice by its **datetime**, so the order of ``times_ns`` is irrelevant — each item
     is correct on its own regardless of the cube's physical slice order. ``base_item`` is not mutated.
@@ -164,7 +176,13 @@ def per_acquisition_items(
         render = item["properties"]["renders"][
             "rgb"
         ]  # reoriented composite (build always emits it)
+        # Keep the cube `store` link (added to base_item before cloning) and add the render links +
+        # the Explorer `via` link (this acquisition's own page). No `viewer` link: the TiTiler viewer
+        # can't deep-link to a single cube slice (it ignores URL query params and has no time selector),
+        # and the per-acq id has no reconstructable store. Render links stay slice-correct via sel=time.
+        store_links = [lk for lk in item.get("links", []) if lk.get("rel") == "store"]
         item["links"] = [
+            *store_links,
             {
                 "rel": "tilejson",
                 "type": "application/json",
@@ -176,6 +194,12 @@ def per_acquisition_items(
                 "type": "image/png",
                 "href": render_xyz(raster_api, cube_collection, tile_id, render, sel_time),
                 "title": "Sentinel-1 GRD RGB composite",
+            },
+            {
+                "rel": "via",
+                "type": "text/html",
+                "href": f"{EXPLORER_BASE}/collections/{collection.lower().replace('_', '-')}/items/{item_id}",
+                "title": "EOPF Explorer",
             },
         ]
         item.setdefault("assets", {})["thumbnail"] = {
@@ -256,6 +280,11 @@ def main() -> None:
     ap.add_argument("--stac-api-url", required=True)
     ap.add_argument("--raster-api-url", required=True)
     ap.add_argument(
+        "--s3-endpoint",
+        default="https://s3.de.io.cloud.ovh.net",
+        help="S3 endpoint for the alternate-assets/storage metadata (region + tier). Default: OVH de.",
+    )
+    ap.add_argument(
         "--reregister-all",
         action="store_true",
         help="re-upsert every slice's item (one-time migration of items still on the old index sel); "
@@ -264,17 +293,21 @@ def main() -> None:
     args = ap.parse_args()
 
     from eopf_geozarr.stac.s1_rtc import build_s1_rtc_stac_item
-    from register_v1 import s3_to_https
+    from register_v1 import add_alternate_s3_assets, add_store_link, s3_to_https
 
     base_item = build_s1_rtc_stac_item(args.store, args.collection)
     apply_s1_rtc_rescale(base_item)
+    # Mirror register_v1_s1_rtc's cube augmentation so per-acq items carry the same assets/metadata:
+    # rewrite s3://→https first (the alternate-assets block is derived from the https href), then add the
+    # cube `store` link + the alternate-assets/storage blocks. These flow into every clone via deepcopy
+    # in per_acquisition_items. Reading times below still uses the s3 store (authoritative; avoids the
+    # gateway's read-cache lag).
+    for asset in base_item.assets.values():
+        if asset.href and asset.href.startswith("s3://"):
+            asset.href = s3_to_https(asset.href)
+    add_store_link(base_item, args.store)
+    add_alternate_s3_assets(base_item, args.s3_endpoint)
     base = base_item.to_dict()
-    # build_s1_rtc_stac_item emits s3:// hrefs for an s3 store; rewrite to the https gateway so the
-    # per-acquisition items match the cube item (register_v1 does the same). Reading times below
-    # still uses the s3 store, which is authoritative and avoids the gateway's read-cache lag.
-    for asset in base.get("assets", {}).values():
-        if isinstance(asset.get("href"), str) and asset["href"].startswith("s3://"):
-            asset["href"] = s3_to_https(asset["href"])
     times = read_times_ns(args.store, args.orbit_direction)
     items = per_acquisition_items(
         base,

--- a/scripts/register_v1_s1_rtc.py
+++ b/scripts/register_v1_s1_rtc.py
@@ -27,7 +27,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from eopf_geozarr.stac.s1_rtc import build_s1_rtc_stac_item
 from pystac import Item
 from pystac_client import Client
-from register_per_acquisition import _reorient_item_to_orbit
+from register_per_acquisition import _reorient_item_to_orbit, apply_s1_rtc_rescale
 from register_v1 import (
     add_alternate_s3_assets,
     add_store_link,
@@ -157,6 +157,9 @@ def register(
     # Default the cube preview to the best-recent acquisition (most recent >80% coverage, else max
     # coverage) and reorient the item to that slice's orbit so the render targets the right group.
     item, sel_time = _pin_preview_to_best_recent(item, store)
+
+    # Override the upstream render rescale (0.0,0.1) before the viz links/thumbnail are derived from it.
+    apply_s1_rtc_rescale(item)
 
     # build_s1_rtc_stac_item returns s3:// hrefs; TiTiler needs https:// via the gateway
     for asset in item.assets.values():

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -210,3 +210,52 @@ def test_apply_s1_rtc_rescale_noop_without_render():
     )  # fmt: skip
     m.apply_s1_rtc_rescale(item)
     assert "renders" not in item.properties
+
+
+# --- alignment with cube item: alternate/storage + store/via links -----------
+
+
+def _base_item_with_alternate() -> dict:
+    """base_item as main() hands it to per_acquisition_items: the build item + the cube augmentation
+    (alternate-assets/storage blocks on the data assets + a `store` link)."""
+    d = _base_item()
+    d["stac_extensions"] = [
+        "https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/storage/v2.0.0/schema.json",
+    ]
+    for key in ("vv", "vh", "zarr-store"):
+        suffix = "" if key == "zarr-store" else "/ascending"  # preferred orbit, as build emits
+        d["assets"][key]["alternate"] = {
+            "s3": {
+                "href": f"s3://bkt/x/s1-rtc-31TCH.zarr{suffix}",
+                "storage:scheme": {"tier": "STANDARD", "region": "de", "platform": "OVHcloud"},
+            }
+        }
+    d["links"] = [
+        {
+            "rel": "store",
+            "type": "application/vnd.zarr+zarr",
+            "href": "https://gw/x/s1-rtc-31TCH.zarr",
+        }
+    ]
+    return d
+
+
+def test_aligned_items_carry_alternate_storage_and_store_via_links():
+    """Per-acq items inherit the cube's alternate-assets/storage blocks + `store` link and gain a `via`
+    link. For a descending run, the s3 alternate href is reoriented to the run orbit (zarr-store stays
+    at the store root)."""
+    items = _mod().per_acquisition_items(
+        _base_item_with_alternate(), [_T_EARLY], tile_id="31TCH", orbit="descending",
+        collection=ACQ, cube_collection=CUBE, raster_api=RASTER,
+    )  # fmt: skip
+    item = items[0]
+    rels = {link["rel"] for link in item["links"]}
+    assert {"store", "tilejson", "xyz", "via"} <= rels
+    via = next(link for link in item["links"] if link["rel"] == "via")
+    assert via["href"].endswith(f"/collections/{ACQ}/items/{item['id']}")
+    for pol in ("vv", "vh"):
+        assert item["assets"][pol]["alternate"]["s3"]["href"].endswith(".zarr/descending")
+        assert item["assets"][pol]["alternate"]["s3"]["storage:scheme"]["platform"] == "OVHcloud"
+    assert item["assets"]["zarr-store"]["alternate"]["s3"]["href"].endswith(".zarr")
+    assert "ascending" not in json.dumps(item)  # fully reoriented (primary + alternate)

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -176,3 +176,37 @@ def test_does_not_mutate_base():
     assert "start_datetime" in base["properties"]
     assert base["properties"]["sat:orbit_state"] == "ascending"  # not reoriented in place
     assert "thumbnail" not in base["assets"]
+
+
+# --- rescale override (S1_RTC_RESCALE) ---------------------------------------
+
+
+def test_apply_s1_rtc_rescale_overrides_build_default():
+    """apply_s1_rtc_rescale replaces build's 0.0,0.1 with S1_RTC_RESCALE (0.0,0.2) on the rgb render."""
+    from pystac import Item
+
+    m = _mod()
+    render = _base_item()["properties"]["renders"][
+        "rgb"
+    ]  # the build-default render (rescale 0.0,0.1)
+    item = Item(
+        id="s1-rtc-31TCH", geometry=None, bbox=None,
+        datetime=dt.datetime(2026, 6, 7, tzinfo=dt.UTC), properties={"renders": {"rgb": render}},
+    )  # fmt: skip
+    assert item.properties["renders"]["rgb"]["rescale"] == [[0.0, 0.1]]
+    m.apply_s1_rtc_rescale(item)
+    assert item.properties["renders"]["rgb"]["rescale"] == [[0.0, 0.2]]
+    assert m.S1_RTC_RESCALE == [[0.0, 0.2]]
+
+
+def test_apply_s1_rtc_rescale_noop_without_render():
+    """No rgb render (e.g. a non-S1 item) → apply is a safe no-op, not an error."""
+    from pystac import Item
+
+    m = _mod()
+    item = Item(
+        id="x", geometry=None, bbox=None,
+        datetime=dt.datetime(2026, 6, 7, tzinfo=dt.UTC), properties={},
+    )  # fmt: skip
+    m.apply_s1_rtc_rescale(item)
+    assert "renders" not in item.properties

--- a/tests/unit/test_register_v1_s1_rtc.py
+++ b/tests/unit/test_register_v1_s1_rtc.py
@@ -107,6 +107,40 @@ def test_upserts_item_with_correct_id() -> None:
     assert called_item.id == "s1-rtc-31TCH"
 
 
+def test_register_overrides_rescale_to_0_2() -> None:
+    """register() applies apply_s1_rtc_rescale: the upserted cube item renders at 0.0,0.2 (not build's
+    0.0,0.1), and the derived xyz/tilejson links inherit it."""
+    item = _make_item()
+    item.properties["renders"] = {
+        "rgb": {
+            "expression": "/ascending:vv;/ascending:vh;(/ascending:vv)/(/ascending:vh)",
+            "rescale": [[0.0, 0.1]],
+            "bidx": [1],
+        }
+    }
+    item.stac_extensions.append("https://stac-extensions.github.io/render/v1.0.0/schema.json")
+    with (
+        patch(f"{_MOD}.build_s1_rtc_stac_item", return_value=item),
+        patch(f"{_MOD}.warm_thumbnail_cache"),
+        patch(f"{_MOD}.slice_coverages", return_value=[]),
+        patch(f"{_MOD}.upsert_item") as mock_upsert,
+        patch(f"{_MOD}.Client"),
+    ):
+        result = register(
+            _STORE,
+            _COLLECTION,
+            "https://stac.example.com",
+            "https://raster.example.com",
+            "https://s3.example.com",
+        )
+
+    assert result == 0
+    called_item = mock_upsert.call_args[0][2]
+    assert called_item.properties["renders"]["rgb"]["rescale"] == [[0.0, 0.2]]
+    hrefs = " ".join(link.href for link in called_item.links if link.rel in ("xyz", "tilejson"))
+    assert "rescale=0.0%2C0.2" in hrefs and "rescale=0.0%2C0.1" not in hrefs
+
+
 def test_visualization_links_called() -> None:
     """add_visualization_links must be called once with correct raster URL and collection."""
     with (


### PR DESCRIPTION
## What & why

Two related S1 RTC rendering fixes.

### 1. Render rescale 0.0,0.1 → 0.0,0.2
The RGB composite (VV, VH, VV/VH) shipped too bright at `rescale=0.0,0.1`. This sets it to `0.0,0.2` at item-build time in the two S1-only registration paths — `register_v1_s1_rtc.py` (cube item) and `register_per_acquisition.py` (per-acquisition items) — **before** any render links/thumbnails are derived, so the single render dict propagates the value to `tilejson`/`xyz`/`thumbnail`.

Done **in-pipeline** rather than upstream: the value originates in `eopf_geozarr.build_s1_rtc_stac_item` (data-model, pinned `16c5f14`), but data-model `main` was refactored to a `src/` layout and that module moved, so a pin bump is a large migration. Revisit when the pin is migrated.

> The 72 existing staging items were already patched live to `0.0,0.2`; this prevents re-ingests from regressing them.

### 2. Align per-acquisition items with cube items
Per-acq items were built straight from `build_s1_rtc_stac_item` and missed the augmentation the cube item gets in `register_v1_s1_rtc`. Mirror it on the base item before cloning so every per-acq item now carries:
- `alternate-assets/v1.2.0` + `storage/v2.0.0` extensions and `alternate.s3` blocks on `vv`/`vh`/`zarr-store` (rewrite `s3://`→https first, since the alternate is derived from the https href; new `--s3-endpoint`, default OVH `de`),
- a `store` link and a per-item Explorer `via` link.

`_reorient_item_to_orbit` now also moves the s3 alternate href onto the run orbit (guarded; no-op on the cube path, which reorients before alternates exist).

**No `viewer` link** is added to per-acq items: the TiTiler viewer ignores URL query params and has no time selector, and the per-acq id has no reconstructable store, so a scene-specific viewer deep-link isn't possible today. Tracked upstream: EOPF-Explorer/titiler-eopf#120. The render links (`tilejson`/`xyz`/`thumbnail`) remain slice-correct via `sel=time`.

## Tests
`uv run pytest tests/unit` green (485 passed). New: rescale override (cube + per-acq + no-op guard), alternate/storage + `store`/`via` link alignment, reoriented alternate href.

## Follow-ups (not in this PR)
- **Backfill**: re-register the 59 staging per-acq items (`--reregister-all`) after this lands + image redeploy, to add the new metadata/links (and clear a stale `sel=time=1` thumbnail).
- **Viewer deep-link**: add a per-acq `viewer` link once titiler-eopf#120 lands.
- **Security (FYI)**: the production STAC transactions API accepts unauthenticated writes from the public internet — worth a separate hardening ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
