### PR TITLE
fix(s1-stac): map.html viewer for the RGB composite link + per-band rescale

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.2",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@02456d5e81a1be946e406395acda58e3dc8e8150",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@ab237ec1a83906a5e23ea15787c783da7bc5685e",
     "mgrs==1.5.4",
     "requests==2.34.2",
 ]

--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -67,13 +67,18 @@ def render_tilejson(
     return f"{base}/WebMercatorQuad/tilejson.json?{_render_to_query(render, include_tilesize=True)}&{_sel_time(sel_time)}"
 
 
-def render_xyz(
+def render_viewer(
     raster_api: str, cube_collection: str, tile_id: str, render: dict, sel_time: str
 ) -> str:
-    """XYZ tile template (``{z}/{x}/{y}.png``) for the cube slice at ``sel_time`` — the map preview."""
+    """Interactive ``map.html`` viewer for the cube slice at ``sel_time`` — the human-clickable map.
+
+    A raw ``{z}/{x}/{y}`` xyz tile template 422s when clicked in a STAC browser (the placeholders are
+    sent to TiTiler literally); ``map.html`` fills the tile coords in itself. ``tilejson`` (above)
+    serves the tile template to machine map clients.
+    """
     base = _cube_item_base(raster_api, cube_collection, tile_id)
     q = _render_to_query(render, include_tilesize=True)
-    return f"{base}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{q}&{_sel_time(sel_time)}"
+    return f"{base}/WebMercatorQuad/map.html?{q}&{_sel_time(sel_time)}"
 
 
 def render_thumbnail(
@@ -93,9 +98,9 @@ def decorate_acquisition_item(
     already done by ``build_s1_rtc_per_acquisition_items``; this adds only the deployment links. They
     point at the shared **cube** TiTiler endpoint (``cube_collection``/``s1-rtc-{tile}``) with
     ``sel=time={datetime}`` — no data duplication; the acquisition item is a reference into the cube,
-    and the render stays slice-correct regardless of the cube's physical slice order. No ``viewer`` link
-    (TiTiler can't deep-link to a single cube slice). Any ``store`` link / S3 ``alternate`` blocks the
-    caller already added are preserved.
+    and the render stays slice-correct regardless of the cube's physical slice order. The ``viewer``
+    link is a ``map.html`` deep-link into this acquisition's slice (``sel=time`` makes that possible).
+    Any ``store`` link / S3 ``alternate`` blocks the caller already added are preserved.
     """
     when = item.datetime
     if when is None:  # per-acquisition items always carry a single datetime
@@ -116,9 +121,9 @@ def decorate_acquisition_item(
             "title": "tilejson",
         },
         {
-            "rel": "xyz",
-            "type": "image/png",
-            "href": render_xyz(raster_api, cube_collection, tile_id, render, sel_time),
+            "rel": "viewer",
+            "type": "text/html",
+            "href": render_viewer(raster_api, cube_collection, tile_id, render, sel_time),
             "title": "Sentinel-1 GRD RGB composite",
         },
         {

--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -227,24 +227,30 @@ def _with_sel_time(query: str, sel_time: str | None) -> str:
 def add_visualization_links(
     item: Item, raster_base: str, collection_id: str, sel_time: str | None = None
 ) -> None:
-    """Add viewer/xyz/tilejson links for TiTiler visualization.
+    """Add the TiTiler visualization links.
+
+    The render path (producer ``renders`` config) emits an interactive ``map.html`` ``viewer`` + a
+    ``tilejson``; the mission fallbacks keep the legacy bare ``/viewer`` + ``xyz`` tile template.
 
     ``sel_time`` (when set) pins the render to one cube slice by datetime — the cube item passes the
     best-recent acquisition so its preview isn't the default (oldest) slice.
     """
     base_url = f"{raster_base}/collections/{collection_id}/items/{item.id}"
-    item.add_link(Link("viewer", f"{base_url}/viewer", "text/html", f"Viewer for {item.id}"))
 
     # Prefer a producer-declared render config (STAC render extension) over the
     # hardcoded mission defaults below.
     if render := _select_render(item):
         query = _with_sel_time(_render_to_query(render, include_tilesize=True), sel_time)
         title = render.get("title") or f"Visualization for {item.id}"
+        # Human-clickable interactive viewer carrying the render expression/rescale/sel. A raw
+        # {z}/{x}/{y} xyz tile template 422s when clicked in a STAC browser (the placeholders are
+        # sent to TiTiler literally); map.html fills the tile coords in itself. Machine map clients
+        # consume the tilejson link below for the tile template.
         item.add_link(
             Link(
-                "xyz",
-                f"{base_url}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{query}",
-                "image/png",
+                "viewer",
+                f"{base_url}/WebMercatorQuad/map.html?{query}",
+                "text/html",
                 title,
             )
         )
@@ -259,7 +265,8 @@ def add_visualization_links(
         _add_explorer_link(item, collection_id)
         return
 
-    # Mission-specific tile configurations
+    # Mission-specific tile configurations (no producer render config): bare viewer + legacy xyz.
+    item.add_link(Link("viewer", f"{base_url}/viewer", "text/html", f"Viewer for {item.id}"))
     coll_lower = collection_id.lower()
     if coll_lower.startswith(("sentinel-1", "sentinel1")):
         # S1: VH band visualization

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -48,7 +48,7 @@ def _acq_item() -> pystac.Item:
             "renders": {
                 "rgb": {
                     "expression": "/descending:vv;/descending:vh;(/descending:vv)/(/descending:vh)",
-                    "rescale": [[0.0, 0.2]],
+                    "rescale": [[0.0, 0.4], [0.0, 0.1], [1.0, 15.0]],
                     "bidx": [1],
                     "tilesize": 256,
                 }
@@ -80,23 +80,28 @@ def test_acquisition_id_format() -> None:
 
 
 def test_render_links_point_at_cube_endpoint_with_sel_datetime() -> None:
-    """tilejson + xyz target the CUBE item's endpoint (not the acquisition item's), carry the composite
-    render + sel=time={datetime}; never the acquisitions collection, no positional index."""
+    """tilejson + viewer target the CUBE item's endpoint (not the acquisition item's), carry the
+    composite render + sel=time={datetime}; never the acquisitions collection, no positional index."""
     d = decorate_acquisition_item(
         _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER
     )
     links = _links(d)
-    for rel in ("tilejson", "xyz"):
+    for rel in ("tilejson", "viewer"):
         href = links[rel]
         assert f"/collections/{CUBE}/items/s1-rtc-31TCH" in href  # cube endpoint, not the acq item
         assert ACQ not in href
         assert "expression=" in href
-        assert "rescale=0.0%2C0.2" in href
+        # one rescale pair per expression band (vv; vh; vv/vh ratio)
+        for pair in ("rescale=0.0%2C0.4", "rescale=0.0%2C0.1", "rescale=1.0%2C15.0"):
+            assert pair in href
         assert _SEL in href
         assert "sel=time=0" not in href  # not a positional index
         assert "/descending:vv" in urllib.parse.unquote(href)  # the item's own orbit
     assert "tilejson.json" in links["tilejson"]
-    assert "{z}/{x}/{y}.png" in links["xyz"]
+    assert (
+        "/WebMercatorQuad/map.html" in links["viewer"]
+    )  # interactive viewer, not a raw tile template
+    assert "{z}/{x}/{y}" not in str(d["links"])  # the broken xyz template is gone
 
 
 def test_thumbnail_via_and_store_link_kept() -> None:
@@ -112,7 +117,7 @@ def test_thumbnail_via_and_store_link_kept() -> None:
     links = _links(d)
     assert links["via"].endswith(f"/collections/{ACQ}/items/s1-rtc-31TCH-20260605t060907")
     assert "store" in links  # the caller's cube store link is preserved
-    assert "viewer" not in links  # no viewer link for a single cube slice
+    assert "/WebMercatorQuad/map.html" in links["viewer"]  # map.html deep-link into this slice
 
 
 def test_no_orbit_leak() -> None:

--- a/tests/unit/test_register_v1.py
+++ b/tests/unit/test_register_v1.py
@@ -221,18 +221,20 @@ class TestRenderToQuery:
 
 
 class TestVisualizationFromRenders:
-    def test_xyz_and_tilejson_use_render_expression(self):
+    def test_viewer_and_tilejson_use_render_expression(self):
         item = _real_item(_s1_rgb_renders())
         add_visualization_links(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
 
-        xyz = next(link for link in item.links if link.rel == "xyz")
+        viewer = next(link for link in item.links if link.rel == "viewer")
         tilejson = next(link for link in item.links if link.rel == "tilejson")
         # render expression is used, NOT the old VH-grayscale rescale=0,219
-        for link in (xyz, tilejson):
+        for link in (viewer, tilejson):
             assert "expression=" in link.href
             assert "rescale=0%2C219" not in link.href
             assert "0.1" in link.href
-        assert "/tiles/WebMercatorQuad/{z}/{x}/{y}.png" in xyz.href
+        # the human viewer is the interactive map.html, not a raw {z}/{x}/{y} tile template
+        assert "/WebMercatorQuad/map.html" in viewer.href
+        assert not any("{z}/{x}/{y}" in link.href for link in item.links)
         assert "tilejson.json" in tilejson.href
 
     def test_thumbnail_uses_render_expression(self):
@@ -264,10 +266,10 @@ class TestSelTimePinsSlice:
         add_thumbnail_asset(item, RASTER_BASE, "sentinel-1-grd-rtc-staging", sel_time=_SEL)
         assert _SEL_Q in item.assets["thumbnail"].href
 
-    def test_xyz_and_tilejson_carry_sel_time(self):
+    def test_viewer_and_tilejson_carry_sel_time(self):
         item = _real_item(_s1_rgb_renders())
         add_visualization_links(item, RASTER_BASE, "sentinel-1-grd-rtc-staging", sel_time=_SEL)
-        for rel in ("xyz", "tilejson"):
+        for rel in ("viewer", "tilejson"):
             link = next(link for link in item.links if link.rel == rel)
             assert _SEL_Q in link.href
 

--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.2" },
     { name = "click", specifier = "==8.4.1" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=02456d5e81a1be946e406395acda58e3dc8e8150" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=ab237ec1a83906a5e23ea15787c783da7bc5685e" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mgrs", specifier = "==1.5.4" },
     { name = "morecantile", specifier = "==7.0.3" },
@@ -997,7 +997,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.1"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=02456d5e81a1be946e406395acda58e3dc8e8150#02456d5e81a1be946e406395acda58e3dc8e8150" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=ab237ec1a83906a5e23ea15787c783da7bc5685e#ab237ec1a83906a5e23ea15787c783da7bc5685e" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
## Problem

Two defects in S1 RTC STAC items (both staging collections), surfaced via STAC Browser:

1. **Broken composite link.** The "VV, VH, VV/VH composite" / "Sentinel-1 GRD RGB composite" link was emitted as `rel="xyz"` → `…/tiles/WebMercatorQuad/{z}/{x}/{y}.png`, a tile *template*. Clicked in STAC Browser the literal `{z}/{x}/{y}` reaches TiTiler → **HTTP 422**.
2. **Flat-wash rescale.** The 3-band RGB expression (`vv; vh; vv/vh`) used a single rescale `[0,0.2]` for all bands → the ratio band saturated and low cross-pol water dropped out.

## Fix

- **Endpoint** (`696405b`): point the human-clickable composite link at TiTiler's self-contained `…/WebMercatorQuad/map.html` viewer (same render query incl. `sel=time`), which fills the tile coords itself. The raw `{z}/{x}/{y}` template is dropped; machine map clients keep it via the retained `tilejson` link.
  - `register_v1.add_visualization_links` (cube items): render path emits one `viewer`→`map.html` + `tilejson`; the bare `/viewer` moves to the mission fallbacks only.
  - `register_per_acquisition` (per-acq items): `render_xyz`→`render_viewer`; the composite link becomes `viewer`/`text/html` (`map.html` + `sel=time` is a valid single-slice deep-link).
- **Rescale** (`d5a3fca`): bump data-model pin `02456d5 → ab237ec` (EOPF-EXPLORER/data-model#204**), giving each band its own pair — vv `[0,0.4]`, vh `[0,0.1]`, ratio `[1,15]`. Clean +1 over the prior pin (`s1_rtc.py` only); `_render_to_query` already serializes N rescale pairs, so links + thumbnail pick it up. Lock change is sha-only. `bidx=1` kept (verified: dropping it 500s).

## Verification

- `uv run pytest -q` → **586 passed, 1 skipped**; ruff + mypy (pinned pre-commit) clean.
- Live (titiler staging), corrected links for 30TXP / 30TWP / 30UVU: `map.html` → **200 text/html**, `/preview` → **200 RGBA**. The broken `{z}/{x}/{y}` form → **422**.

## Notes

- Base is `feat--s1_grd_phase5`; because `chore/bump-datamodel-consolidate-orbits` isn't merged there yet, this diff also carries its `02456d5` bump (`9cdf813`) — that commit drops out once the bump PR merges.
- **Follow-up (not in this PR):** re-register existing staging items in both collections from the bumped image so live items get `map.html` + per-band rescale (the code fix applies to future ingests automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z3eVtkSNHhN9vHd8QqGcf