### PR TITLE
feat(s1-stac): bidirectional related links between cube tile & per-acquisition items

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.2",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@ab237ec1a83906a5e23ea15787c783da7bc5685e",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@f882a3f06364dc6cccf4d6892524bada31ff60a2",
     "mgrs==1.5.4",
     "requests==2.34.2",
 ]

--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -90,9 +90,9 @@ def render_thumbnail(
 
 
 def decorate_acquisition_item(
-    item: Item, *, tile_id: str, cube_collection: str, raster_api: str
+    item: Item, *, tile_id: str, cube_collection: str, raster_api: str, stac_api_url: str
 ) -> dict:
-    """Add the render/``via`` links + thumbnail to a per-acquisition item and return its dict.
+    """Add the render/``via``/``related`` links + thumbnail to a per-acquisition item and return its dict.
 
     Construction (single ``datetime``, run-orbit metadata, the orbit's γ⁰ asset, ``renders.rgb``) is
     already done by ``build_s1_rtc_per_acquisition_items``; this adds only the deployment links. They
@@ -100,6 +100,8 @@ def decorate_acquisition_item(
     ``sel=time={datetime}`` — no data duplication; the acquisition item is a reference into the cube,
     and the render stays slice-correct regardless of the cube's physical slice order. The ``viewer``
     link is a ``map.html`` deep-link into this acquisition's slice (``sel=time`` makes that possible).
+    A ``related`` link points at this acquisition's parent **tile datacube** STAC item
+    (``stac_api_url``/collections/``cube_collection``/items/``s1-rtc-{tile}``) for browser navigation.
     Any ``store`` link / S3 ``alternate`` blocks the caller already added are preserved.
     """
     when = item.datetime
@@ -131,6 +133,12 @@ def decorate_acquisition_item(
             "type": "text/html",
             "href": f"{EXPLORER_BASE}/collections/{collection.lower().replace('_', '-')}/items/{item_id}",
             "title": "EOPF Explorer",
+        },
+        {
+            "rel": "related",
+            "type": "application/json",
+            "href": f"{stac_api_url.rstrip('/')}/collections/{cube_collection}/items/s1-rtc-{tile_id}",
+            "title": "Parent tile datacube",
         },
     ]
     d.setdefault("assets", {})["thumbnail"] = {
@@ -219,6 +227,7 @@ def main() -> None:
                 tile_id=args.tile_id,
                 cube_collection=args.cube_collection,
                 raster_api=args.raster_api_url,
+                stac_api_url=args.stac_api_url,
             )
         )
 

--- a/scripts/register_v1_s1_rtc.py
+++ b/scripts/register_v1_s1_rtc.py
@@ -15,12 +15,12 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 sys.path.insert(0, str(Path(__file__).parent))
 
 from eopf_geozarr.stac.s1_rtc import build_s1_rtc_stac_item, pick_slice, slice_coverages
-from pystac import Item
+from pystac import Item, Link
 from pystac_client import Client
 from register_v1 import (
     add_alternate_s3_assets,
@@ -84,12 +84,34 @@ def _pin_preview_to_best_recent(item: Item, store: str) -> tuple[Item, str | Non
     return Item.from_dict(item_dict), chosen.dt.strftime("%Y-%m-%dT%H:%M:%S")
 
 
+def acquisitions_collection_of(cube_collection: str) -> str:
+    """The per-acquisition collection paired with a cube collection (its env-split sibling).
+
+    ``sentinel-1-grd-rtc-{env}`` → ``sentinel-1-grd-rtc-acquisitions-{env}``. Overridable via
+    ``--acquisitions-collection`` so platform-deploy isn't coupled to this string surgery.
+    """
+    return cube_collection.replace("sentinel-1-grd-rtc", "sentinel-1-grd-rtc-acquisitions", 1)
+
+
+def acquisitions_search_href(stac_api_url: str, acq_collection: str, tile_id: str) -> str:
+    """STAC item-search URL listing this tile's per-acquisition items (self-maintaining — no enumeration).
+
+    Filters by id prefix ``s1-rtc-{tile}-`` (works today, no new property). Switch to
+    ``grid:code='MGRS-{tile}'`` once the grid extension is pinned (data-model L1). ``tile_id`` is a
+    controlled MGRS token from the cube item id, not user input.
+    """
+    cql2 = f"id LIKE 's1-rtc-{tile_id}-%'"
+    query = urlencode({"collections": acq_collection, "filter-lang": "cql2-text", "filter": cql2})
+    return f"{stac_api_url.rstrip('/')}/search?{query}"
+
+
 def register(
     store: str,
     collection: str,
     stac_api_url: str,
     raster_api_url: str,
     s3_endpoint: str,
+    acquisitions_collection: str | None = None,
 ) -> int:
     """Build and register one S1 RTC STAC item.
 
@@ -123,6 +145,19 @@ def register(
     add_thumbnail_asset(item, raster_api_url, collection, sel_time=sel_time)
     warm_thumbnail_cache(item)
 
+    # Cross-link to this tile's per-acquisition items (one self-maintaining search link, not N
+    # enumerated links — the set grows each ingest). tile is the cube id's suffix (`s1-rtc-{tile}`).
+    tile_id = item.id.removeprefix("s1-rtc-")
+    acq_collection = acquisitions_collection or acquisitions_collection_of(collection)
+    item.add_link(
+        Link(
+            "related",
+            acquisitions_search_href(stac_api_url, acq_collection, tile_id),
+            "application/json",
+            "Per-acquisition items (this tile)",
+        )
+    )
+
     try:
         client = Client.open(stac_api_url)
         upsert_item(client, collection, item)
@@ -143,6 +178,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--stac-api-url", required=True, help="STAC API base URL")
     parser.add_argument("--raster-api-url", required=True, help="TiTiler raster API base URL")
     parser.add_argument("--s3-endpoint", required=True, help="S3 endpoint URL")
+    parser.add_argument(
+        "--acquisitions-collection",
+        default=None,
+        help="per-acquisition collection for the cube→acquisitions cross-link "
+        "(default: derived as the …-acquisitions-{env} sibling of --collection)",
+    )
     return parser
 
 
@@ -156,6 +197,7 @@ def main() -> None:
             stac_api_url=args.stac_api_url,
             raster_api_url=args.raster_api_url,
             s3_endpoint=args.s3_endpoint,
+            acquisitions_collection=args.acquisitions_collection,
         )
     )
 

--- a/scripts/register_v1_s1_rtc.py
+++ b/scripts/register_v1_s1_rtc.py
@@ -96,11 +96,10 @@ def acquisitions_collection_of(cube_collection: str) -> str:
 def acquisitions_search_href(stac_api_url: str, acq_collection: str, tile_id: str) -> str:
     """STAC item-search URL listing this tile's per-acquisition items (self-maintaining — no enumeration).
 
-    Filters by id prefix ``s1-rtc-{tile}-`` (works today, no new property). Switch to
-    ``grid:code='MGRS-{tile}'`` once the grid extension is pinned (data-model L1). ``tile_id`` is a
-    controlled MGRS token from the cube item id, not user input.
+    Filters on the grid extension's ``grid:code='MGRS-{tile}'`` (both collections carry it since
+    data-model #205). ``tile_id`` is a controlled MGRS token from the cube item id, not user input.
     """
-    cql2 = f"id LIKE 's1-rtc-{tile_id}-%'"
+    cql2 = f"grid:code='MGRS-{tile_id}'"
     query = urlencode({"collections": acq_collection, "filter-lang": "cql2-text", "filter": cql2})
     return f"{stac_api_url.rstrip('/')}/search?{query}"
 

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -26,6 +26,7 @@ from register_per_acquisition import (  # noqa: E402
 CUBE = "sentinel-1-grd-rtc-staging"  # cube collection (render endpoint)
 ACQ = "sentinel-1-grd-rtc-acquisitions"  # per-acquisition collection (items go here)
 RASTER = "https://api.explorer.eopf.copernicus.eu/raster"
+STAC = "https://api.explorer.eopf.copernicus.eu/stac"
 WHEN = dt.datetime(2026, 6, 5, 6, 9, 7, tzinfo=dt.UTC)
 # sel fragment TiTiler matches against the CF-decoded datetime (colons percent-encoded)
 _SEL = "sel=time=2026-06-05T06%3A09%3A07"
@@ -83,7 +84,7 @@ def test_render_links_point_at_cube_endpoint_with_sel_datetime() -> None:
     """tilejson + viewer target the CUBE item's endpoint (not the acquisition item's), carry the
     composite render + sel=time={datetime}; never the acquisitions collection, no positional index."""
     d = decorate_acquisition_item(
-        _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER
+        _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER, stac_api_url=STAC
     )
     links = _links(d)
     for rel in ("tilejson", "viewer"):
@@ -106,7 +107,7 @@ def test_render_links_point_at_cube_endpoint_with_sel_datetime() -> None:
 
 def test_thumbnail_via_and_store_link_kept() -> None:
     d = decorate_acquisition_item(
-        _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER
+        _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER, stac_api_url=STAC
     )
     thumb = d["assets"]["thumbnail"]
     assert thumb["type"] == "image/png"
@@ -118,11 +119,13 @@ def test_thumbnail_via_and_store_link_kept() -> None:
     assert links["via"].endswith(f"/collections/{ACQ}/items/s1-rtc-31TCH-20260605t060907")
     assert "store" in links  # the caller's cube store link is preserved
     assert "/WebMercatorQuad/map.html" in links["viewer"]  # map.html deep-link into this slice
+    # related link → the parent tile datacube STAC item (cube collection)
+    assert links["related"] == f"{STAC}/collections/{CUBE}/items/s1-rtc-31TCH"
 
 
 def test_no_orbit_leak() -> None:
     """A descending item's links never reference the ascending group."""
     d = decorate_acquisition_item(
-        _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER
+        _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER, stac_api_url=STAC
     )
     assert "ascending" not in urllib.parse.unquote(str(d["links"]))

--- a/tests/unit/test_register_v1_s1_rtc.py
+++ b/tests/unit/test_register_v1_s1_rtc.py
@@ -12,7 +12,11 @@ import pytest
 scripts_dir = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(scripts_dir))
 
-from register_v1_s1_rtc import register  # noqa: E402
+from register_v1_s1_rtc import (  # noqa: E402
+    acquisitions_collection_of,
+    acquisitions_search_href,
+    register,
+)
 
 # ---------------------------------------------------------------------------
 # Fixture
@@ -241,6 +245,81 @@ def test_matched_env_store_allowed() -> None:
 
     assert result == 0
     mock_upsert.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Cube → per-acquisition cross-link
+# ---------------------------------------------------------------------------
+
+
+def test_acquisitions_collection_derivation() -> None:
+    assert (
+        acquisitions_collection_of("sentinel-1-grd-rtc-staging")
+        == "sentinel-1-grd-rtc-acquisitions-staging"
+    )
+    assert (
+        acquisitions_collection_of("sentinel-1-grd-rtc-tests")
+        == "sentinel-1-grd-rtc-acquisitions-tests"
+    )
+
+
+def test_acquisitions_search_href_filters_by_tile() -> None:
+    href = acquisitions_search_href(
+        "https://stac.example.com/", "sentinel-1-grd-rtc-acquisitions-staging", "31TCH"
+    )
+    assert href.startswith("https://stac.example.com/search?")  # trailing slash stripped
+    assert "collections=sentinel-1-grd-rtc-acquisitions-staging" in href
+    assert "filter-lang=cql2-text" in href
+    assert "s1-rtc-31TCH-%25" in href  # id LIKE 's1-rtc-31TCH-%' (% encoded)
+
+
+def test_register_adds_related_acquisitions_link() -> None:
+    """The cube item gets one `related` link to its tile's per-acquisition search (derived coll)."""
+    with (
+        patch(f"{_MOD}.build_s1_rtc_stac_item", return_value=_make_item()),
+        patch(f"{_MOD}.warm_thumbnail_cache"),
+        patch(f"{_MOD}.slice_coverages", return_value=[]),
+        patch(f"{_MOD}.upsert_item") as mock_upsert,
+        patch(f"{_MOD}.Client"),
+    ):
+        register(
+            _STORE,
+            _COLLECTION,
+            "https://stac.example.com",
+            "https://raster.example.com",
+            "https://s3.example.com",
+        )
+
+    item = mock_upsert.call_args[0][2]
+    related = [lk for lk in item.links if lk.rel == "related"]
+    assert len(related) == 1
+    href = related[0].href
+    assert "/search?" in href
+    assert "sentinel-1-grd-rtc-acquisitions-staging" in href  # derived acq collection
+    assert "s1-rtc-31TCH-%25" in href  # this tile's acquisitions
+
+
+def test_register_acquisitions_collection_override() -> None:
+    """--acquisitions-collection overrides the derived sibling name."""
+    with (
+        patch(f"{_MOD}.build_s1_rtc_stac_item", return_value=_make_item()),
+        patch(f"{_MOD}.warm_thumbnail_cache"),
+        patch(f"{_MOD}.slice_coverages", return_value=[]),
+        patch(f"{_MOD}.upsert_item") as mock_upsert,
+        patch(f"{_MOD}.Client"),
+    ):
+        register(
+            _STORE,
+            _COLLECTION,
+            "https://stac.example.com",
+            "https://raster.example.com",
+            "https://s3.example.com",
+            acquisitions_collection="custom-acq-coll",
+        )
+
+    item = mock_upsert.call_args[0][2]
+    related = next(lk for lk in item.links if lk.rel == "related")
+    assert "collections=custom-acq-coll" in related.href
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_register_v1_s1_rtc.py
+++ b/tests/unit/test_register_v1_s1_rtc.py
@@ -270,7 +270,7 @@ def test_acquisitions_search_href_filters_by_tile() -> None:
     assert href.startswith("https://stac.example.com/search?")  # trailing slash stripped
     assert "collections=sentinel-1-grd-rtc-acquisitions-staging" in href
     assert "filter-lang=cql2-text" in href
-    assert "s1-rtc-31TCH-%25" in href  # id LIKE 's1-rtc-31TCH-%' (% encoded)
+    assert "grid%3Acode" in href and "MGRS-31TCH" in href  # grid:code='MGRS-31TCH'
 
 
 def test_register_adds_related_acquisitions_link() -> None:
@@ -296,7 +296,7 @@ def test_register_adds_related_acquisitions_link() -> None:
     href = related[0].href
     assert "/search?" in href
     assert "sentinel-1-grd-rtc-acquisitions-staging" in href  # derived acq collection
-    assert "s1-rtc-31TCH-%25" in href  # this tile's acquisitions
+    assert "MGRS-31TCH" in href  # this tile's acquisitions (grid:code filter)
 
 
 def test_register_acquisitions_collection_override() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.2" },
     { name = "click", specifier = "==8.4.1" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=ab237ec1a83906a5e23ea15787c783da7bc5685e" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=f882a3f06364dc6cccf4d6892524bada31ff60a2" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mgrs", specifier = "==1.5.4" },
     { name = "morecantile", specifier = "==7.0.3" },
@@ -997,7 +997,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.1"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=ab237ec1a83906a5e23ea15787c783da7bc5685e#ab237ec1a83906a5e23ea15787c783da7bc5685e" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=f882a3f06364dc6cccf4d6892524bada31ff60a2#f882a3f06364dc6cccf4d6892524bada31ff60a2" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
## What

STAC `related` cross-links so STAC Browser can navigate **both ways** between a tile's datacube item and its per-acquisition slices, on a queryable tile id (Part 2 of the S1 RTC STAC UX work; follows #298).

- **per-acq → cube** (`register_per_acquisition`): `decorate_acquisition_item` gains `stac_api_url` and adds one stable `related` link to the parent tile datacube item (`{stac}/collections/{cube}/items/s1-rtc-{tile}`).
- **cube → acq** (`register_v1_s1_rtc`): one **self-maintaining** `related` link to a STAC item-search filtered by `grid:code='MGRS-{tile}'` — not N enumerated links (the acquisition set grows each ingest). New optional `--acquisitions-collection` overrides the derived `…-acquisitions-{env}` sibling.
- **grid:code**: bumps the `eopf-geozarr` pin to EOPF-EXPLORER/data-model#205 (`f882a3f`), so cube + per-acquisition items carry `grid:code = "MGRS-{tile}"` (grid extension). This makes the tile a queryable property — the acquisitions collection is natively tile-filterable in Browser, and the cube→acq link filters on it.

## Verification

- `uv run pytest -q` → **590 passed, 1 skipped**; ruff + mypy clean; lock change is sha-only.
- cube→acq href is well-formed and the live STAC API **accepts** the `grid:code` CQL2 filter (HTTP 200); it returns the tile's acquisitions once items are re-registered with `grid:code` (the id-`LIKE` form was validated live earlier = 9 acquisitions for 30TXP).

## Follow-ups (not in this PR)

- **Re-registration** of existing staging items applies the cross-links + grid:code to live data (staged pilot: 30TXP first).
- **Browser-rendering check** of the cube→acq `related` search link, at the re-registration pilot; trivial fallback = link the acquisitions collection instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z3eVtkSNHhN9vHd8QqGcf