### PR TITLE
fix(s1-rtc): ingest exits 2 (skip register) for a fresh tile with no valid acquisitions

### DIFF
--- a/scripts/ingest_v1_s1_rtc.py
+++ b/scripts/ingest_v1_s1_rtc.py
@@ -3,7 +3,8 @@
 Exit codes:
     0 -- success (all acquisitions ingested)
     1 -- error during ingest (first failure aborts)
-    2 -- no acquisitions found (empty prefix)
+    2 -- nothing to register: empty prefix, OR a fresh tile whose only new scenes are all-nodata
+         (no store built) — the workflow skips register on 2 (so an uncovered edge tile is a clean skip)
 """
 
 from __future__ import annotations
@@ -180,8 +181,17 @@ def ingest_all(s3_geotiff_prefix: str, store_path: str, orbit_direction: str) ->
         log.info("Skipping %d new acquisition(s) with no valid data (all-nodata)", empty)
     acquisitions_to_ingest = with_data
     if not acquisitions_to_ingest:
-        log.info("No new acquisition(s) with valid data; nothing to ingest")
-        return 0
+        # A fresh tile (no existing cube) whose only new scenes are all-nodata builds no store, so there
+        # is nothing to register: return 2 (same as the empty-prefix case) so the workflow skips register
+        # instead of failing it ("No acquisitions found" — the 30TWQ edge-tile failure). If the cube
+        # already has slices, return 0 so register re-registers the existing cube (idempotent).
+        if present:
+            log.info(
+                "No new acquisition(s) with valid data; cube already has %d slice(s)", len(present)
+            )
+            return 0
+        log.info("No new acquisition(s) with valid data and no existing cube; nothing to register")
+        return 2
 
     # Step 2 -- ingest each new acquisition (abort on first error)
     for acq in acquisitions_to_ingest:

--- a/tests/unit/test_ingest_v1_s1_rtc.py
+++ b/tests/unit/test_ingest_v1_s1_rtc.py
@@ -200,18 +200,39 @@ def test_ingest_all_skips_empty_acquisition() -> None:
     assert mock_ing.call_args.kwargs["vv_path"] == acq_data["vv"]
 
 
-def test_ingest_all_all_empty_creates_no_store() -> None:
-    """If every new acquisition is empty, nothing is ingested and no store is built (exit 0)."""
+def test_ingest_all_all_empty_fresh_tile_returns_2_skips_register() -> None:
+    """A fresh tile (no existing cube) whose only new scenes are all-nodata builds no store and must
+    return 2 (no acquisitions) so the workflow skips register — returning 0 would run register against
+    a never-built store (the 30TWQ edge-tile failure: 'No acquisitions found' / 'Orbit group not found')."""
     with (
         patch(f"{_MOD}.discover_s1tiling_acquisitions", return_value=[_ACQ]),
         patch(f"{_MOD}._acquisition_has_data", return_value=False),
         patch(f"{_MOD}.ingest_s1tiling_acquisition") as mock_ing,
         patch(f"{_MOD}.consolidate_s1_store") as mock_cons,
     ):
+        result = ingest_all(
+            "/input", "/store.zarr", "ascending"
+        )  # no existing store -> present empty
+    assert result == 2
+    mock_ing.assert_not_called()
+    mock_cons.assert_not_called()
+
+
+def test_ingest_all_all_empty_with_existing_cube_returns_0() -> None:
+    """All-nodata new scenes but the cube already has slices -> return 0 (re-register the existing cube,
+    idempotent). Only a *fresh* tile with nothing to register returns 2."""
+    with (
+        patch(f"{_MOD}.discover_s1tiling_acquisitions", return_value=[_ACQ]),
+        patch(
+            f"{_MOD}.store_times_ns", return_value={123}
+        ),  # existing cube already has a time slice
+        patch(f"{_MOD}._acquisition_has_data", return_value=False),
+        patch(f"{_MOD}.ingest_s1tiling_acquisition") as mock_ing,
+        patch(f"{_MOD}.consolidate_s1_store"),
+    ):
         result = ingest_all("/input", "/store.zarr", "ascending")
     assert result == 0
     mock_ing.assert_not_called()
-    mock_cons.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The first live cron run failed on **`30TWQ`** (a new northern-edge tile in the extended France-coast AOI): `ingest(0)` succeeded but built **no store**, yet the workflow ran register against it → `No acquisitions found in Zarr store` / `Orbit group 'ascending' not found`. One uncovered edge tile fails the whole cron run.

## Root cause
`ingest_all` (`scripts/ingest_v1_s1_rtc.py`) returned **0** when, after dropping all-nodata scenes, nothing valid remained — **even on a fresh tile with no existing cube**. Exit 0 → template sets `ingested=true` → register runs against a never-built store. (The empty-*prefix* case already returns 2 and is skipped correctly; the all-empty-*data* fresh-tile case was the gap.)

## Fix
Return **2** (nothing to register) when a **fresh** tile (no existing cube) yields no valid acquisitions — reusing the existing exit-2 path the ingest template already treats as a clean skip (no register, **not** retried). If the cube already has slices, keep returning **0** (re-register existing, idempotent). One-function change; **no template/infra change**.

## TDD
The prior test `test_ingest_all_all_empty_creates_no_store` codified the buggy `return 0`; flipped it to expect **2** (fresh tile) and added `…_with_existing_cube_returns_0`. Confirmed RED on old code, GREEN after; full `tests/unit` suite passes (486).

## Effect
An uncovered edge tile becomes a clean per-tile skip (no STAC item, no failure) instead of failing the cron run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)