### PR TITLE
chore(deps): bump data-model to ac3167f (S1 RTC _FillValue + nodata → NaN render fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.2",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@082913a2b0a2168a13db0af03548cb4e7e50d8d1",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@ac3167f95b7f72021aa592fd9096d32f2510f79d",
     "mgrs==1.5.4",
     "requests==2.34.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.2",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@2677c2409ea0a3dbfbb64f406014b769427a891d",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@082913a2b0a2168a13db0af03548cb4e7e50d8d1",
     "mgrs==1.5.4",
     "requests==2.34.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.2" },
     { name = "click", specifier = "==8.4.1" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=082913a2b0a2168a13db0af03548cb4e7e50d8d1" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=ac3167f95b7f72021aa592fd9096d32f2510f79d" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mgrs", specifier = "==1.5.4" },
     { name = "morecantile", specifier = "==7.0.3" },
@@ -997,7 +997,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.1"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=082913a2b0a2168a13db0af03548cb4e7e50d8d1#082913a2b0a2168a13db0af03548cb4e7e50d8d1" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=ac3167f95b7f72021aa592fd9096d32f2510f79d#ac3167f95b7f72021aa592fd9096d32f2510f79d" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.2" },
     { name = "click", specifier = "==8.4.1" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=2677c2409ea0a3dbfbb64f406014b769427a891d" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=082913a2b0a2168a13db0af03548cb4e7e50d8d1" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mgrs", specifier = "==1.5.4" },
     { name = "morecantile", specifier = "==7.0.3" },
@@ -997,7 +997,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.1"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=2677c2409ea0a3dbfbb64f406014b769427a891d#2677c2409ea0a3dbfbb64f406014b769427a891d" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=082913a2b0a2168a13db0af03548cb4e7e50d8d1#082913a2b0a2168a13db0af03548cb4e7e50d8d1" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
Pin `eopf-geozarr` to data-model **ac3167f** (`feat/s1-rtc-stac-builder` head — EOPF-Explorer/data-model#180, with [#201 `_FillValue`](https://github.com/EOPF-Explorer/data-model/pull/201) and [#202 nodata → NaN](https://github.com/EOPF-Explorer/data-model/pull/202) merged).

## Why
This completes the "render S1 RTC nodata transparent like S2" work in two halves, both now on the data-model feature branch:

1. **Metadata half (EOPF-Explorer/data-model#201, pin `082913a`)** — the writer emits CF **`_FillValue`** / `standard_name` / `units` on float bands (`vv`/`vh`) and conditions (`gamma_area`/`lia`) at every level, so xarray can mask NaN nodata (`use_zarr_fill_value_as_mask`, xarray #11345).
2. **Data half (EOPF-Explorer/data-model#202, pin `ac3167f`)** — those attrs were inert because **no NaN was ever written**: s1tiling stores `0.0` out of swath, which titiler treats as valid data → opaque black. EOPF-Explorer/data-model#202 masks `vv`/`vh` by `border_mask` (`0` = no-data) and conditions by the GeoTIFF's declared nodata, storing **`NaN`** there. `np.nanmean` downsampling carries it to every overview.

The prior pin `2677c240` (#200) predates both.

## What
- `pyproject.toml` + `uv.lock`: `2677c240` → `082913a` (EOPF-Explorer/data-model#201) → **`ac3167f`** (EOPF-Explorer/data-model#202) — hand-edited rev, no full relock → lockfile revision stable.

## Verification
- `uv sync --frozen` installs `ac3167f` cleanly; the nodata→NaN masking code path is present in the built package (`np.where(mask_data == 0, np.nan, …)` + conditions `read(1, masked=True).filled(np.nan)`).
- data-pipeline suite green (586 passed, 1 skipped).
- data-model side TDD-proven (NaN ⟺ `border_mask==0` at native + overview; masking round-trips).
- Temporary image tag **`v0.7.2-s1rtc-rc1`** is built from this branch to verify transparency end-to-end in staging (vs the S2 reference) before a durable release. Supersedes `v0.7.1-s1rtc-rc1` (0-nodata cubes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
