### PR TITLE
fix(s1-ingest): self-heal missing per-level `time` + fetch-minimal append download

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.2",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@817e2b921bd63a33570fba4bd587242842a8fb7d",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@2677c2409ea0a3dbfbb64f406014b769427a891d",
     "mgrs==1.5.4",
     "requests==2.34.2",
 ]

--- a/scripts/ingest_v1_s1_rtc.py
+++ b/scripts/ingest_v1_s1_rtc.py
@@ -332,6 +332,80 @@ def _drop_consolidated_metadata(local_store: str) -> None:
         )
 
 
+def _level_time_axis_len(level: Any) -> int | None:
+    """Length of a multiscale level's time axis, read from its first ``time``-dimensioned data array
+    (``vv``/``vh``/``border_mask``); ``None`` if the group has no such array (e.g. the ``conditions``
+    group, whose arrays are ``(y, x)`` only)."""
+    for _name, arr in level.arrays():
+        dims = arr.metadata.dimension_names or ()
+        if dims and dims[0] == "time":
+            return int(arr.shape[0])
+    return None
+
+
+def _ensure_level_time_coords(local_store: str, orbit_direction: str) -> None:
+    """Backfill a missing per-level ``time`` coordinate before append (self-heal -> convergence).
+
+    eopf_geozarr's append resizes ``level["time"]`` on **every** multiscale level, assuming a fresh
+    build created ``time`` at each level (data-model #192). A cube built before #192 -- or left
+    half-built by an interrupted append -- can carry ``r10m/time`` yet lack it at ``r20m``/``r60m``;
+    the resize then raises ``KeyError: 'time'``. Because the dedup only reads ``r10m/time``
+    (``store_times_ns``), the crash recurs on every re-run (non-convergent). For each multiscale level
+    missing ``time``, recreate it from ``r10m/time`` -- copying its values, dtype, ``dimension_names``
+    and attrs (already the CF time attrs) -- so the backfilled coordinate is byte-identical to a fresh
+    build without hardcoding the attr dict. No-op when every level already has ``time``.
+
+    Refuses to mask a deeper corruption rather than write a wrong-length coordinate: raises if
+    ``r10m`` holds slices but no ``time`` (no backfill source) or a level's time-axis length disagrees
+    with ``r10m/time`` (a half-built cube a wipe must repair, plan T4).
+    """
+    if not Path(local_store).exists():
+        return
+    root = zarr.open_group(local_store, mode="r+", zarr_format=3)
+    if orbit_direction not in root:
+        return
+    orbit: Any = root[orbit_direction]
+    levels = dict(orbit.groups())
+    r10m = levels.get("r10m")
+    if r10m is None:
+        return
+    if "time" not in list(r10m.array_keys()):
+        r10m_len = _level_time_axis_len(r10m)
+        if r10m_len:
+            raise ValueError(
+                f"Cannot self-heal {orbit_direction}: r10m has {r10m_len} slice(s) but no `time` "
+                "coordinate (no backfill source -- wipe + reingest)"
+            )
+        return  # nothing ingested yet -> the writer creates r10m/time on the first append
+    src = r10m["time"]
+    values = np.asarray(src[...])
+    healed: list[str] = []
+    for name, level in levels.items():
+        if name == "r10m" or "time" in list(level.array_keys()):
+            continue
+        data_len = _level_time_axis_len(level)
+        if data_len is None:
+            continue  # not a multiscale level (e.g. the `conditions` group) -- no `time` belongs here
+        if data_len != int(values.shape[0]):
+            raise ValueError(
+                f"Cannot self-heal {orbit_direction}/{name}/time: data length {data_len} != "
+                f"r10m/time length {int(values.shape[0])} (half-built cube -- wipe + reingest)"
+            )
+        arr = level.create_array(
+            "time",
+            shape=values.shape,
+            dtype=src.dtype,
+            chunks=src.chunks,
+            fill_value=0,
+            dimension_names=list(src.metadata.dimension_names or ["time"]),
+        )
+        arr[...] = values
+        arr.attrs.update(dict(src.attrs))
+        healed.append(f"{orbit_direction}/{name}")
+    if healed:
+        log.info("Backfilled missing per-level `time` from r10m/time: %s", healed)
+
+
 def _sync_tree(fs: Any, local_store: str, dest: str) -> None:
     """Upload only new/changed objects under ``local_store`` to ``dest``; delete vanished keys.
 
@@ -415,6 +489,7 @@ def run_ingest(s3_geotiff_prefix: str, store: str, orbit_direction: str) -> int:
     try:
         _fetch_store_from_s3(store, local_store)  # append to the existing per-tile cube (T4)
         _drop_consolidated_metadata(local_store)  # so eopf_geozarr can resize `time` on append
+        _ensure_level_time_coords(local_store, orbit_direction)  # heal a level missing `time` (T2)
         rc = ingest_all(s3_geotiff_prefix, local_store, orbit_direction)
         if rc != 0:
             return rc

--- a/scripts/ingest_v1_s1_rtc.py
+++ b/scripts/ingest_v1_s1_rtc.py
@@ -273,14 +273,11 @@ def _put_files(fs: Any, pairs: list[tuple[str, str]]) -> None:
     fs.put(lpaths, rpaths, batch_size=_S3_CONCURRENCY)
 
 
-def _get_tree(fs: Any, src: str, local_store: str) -> None:
-    """Download every object under ``src`` to ``local_store/<relpath>`` concurrently.
-
-    Builds the key→lpath mapping, pre-creates the local parent dirs (the batched list form
-    does not), then issues a single ``fs.get`` so the existing cube is fetched concurrently
-    up to ``_S3_CONCURRENCY``. The download mirror of the ``_put_files`` upload primitive.
+def _get_keys(fs: Any, src: str, keys: list[str], local_store: str) -> None:
+    """Download the given remote ``keys`` (all under ``src``) to ``local_store/<relpath>`` in one
+    batched ``fs.get`` (concurrent up to ``_S3_CONCURRENCY``), pre-creating the local parent dirs the
+    batched list form does not. The download mirror of the ``_put_files`` upload primitive.
     """
-    keys = fs.find(src)
     if not keys:
         return
     lpaths = [
@@ -289,6 +286,65 @@ def _get_tree(fs: Any, src: str, local_store: str) -> None:
     for parent in {os.path.dirname(p) for p in lpaths}:
         os.makedirs(parent, exist_ok=True)
     fs.get(keys, lpaths, batch_size=_S3_CONCURRENCY)
+
+
+def _coordinate_array_dirs(local_store: str) -> set[str]:
+    """Store-relative dirs (posix) of every Zarr array with ``ndim <= 1`` -- the coordinate/aux
+    arrays (``time``/``x``/``y``/``absolute_orbit``/``relative_orbit``/``platform``; ``spatial_ref``
+    is 0-D). Read from the local ``zarr.json`` metadata, so it costs no network round-trips.
+
+    The bulk ``ndim >= 2`` data arrays (``vv``/``vh``/``border_mask``/``gamma_area_*``/``lia_*``) are
+    excluded. Used to (a) fetch only coordinate chunks on append and (b) scope the upload deletion so
+    a deliberately-skipped bulk chunk is never removed. Classifying by **dimensionality** (not an
+    array-name denylist) is self-maintaining and robust to sharding -- the on-disk key layout differs
+    between chunked and sharded arrays, but the logical ``shape`` does not.
+    """
+    base = Path(local_store)
+    dirs: set[str] = set()
+    for zj in base.rglob("zarr.json"):
+        meta = json.loads(zj.read_text())
+        if meta.get("node_type") == "array" and len(meta.get("shape", [])) <= 1:
+            dirs.add(zj.parent.relative_to(base).as_posix())
+    return dirs
+
+
+def _is_coordinate_key(rel: str, coord_dirs: set[str]) -> bool:
+    """True if a store-relative object path lives under a coordinate/aux (``ndim <= 1``) array dir."""
+    return any(rel == d or rel.startswith(f"{d}/") for d in coord_dirs)
+
+
+def _fetch_for_append(fs: Any, src: str, local_store: str) -> None:
+    """Fetch only what an append reads/writes: every ``zarr.json`` + the small coordinate arrays.
+
+    The append reads zarr metadata + ``r10m["vv"].shape`` and the 1-D coordinate arrays, then writes
+    a NEW time slice; it never reads the existing bulk ``vv``/``vh``/``border_mask``/``gamma_area_*``/
+    ``lia_*`` chunks (the overwhelming majority of the objects). Skipping them turns the per-append
+    fetch from O(cube) into O(metadata + coords) -- the fix for the 42-179 min outliers on large
+    cubes (the fetch is the only append phase that grows with accumulated cube size; #287 already
+    made the upload incremental).
+
+    SAFE because the bulk arrays shard with **time-extent 1** (data-model ``s1_ingest.py`` builds them
+    ``shards=(1, level_h, level_w)``): a new time index writes entirely new shard objects, never
+    read-modify-writing a skipped one; the condition arrays are single-shard and overwritten whole. If
+    that upstream sharding ever spans multiple time indices, this minimal fetch must be reverted (it
+    would corrupt via RMW of an absent shard). Two batched ``fs.get`` calls -- no per-object
+    round-trips; the single ``fs.find`` listing stays O(object count) but is a cheap LIST.
+    """
+    keys = fs.find(src)
+    if not keys:
+        return
+    meta_keys = [k for k in keys if k.rsplit("/", 1)[-1] == "zarr.json"]
+    _get_keys(fs, src, meta_keys, local_store)  # phase 1: all metadata
+    coord_dirs = _coordinate_array_dirs(
+        local_store
+    )  # classify from the local metadata (no network)
+    meta_set = set(meta_keys)
+    coord_chunks = [
+        k
+        for k in keys
+        if k not in meta_set and _is_coordinate_key(k[len(src) :].lstrip("/"), coord_dirs)
+    ]
+    _get_keys(fs, src, coord_chunks, local_store)  # phase 2: coordinate chunks only
 
 
 def _fetch_store_from_s3(s3_uri: str, local_store: str) -> None:
@@ -305,8 +361,10 @@ def _fetch_store_from_s3(s3_uri: str, local_store: str) -> None:
     src = s3_uri[len("s3://") :].rstrip("/")
     if not fs.exists(src):
         return
-    log.info("Fetching existing cube %s -> %s (append mode)", s3_uri, local_store)
-    _get_tree(fs, src, local_store)
+    log.info(
+        "Fetching existing cube %s -> %s (append mode: metadata + coords only)", s3_uri, local_store
+    )
+    _fetch_for_append(fs, src, local_store)
 
 
 def _drop_consolidated_metadata(local_store: str) -> None:
@@ -419,7 +477,11 @@ def _sync_tree(fs: Any, local_store: str, dest: str) -> None:
       **size differs** (changed). A content-changed blosc-compressed shard almost always
       changes compressed size. NOT ETag/MD5 — s3fs uploads shards multipart, whose ETag is
       ``<md5>-<nparts>``, not the object MD5, so an MD5 compare is both wrong and pointless.
-    - deletions: drop S3 keys no longer present locally (rare — e.g. a re-chunk).
+    - deletions: drop only vanished **coordinate/metadata** keys. The append fetch
+      (``_fetch_for_append``) deliberately skips the bulk >=2-D data chunks, so they are absent
+      locally but MUST NOT be deleted from S3 -- a whole-cube ``set(remote) - local`` would wipe
+      them. Scope the deletion to the coordinate/aux arrays + ``zarr.json`` (``_coordinate_array_dirs``);
+      after a correct append every such key is present locally, so this is a no-op in the normal case.
 
     Both the presence and size checks come from the single ``fs.find`` listing — no extra
     round-trips. Keeps per-append upload flat as the cube grows.
@@ -442,7 +504,15 @@ def _sync_tree(fs: Any, local_store: str, dest: str) -> None:
             ):
                 pairs.append((lpath, rpath))
     _put_files(fs, pairs)
-    stale = sorted(set(remote_size) - local_keys)
+    # Scope deletion to coordinate/metadata keys (C1): the append fetch skips the bulk >=2-D chunks,
+    # so they are absent locally but must not be removed from S3.
+    coord_dirs = _coordinate_array_dirs(local_store)
+    stale = sorted(
+        k
+        for k in set(remote_size) - local_keys
+        if k.rsplit("/", 1)[-1] == "zarr.json"
+        or _is_coordinate_key(k[len(dest) :].lstrip("/"), coord_dirs)
+    )
     if stale:
         fs.rm(stale)
     # A mid-append failure can leave the cube between states; the per-tile Argo mutex serialises

--- a/tests/unit/test_ingest_v1_s1_rtc.py
+++ b/tests/unit/test_ingest_v1_s1_rtc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import call, patch
@@ -13,7 +14,9 @@ sys.path.insert(0, str(scripts_dir))
 
 from ingest_v1_s1_rtc import (  # noqa: E402
     _S3_CONCURRENCY,
-    _get_tree,
+    _coordinate_array_dirs,
+    _fetch_for_append,
+    _get_keys,
     _patch_cf_grid_mapping,
     _sync_tree,
     acq_time_ns,
@@ -673,21 +676,20 @@ def test_discover_resolves_masked_multiframe_stamp(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# T1/T2 -- concurrent transfer: the upload (via _put_files) and _get_tree issue
+# T1/T2 -- concurrent transfer: the upload (via _put_files) and the download (via _get_keys) issue
 # ONE batched call, not a per-file put_file/get_file loop (capped at _S3_CONCURRENCY).
 # (the upload side is asserted on _sync_tree below, the sole upload path.)
 # ---------------------------------------------------------------------------
 
 
-def test_get_tree_issues_single_concurrent_batch(tmp_path) -> None:
-    """_get_tree fetches the existing cube via one batched fs.get, pre-creating local parents."""
+def test_get_keys_issues_single_concurrent_batch(tmp_path) -> None:
+    """_get_keys fetches the given keys via one batched fs.get, pre-creating local parents."""
     from unittest.mock import MagicMock
 
     fs = MagicMock()
-    fs.find.return_value = ["bucket/src/zarr.json", "bucket/src/g/0.0"]
     local = tmp_path / "local"
 
-    _get_tree(fs, "bucket/src", str(local))
+    _get_keys(fs, "bucket/src", ["bucket/src/zarr.json", "bucket/src/g/0.0"], str(local))
 
     fs.get_file.assert_not_called()
     assert fs.get.call_count == 1
@@ -697,14 +699,129 @@ def test_get_tree_issues_single_concurrent_batch(tmp_path) -> None:
     assert (local / "g").is_dir()  # local parent created before the batched get
 
 
-def test_get_tree_empty_src_is_noop(tmp_path) -> None:
-    """An empty source (no keys) issues no transfer."""
+def test_get_keys_empty_is_noop(tmp_path) -> None:
+    """An empty key list issues no transfer."""
     from unittest.mock import MagicMock
 
     fs = MagicMock()
-    fs.find.return_value = []
-    _get_tree(fs, "bucket/empty", str(tmp_path / "local"))
+    _get_keys(fs, "bucket/empty", [], str(tmp_path / "local"))
     fs.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# T3 -- fetch-minimal append download: pull every zarr.json + the small (<=1-D) coordinate arrays,
+# but SKIP the bulk (>=2-D) vv/vh/border_mask/gamma_area_*/lia_* chunks the append never reads.
+# Classify by dimensionality (not a name denylist), so `lia_*` and future arrays are covered.
+# ---------------------------------------------------------------------------
+
+
+def _build_remote_cube_with_chunks(path: str) -> None:
+    """A realistic on-disk cube: r10m with a 1-D `time` coord + a 3-D `vv` data array, plus a
+    `conditions/gamma_area_008` 2-D array — so the fetch filter has real chunk objects to classify."""
+    import numpy as np
+
+    root = zarr.open_group(path, mode="w-", zarr_format=3)
+    og = root.create_group("ascending")
+    r10 = og.create_group("r10m")
+    r10.create_array("time", shape=(2,), dtype="int64", chunks=(512,), dimension_names=("time",))[
+        ...
+    ] = [10, 20]
+    r10.create_array(
+        "vv", shape=(2, 4, 4), dtype="float32", chunks=(1, 4, 4), dimension_names=("time", "y", "x")
+    )[...] = np.ones((2, 4, 4), dtype="float32")
+    cg = og.create_group("conditions")
+    cg.create_array(
+        "gamma_area_008", shape=(4, 4), dtype="float32", chunks=(4, 4), dimension_names=("y", "x")
+    )[...] = np.ones((4, 4), dtype="float32")
+
+
+def _relpaths(base: str) -> set[str]:
+    """All file paths under ``base``, store-relative posix."""
+    out: set[str] = set()
+    for root, _dirs, files in os.walk(base):
+        for n in files:
+            out.add(os.path.relpath(os.path.join(root, n), base).replace(os.sep, "/"))
+    return out
+
+
+def test_coordinate_array_dirs_classifies_by_dimensionality(tmp_path) -> None:
+    """time (1-D) is a coordinate dir; vv (3-D) and gamma_area_008 (2-D) are not."""
+    store = str(tmp_path / "cube.zarr")
+    _build_remote_cube_with_chunks(store)
+    coord_dirs = _coordinate_array_dirs(store)
+    assert "ascending/r10m/time" in coord_dirs
+    assert "ascending/r10m/vv" not in coord_dirs
+    assert "ascending/conditions/gamma_area_008" not in coord_dirs
+
+
+def test_fetch_for_append_keeps_metadata_and_coords_skips_bulk(tmp_path) -> None:
+    """The append fetch downloads every zarr.json + the coordinate (time) chunks, but NONE of the
+    bulk vv / gamma_area chunks — turning O(cube) into O(metadata + coords)."""
+    import fsspec
+
+    fs = fsspec.filesystem("file")
+    remote = str(tmp_path / "remote.zarr")
+    _build_remote_cube_with_chunks(remote)
+    local = str(tmp_path / "local.zarr")
+
+    _fetch_for_append(fs, remote, local)
+
+    fetched = _relpaths(local)
+    # every zarr.json present (metadata is needed to open + resize on append)
+    assert "zarr.json" in fetched
+    assert "ascending/r10m/vv/zarr.json" in fetched
+    assert "ascending/conditions/gamma_area_008/zarr.json" in fetched
+    # the coordinate chunks are present...
+    assert any(
+        f.startswith("ascending/r10m/time/") and not f.endswith("zarr.json") for f in fetched
+    )
+    # ...but the bulk data chunks are NOT fetched (the regression guard: a revert to a full fetch
+    # would pull these and fail this test)
+    assert not any(
+        f.startswith("ascending/r10m/vv/") and not f.endswith("zarr.json") for f in fetched
+    )
+    assert not any(
+        f.startswith("ascending/conditions/gamma_area_008/") and not f.endswith("zarr.json")
+        for f in fetched
+    )
+
+
+def test_fetch_for_append_then_sync_preserves_remote_bulk_chunks(tmp_path) -> None:
+    """C1 regression (data loss): after a minimal fetch the local store lacks the existing bulk
+    chunks, so a whole-cube `set(remote) - local` deletion would WIPE them. The scoped `_sync_tree`
+    must leave them on S3 while still uploading the new slice's chunks and refreshed metadata."""
+    import fsspec
+
+    fs = fsspec.filesystem("file")
+    remote = str(tmp_path / "remote.zarr")
+    _build_remote_cube_with_chunks(remote)
+    bulk_before = {
+        k
+        for k in _relpaths(remote)
+        if not k.endswith("zarr.json")
+        and (k.startswith("ascending/r10m/vv/") or k.startswith("ascending/conditions/"))
+    }
+    assert bulk_before  # sanity: there ARE bulk chunks on the "remote"
+
+    local = str(tmp_path / "local.zarr")
+    _fetch_for_append(fs, remote, local)
+    # the minimal fetch did not pull the bulk chunks
+    assert not {k for k in _relpaths(local) if k in bulk_before}
+
+    # simulate the append: write the new slice's bulk chunk + refresh vv metadata with the grown
+    # (still 3-D) shape — vv must stay classified as bulk so the scoped deletion leaves its old chunks
+    new_chunk = Path(local) / "ascending" / "r10m" / "vv" / "c" / "2" / "0" / "0"
+    new_chunk.parent.mkdir(parents=True, exist_ok=True)
+    new_chunk.write_bytes(b"new-slice-shard")
+    (Path(local) / "ascending" / "r10m" / "vv" / "zarr.json").write_text(
+        '{"node_type":"array","shape":[3,4,4]}'
+    )
+
+    _sync_tree(fs, local, remote)
+
+    after = _relpaths(remote)
+    assert bulk_before <= after  # existing bulk chunks NOT deleted (the C1 fix)
+    assert "ascending/r10m/vv/c/2/0/0" in after  # the new slice's chunk WAS uploaded
 
 
 # ---------------------------------------------------------------------------
@@ -714,14 +831,15 @@ def test_get_tree_empty_src_is_noop(tmp_path) -> None:
 
 
 def test_sync_tree_uploads_only_new_changed_and_metadata(tmp_path) -> None:
-    """Append uploads only new + size-changed chunks, every zarr.json, and deletes vanished keys —
-    no rm(recursive) of the live cube."""
+    """Append uploads only new + size-changed chunks, every zarr.json, and deletes a vanished
+    coordinate key — no rm(recursive) of the live cube. `g` is a 1-D coordinate array (its chunks
+    are deletable under the scoped deletion); a separate test covers bulk-chunk preservation."""
     from unittest.mock import MagicMock
 
     store = tmp_path / "cube.zarr"
     (store / "g").mkdir(parents=True)
-    (store / "zarr.json").write_text('{"meta":1}')  # metadata -> always re-upload
-    (store / "g" / "zarr.json").write_text('{"m":2}')  # metadata -> always re-upload
+    (store / "zarr.json").write_text('{"node_type":"group"}')  # metadata -> always re-upload
+    (store / "g" / "zarr.json").write_text('{"node_type":"array","shape":[2]}')  # 1-D coord array
     (store / "g" / "new.0").write_text("brand new shard")  # absent remotely -> upload
     (store / "g" / "same.0").write_text("unchanged")  # same size remote -> skip
     (store / "g" / "changed.0").write_text("now much bigger")  # size differs -> upload
@@ -733,7 +851,7 @@ def test_sync_tree_uploads_only_new_changed_and_metadata(tmp_path) -> None:
         "bucket/c/g/zarr.json": {"size": 99},
         "bucket/c/g/same.0": {"size": len("unchanged")},
         "bucket/c/g/changed.0": {"size": 3},  # local is larger -> changed
-        "bucket/c/g/gone.0": {"size": 5},  # not local -> delete
+        "bucket/c/g/gone.0": {"size": 5},  # not local, a coord chunk -> delete
     }
 
     _sync_tree(fs, str(store), "bucket/c")
@@ -750,7 +868,7 @@ def test_sync_tree_uploads_only_new_changed_and_metadata(tmp_path) -> None:
         "bucket/c/g/changed.0",  # new + size-changed
     }
     assert "bucket/c/g/same.0" not in sent  # unchanged chunk skipped
-    fs.rm.assert_called_once_with(["bucket/c/g/gone.0"])  # vanished key deleted
+    fs.rm.assert_called_once_with(["bucket/c/g/gone.0"])  # vanished coordinate key deleted
     # never an rm(recursive) of the whole cube
     for c in fs.rm.call_args_list:
         assert c.kwargs.get("recursive") is not True
@@ -785,6 +903,7 @@ def test_sync_tree_local_roundtrip_converges(tmp_path) -> None:
     remote = tmp_path / "remote.zarr"
     (store / "g").mkdir(parents=True)
     (store / "zarr.json").write_text('{"v":1}')
+    (store / "g" / "zarr.json").write_text('{"node_type":"array","shape":[3]}')  # 1-D coord array
     (store / "g" / "0.0").write_text("aaa")
     (store / "g" / "1.0").write_text("bbb")
 

--- a/tests/unit/test_ingest_v1_s1_rtc.py
+++ b/tests/unit/test_ingest_v1_s1_rtc.py
@@ -498,6 +498,130 @@ def test_drop_consolidated_metadata_enables_resize(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# T2 -- self-heal: backfill a per-level `time` missing on r20m/r60m before append
+# (an inconsistent/legacy cube where r10m has `time` but a coarser level does not -> the eopf_geozarr
+# per-level resize raises KeyError 'time'; the guard makes the append convergent).
+# ---------------------------------------------------------------------------
+
+_TIME_CF_ATTRS = {
+    "units": "nanoseconds since 1970-01-01",
+    "calendar": "proleptic_gregorian",
+    "standard_name": "time",
+    "_ARRAY_DIMENSIONS": ["time"],
+}
+
+
+def _build_multilevel_cube(
+    store_path: str,
+    times_ns: list[int],
+    *,
+    levels_with_time: tuple[str, ...] = ("r10m",),
+    orbit: str = "ascending",
+    level_lens: dict[str, int] | None = None,
+) -> None:
+    """A cube with r10m/r20m/r60m, each level carrying a (time, y, x) `vv` of length ``level_lens``
+    (default = len(times_ns)), but a CF `time` coordinate only on ``levels_with_time``."""
+    import numpy as np
+
+    root = zarr.open_group(store_path, mode="w-", zarr_format=3)
+    og = root.create_group(orbit)
+    n = len(times_ns)
+    for lvl in ("r10m", "r20m", "r60m"):
+        g = og.create_group(lvl)
+        ln = (level_lens or {}).get(lvl, n)
+        vv = g.create_array(
+            "vv", shape=(ln, 4, 4), dtype="float32", dimension_names=("time", "y", "x")
+        )
+        vv[...] = np.zeros((ln, 4, 4), dtype="float32")
+        if lvl in levels_with_time:
+            t = g.create_array(
+                "time", shape=(n,), dtype="int64", chunks=(512,), dimension_names=("time",)
+            )
+            t[...] = np.asarray(times_ns, dtype="int64")
+            t.attrs.update(_TIME_CF_ATTRS)
+
+
+def test_ensure_level_time_coords_backfills_missing_levels(tmp_path) -> None:
+    """r10m has `time`, r20m/r60m do not -> the guard backfills both with values + dtype + CF attrs
+    identical to r10m/time, and the per-level resize the append does then succeeds."""
+    from ingest_v1_s1_rtc import _ensure_level_time_coords
+
+    t0, t1 = acq_time_ns("20230115t061234"), acq_time_ns("20230127t061230")
+    store = str(tmp_path / "cube.zarr")
+    _build_multilevel_cube(store, [t0, t1], levels_with_time=("r10m",))
+
+    _ensure_level_time_coords(store, "ascending")
+
+    og = zarr.open_group(store, mode="r", zarr_format=3)["ascending"]
+    src = og["r10m"]["time"]
+    for lvl in ("r10m", "r20m", "r60m"):
+        t = og[lvl]["time"]
+        assert list(t[...]) == [t0, t1]
+        assert t.dtype == src.dtype
+        assert list(t.metadata.dimension_names) == ["time"]
+        assert dict(t.attrs) == dict(src.attrs)
+    # the resize that crashed before (KeyError 'time' on r20m) now succeeds
+    r20 = zarr.open_group(store, mode="r+", zarr_format=3)["ascending"]["r20m"]
+    r20["time"].resize((3,))
+    assert r20["time"].shape == (3,)
+
+
+def test_ensure_level_time_coords_noop_when_all_present(tmp_path) -> None:
+    """Every level already has `time` -> idempotent no-op (no raise, values untouched)."""
+    from ingest_v1_s1_rtc import _ensure_level_time_coords
+
+    store = str(tmp_path / "cube.zarr")
+    _build_multilevel_cube(store, [1, 2, 3], levels_with_time=("r10m", "r20m", "r60m"))
+    _ensure_level_time_coords(store, "ascending")
+    og = zarr.open_group(store, mode="r", zarr_format=3)["ascending"]
+    for lvl in ("r10m", "r20m", "r60m"):
+        assert list(og[lvl]["time"][...]) == [1, 2, 3]
+
+
+def test_ensure_level_time_coords_raises_on_length_mismatch(tmp_path) -> None:
+    """A half-built cube (r20m/vv shorter than r10m/time) must fail loudly, not mis-heal with a
+    wrong-length coordinate."""
+    import pytest
+    from ingest_v1_s1_rtc import _ensure_level_time_coords
+
+    store = str(tmp_path / "cube.zarr")
+    _build_multilevel_cube(store, [1, 2], levels_with_time=("r10m",), level_lens={"r20m": 1})
+    with pytest.raises(ValueError, match="half-built"):
+        _ensure_level_time_coords(store, "ascending")
+
+
+def test_ensure_level_time_coords_raises_when_r10m_time_missing(tmp_path) -> None:
+    """r10m holds slices but no `time` -> no backfill source -> raise (wipe required), not a silent
+    invention of a coordinate."""
+    import pytest
+    from ingest_v1_s1_rtc import _ensure_level_time_coords
+
+    store = str(tmp_path / "cube.zarr")
+    _build_multilevel_cube(store, [1, 2], levels_with_time=())  # no level has `time`, incl. r10m
+    with pytest.raises(ValueError, match="backfill source"):
+        _ensure_level_time_coords(store, "ascending")
+
+
+def test_ensure_level_time_coords_skips_conditions_group(tmp_path) -> None:
+    """The `conditions` group (arrays are (y, x) only) is not a multiscale level and must never gain
+    a `time` coordinate."""
+    import numpy as np
+    from ingest_v1_s1_rtc import _ensure_level_time_coords
+
+    store = str(tmp_path / "cube.zarr")
+    _build_multilevel_cube(store, [1, 2], levels_with_time=("r10m", "r20m", "r60m"))
+    cond = zarr.open_group(store, mode="r+", zarr_format=3)["ascending"].create_group("conditions")
+    cond.create_array("gamma_area_008", shape=(4, 4), dtype="float32", dimension_names=("y", "x"))[
+        ...
+    ] = np.ones((4, 4), dtype="float32")
+
+    _ensure_level_time_coords(store, "ascending")
+
+    cond_r = zarr.open_group(store, mode="r", zarr_format=3)["ascending"]["conditions"]
+    assert "time" not in list(cond_r.array_keys())
+
+
+# ---------------------------------------------------------------------------
 # F1 -- multi-frame "daily" products whose time is masked (…txxxxxx…) are resolved upstream
 # (data-model #184); the local _normalize_masked_stamps workaround (#237) has been removed.
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -876,13 +876,13 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.2" },
     { name = "click", specifier = "==8.4.1" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=817e2b921bd63a33570fba4bd587242842a8fb7d" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=2677c2409ea0a3dbfbb64f406014b769427a891d" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mgrs", specifier = "==1.5.4" },
     { name = "morecantile", specifier = "==7.0.3" },
     { name = "pystac", specifier = "==1.14.3" },
     { name = "pystac-client", specifier = "==0.9.0" },
-    { name = "requests", specifier = "==2.34.1" },
+    { name = "requests", specifier = "==2.34.2" },
     { name = "s3fs", specifier = "==2026.4.0" },
     { name = "tenacity", specifier = "==9.1.4" },
     { name = "xarray", specifier = "==2026.4.0" },
@@ -997,7 +997,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.1"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=817e2b921bd63a33570fba4bd587242842a8fb7d#817e2b921bd63a33570fba4bd587242842a8fb7d" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=2677c2409ea0a3dbfbb64f406014b769427a891d#2677c2409ea0a3dbfbb64f406014b769427a891d" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },
@@ -3066,7 +3066,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.34.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -3074,9 +3074,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/36/7180e7f077c38108945dbbdf60fe04db681c3feb6e96419f8c6dc8723741/requests-2.34.1.tar.gz", hash = "sha256:0fc5669f2b69704449fe1552360bd2a73a54512dfd03e65529157f1513322beb", size = 142783, upload-time = "2026-05-13T19:20:24.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/5a/4a949d170476de3c04ac036b5466422fbcbf348a917d8042eedf2cac7d1b/requests-2.34.1-py3-none-any.whl", hash = "sha256:bf38a3ff993960d3dd819c08862c40b3c703306eb7c744fcd9f4ddbb95b548f0", size = 73085, upload-time = "2026-05-13T19:20:22.827Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #186 (PR into \`feat--s1_grd_phase5\`). Fixes the **non-convergent \`KeyError: 'time'\`** append crash on inconsistent S1 RTC cubes (hit on 30TWM during the sha-fbd0f42 France backfill, ~179 min then exit 1) and collapses the **42–179 min append outliers** on large cubes.

## What & why

**1. Self-heal a multiscale level missing `time` (correctness, `30d766a`).**
`eopf_geozarr`'s append resizes `level["time"]` on *every* multiscale level (r10m/r20m/r60m), assuming a fresh build created `time` at each level (data-model #192). A cube built before #192 — or left half-built by an interrupted append — can carry `r10m/time` yet lack it at a coarser level, so the resize raises `KeyError: 'time'`. The dedup (`store_times_ns`) only reads `r10m/time`, so the inconsistency is invisible and the crash recurs every run (non-convergent). `_ensure_level_time_coords` backfills the missing level from `r10m/time` (byte-identical values/dtype/attrs), refuses to mask deeper corruption (raises on length mismatch / missing root `time`), and skips the non-level `conditions` group.

**2. Fetch only metadata + coords on append (performance, `e970649`).**
The per-append fetch downloaded the whole cube even though the append reads only metadata + the 1-D coordinate arrays and writes a new time slice. `_fetch_for_append` now pulls every `zarr.json` + only `ndim ≤ 1` array chunks (classified by **dimensionality**, not a name denylist — which had omitted `lia_*`) — O(metadata+coords) instead of O(cube). The fetch is the only append phase that grows with accumulated cube size (#287 already made the upload incremental).

**3. Coupled data-loss fix.** A minimal fetch leaves the bulk chunks absent locally, so `_sync_tree`'s old `set(remote) − local` deletion would have **wiped every existing vv/vh/gamma_area/lia chunk on the first append**. The deletion is now scoped to coordinate/metadata keys (regression-tested).

## Safety precondition (cross-repo)
Minimal fetch is safe **only because** the bulk arrays shard with time-extent 1 (`data-model s1_ingest.py` `shards=(1, level_h, level_w)`): a new time index writes entirely new shard objects, never RMW-ing a skipped one. If upstream re-shards across time, this minimal fetch must be reverted. Documented in code + the `_fetch_for_append` docstring.

## Tests
38 ingest unit tests (incl. the C1 deletion-scoping regression + the time-heal cases), ruff, ruff-format, mypy all pass.

> NB: the repo's pre-commit `pytest` hook runs the full suite, which has one **pre-existing, unrelated** failure on this base — `tests/test_stac_collections.py::test_s1_rtc_collection_valid` expects the old `vv` asset key (collection moved to `gamma0-rtc-backscatter-*`). Not touched here.

## Follow-up
- Durable upstream fix (T5): make `ingest_s1tiling_acquisition` create-or-resize per-level `time` itself + validate it in the append consistency check — turns this guard into belt-and-suspenders. Separate data-model PR (planned).
- In-cluster verification pending: re-ingest the 30TWM ascending `20260611t180325` acquisition (convergence + no `KeyError`), confirm fetch-phase wall-time drops, byte/asset parity on a control tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)