### PR TITLE
chore(deps): bump data-model to 02456d5 (consolidate every orbit group)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.2",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@ac3167f95b7f72021aa592fd9096d32f2510f79d",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@02456d5e81a1be946e406395acda58e3dc8e8150",
     "mgrs==1.5.4",
     "requests==2.34.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.2" },
     { name = "click", specifier = "==8.4.1" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=ac3167f95b7f72021aa592fd9096d32f2510f79d" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=02456d5e81a1be946e406395acda58e3dc8e8150" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mgrs", specifier = "==1.5.4" },
     { name = "morecantile", specifier = "==7.0.3" },
@@ -997,7 +997,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.1"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=ac3167f95b7f72021aa592fd9096d32f2510f79d#ac3167f95b7f72021aa592fd9096d32f2510f79d" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=02456d5e81a1be946e406395acda58e3dc8e8150#02456d5e81a1be946e406395acda58e3dc8e8150" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
Pin `eopf-geozarr` `ac3167f` → **`02456d5`** to pick up the consolidation fix ([data-model #203](https://github.com/EOPF-Explorer/data-model/pull/203), merged into #180).

## Why
`consolidate_s1_store` now consolidates **every** orbit group present, not just the last-ingested one. Re-ingested S1 RTC cubes were ending up with only one orbit consolidated on disk (asc✓/desc✗); a client opening the unconsolidated orbit standalone (the STAC `<cube>.zarr/<orbit>` hrefs) with `consolidated=True` fell back to a listing. Cosmetic (root consolidation was already complete) but worth shipping.

## What
- `pyproject.toml` + `uv.lock`: `ac3167f` → `02456d5` — hand-edited rev, no relock (lockfile revision stable).

## Verification
- `uv sync --frozen` installs `02456d5`; the consolidate-all-orbits code path is present in the built package.
- data-pipeline suite green (586 passed, 1 skipped).
- Test image **`v0.7.3-s1rtc-rc1`** builds from this branch for staging validation. Supersedes `v0.7.2-s1rtc-rc1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)