### PR TITLE
fix(s1-stac): cube↔acquisitions navigation — collection link + enumerated acquisition links

### DIFF
--- a/scripts/register_v1_s1_rtc.py
+++ b/scripts/register_v1_s1_rtc.py
@@ -15,7 +15,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlparse
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -93,15 +93,14 @@ def acquisitions_collection_of(cube_collection: str) -> str:
     return cube_collection.replace("sentinel-1-grd-rtc", "sentinel-1-grd-rtc-acquisitions", 1)
 
 
-def acquisitions_search_href(stac_api_url: str, acq_collection: str, tile_id: str) -> str:
-    """STAC item-search URL listing this tile's per-acquisition items (self-maintaining — no enumeration).
+def acquisitions_collection_href(stac_api_url: str, acq_collection: str) -> str:
+    """STAC API URL of the per-acquisition collection — the cube→acquisitions navigation target.
 
-    Filters on the grid extension's ``grid:code='MGRS-{tile}'`` (both collections carry it since
-    data-model #205). ``tile_id`` is a controlled MGRS token from the cube item id, not user input.
+    Points at the **collection** (not a ``/search?filter=…`` URL, which STAC Browser renders as a blank
+    page). The collection page is browsable; the tile's scenes are then narrowed with its
+    ``grid:code='MGRS-{tile}'`` item-filter (both item types carry grid:code since data-model #205).
     """
-    cql2 = f"grid:code='MGRS-{tile_id}'"
-    query = urlencode({"collections": acq_collection, "filter-lang": "cql2-text", "filter": cql2})
-    return f"{stac_api_url.rstrip('/')}/search?{query}"
+    return f"{stac_api_url.rstrip('/')}/collections/{acq_collection}"
 
 
 def register(
@@ -144,16 +143,15 @@ def register(
     add_thumbnail_asset(item, raster_api_url, collection, sel_time=sel_time)
     warm_thumbnail_cache(item)
 
-    # Cross-link to this tile's per-acquisition items (one self-maintaining search link, not N
-    # enumerated links — the set grows each ingest). tile is the cube id's suffix (`s1-rtc-{tile}`).
-    tile_id = item.id.removeprefix("s1-rtc-")
+    # Cross-link to the per-acquisition items: target the browsable collection (a raw /search?filter
+    # URL renders blank in STAC Browser). Filter to this tile there via grid:code='MGRS-{tile}'.
     acq_collection = acquisitions_collection or acquisitions_collection_of(collection)
     item.add_link(
         Link(
             "related",
-            acquisitions_search_href(stac_api_url, acq_collection, tile_id),
+            acquisitions_collection_href(stac_api_url, acq_collection),
             "application/json",
-            "Per-acquisition items (this tile)",
+            "Per-acquisition items (filter by tile grid:code)",
         )
     )
 

--- a/scripts/register_v1_s1_rtc.py
+++ b/scripts/register_v1_s1_rtc.py
@@ -17,6 +17,8 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
+import httpx
+
 sys.path.insert(0, str(Path(__file__).parent))
 
 from eopf_geozarr.stac.s1_rtc import build_s1_rtc_stac_item, pick_slice, slice_coverages
@@ -103,6 +105,46 @@ def acquisitions_collection_href(stac_api_url: str, acq_collection: str) -> str:
     return f"{stac_api_url.rstrip('/')}/collections/{acq_collection}"
 
 
+def add_acquisition_links(item: Item, stac_api_url: str, acq_collection: str) -> None:
+    """Enumerate this tile's per-acquisition items as ``related`` links on the cube item.
+
+    STAC Browser can't deep-link a filtered list (it runs CQL2 filters as POST — never in the URL —
+    and can't render a raw ItemCollection), so each acquisition is listed as a clickable link the user
+    opens directly from the cube item. Best-effort: queries the per-acquisition collection by the
+    cube's ``grid:code='MGRS-{tile}'`` (needs those items already registered; they are, each ingest).
+    """
+    stac = stac_api_url.rstrip("/")
+    tile_id = item.id.removeprefix("s1-rtc-")
+    try:
+        with httpx.Client(timeout=30.0, follow_redirects=True) as http:
+            resp = http.get(
+                f"{stac}/search",
+                params={
+                    "collections": acq_collection,
+                    "filter-lang": "cql2-text",
+                    "filter": f"grid:code='MGRS-{tile_id}'",
+                    "limit": 100,
+                },
+            )
+            feats = sorted(
+                resp.json().get("features", []), key=lambda f: f["properties"]["datetime"]
+            )
+        for f in feats:
+            when = f["properties"]["datetime"]
+            orbit = f["properties"].get("sat:orbit_state", "")
+            item.add_link(
+                Link(
+                    "related",
+                    f"{stac}/collections/{acq_collection}/items/{f['id']}",
+                    "application/geo+json",
+                    f"Acquisition {when[:16].replace('T', ' ')}Z ({orbit})",
+                )
+            )
+        log.info("Added %d per-acquisition related links for %s", len(feats), tile_id)
+    except Exception:
+        log.warning("Could not enumerate per-acquisition links for %s", tile_id, exc_info=True)
+
+
 def register(
     store: str,
     collection: str,
@@ -154,6 +196,10 @@ def register(
             "Per-acquisition items (filter by tile grid:code)",
         )
     )
+
+    # Also list this tile's per-acquisition items as individual related links (one clickable link each)
+    # so the user can open a scene directly from the cube — STAC Browser can't deep-link a filtered list.
+    add_acquisition_links(item, stac_api_url, acq_collection)
 
     try:
         client = Client.open(stac_api_url)

--- a/tests/unit/test_register_v1_s1_rtc.py
+++ b/tests/unit/test_register_v1_s1_rtc.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(scripts_dir))
 from register_v1_s1_rtc import (  # noqa: E402
     acquisitions_collection_href,
     acquisitions_collection_of,
+    add_acquisition_links,
     register,
 )
 
@@ -92,6 +93,7 @@ def test_upserts_item_with_correct_id() -> None:
         patch(f"{_MOD}.slice_coverages", return_value=[]),  # no store read in these unit tests
         patch(f"{_MOD}.upsert_item") as mock_upsert,
         patch(f"{_MOD}.Client"),
+        patch(f"{_MOD}.add_acquisition_links"),  # no network in register() unit tests
     ):
         result = register(
             _STORE,
@@ -129,6 +131,7 @@ def test_render_rescale_propagates_to_links() -> None:
         patch(f"{_MOD}.slice_coverages", return_value=[]),
         patch(f"{_MOD}.upsert_item") as mock_upsert,
         patch(f"{_MOD}.Client"),
+        patch(f"{_MOD}.add_acquisition_links"),  # no network in register() unit tests
     ):
         result = register(
             _STORE,
@@ -153,6 +156,7 @@ def test_visualization_links_called() -> None:
         patch(f"{_MOD}.slice_coverages", return_value=[]),  # no store read in these unit tests
         patch(f"{_MOD}.upsert_item"),
         patch(f"{_MOD}.Client"),
+        patch(f"{_MOD}.add_acquisition_links"),  # no network in register() unit tests
         patch(f"{_MOD}.add_visualization_links") as mock_viz,
     ):
         register(
@@ -234,6 +238,7 @@ def test_matched_env_store_allowed() -> None:
         patch(f"{_MOD}.slice_coverages", return_value=[]),  # no store read in these unit tests
         patch(f"{_MOD}.upsert_item") as mock_upsert,
         patch(f"{_MOD}.Client"),
+        patch(f"{_MOD}.add_acquisition_links"),  # no network in register() unit tests
     ):
         result = register(
             good_store,
@@ -279,6 +284,7 @@ def test_register_adds_related_acquisitions_link() -> None:
         patch(f"{_MOD}.slice_coverages", return_value=[]),
         patch(f"{_MOD}.upsert_item") as mock_upsert,
         patch(f"{_MOD}.Client"),
+        patch(f"{_MOD}.add_acquisition_links"),  # no network in register() unit tests
     ):
         register(
             _STORE,
@@ -304,6 +310,7 @@ def test_register_acquisitions_collection_override() -> None:
         patch(f"{_MOD}.slice_coverages", return_value=[]),
         patch(f"{_MOD}.upsert_item") as mock_upsert,
         patch(f"{_MOD}.Client"),
+        patch(f"{_MOD}.add_acquisition_links"),  # no network in register() unit tests
     ):
         register(
             _STORE,
@@ -317,6 +324,59 @@ def test_register_acquisitions_collection_override() -> None:
     item = mock_upsert.call_args[0][2]
     related = next(lk for lk in item.links if lk.rel == "related")
     assert related.href.endswith("/collections/custom-acq-coll")
+
+
+def test_add_acquisition_links_enumerates_sorted() -> None:
+    """add_acquisition_links lists the tile's acquisitions as related links, sorted by datetime."""
+    import datetime as dt
+
+    feats = [
+        {
+            "id": "s1-rtc-31TCH-20260605t060842",
+            "properties": {"datetime": "2026-06-05T06:08:42Z", "sat:orbit_state": "descending"},
+        },
+        {
+            "id": "s1-rtc-31TCH-20260604t061555",
+            "properties": {"datetime": "2026-06-04T06:15:55Z", "sat:orbit_state": "ascending"},
+        },
+    ]
+
+    class _Resp:
+        def json(self):
+            return {"features": feats}
+
+    class _Http:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, *a, **k):
+            return _Resp()
+
+    item = pystac.Item(
+        id="s1-rtc-31TCH",
+        geometry=None,
+        bbox=None,
+        datetime=dt.datetime(2026, 6, 7, tzinfo=dt.UTC),
+        properties={},
+    )
+    with patch(f"{_MOD}.httpx.Client", lambda *a, **k: _Http()):
+        add_acquisition_links(
+            item, "https://stac.example.com", "sentinel-1-grd-rtc-acquisitions-staging"
+        )
+
+    related = [lk for lk in item.links if lk.rel == "related"]
+    assert len(related) == 2
+    # sorted by datetime (earliest first), titled by date + orbit, href → the acquisition item
+    assert "20260604t061555" in related[0].href and related[0].title.startswith(
+        "Acquisition 2026-06-04 06:15Z"
+    )
+    assert "20260605t060842" in related[1].href
+    assert related[0].href.startswith(
+        "https://stac.example.com/collections/sentinel-1-grd-rtc-acquisitions-staging/items/"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_register_v1_s1_rtc.py
+++ b/tests/unit/test_register_v1_s1_rtc.py
@@ -13,8 +13,8 @@ scripts_dir = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(scripts_dir))
 
 from register_v1_s1_rtc import (  # noqa: E402
+    acquisitions_collection_href,
     acquisitions_collection_of,
-    acquisitions_search_href,
     register,
 )
 
@@ -263,18 +263,16 @@ def test_acquisitions_collection_derivation() -> None:
     )
 
 
-def test_acquisitions_search_href_filters_by_tile() -> None:
-    href = acquisitions_search_href(
-        "https://stac.example.com/", "sentinel-1-grd-rtc-acquisitions-staging", "31TCH"
+def test_acquisitions_collection_href() -> None:
+    href = acquisitions_collection_href(
+        "https://stac.example.com/", "sentinel-1-grd-rtc-acquisitions-staging"
     )
-    assert href.startswith("https://stac.example.com/search?")  # trailing slash stripped
-    assert "collections=sentinel-1-grd-rtc-acquisitions-staging" in href
-    assert "filter-lang=cql2-text" in href
-    assert "grid%3Acode" in href and "MGRS-31TCH" in href  # grid:code='MGRS-31TCH'
+    # the browsable collection URL (NOT a /search?filter URL, which blanks in STAC Browser)
+    assert href == "https://stac.example.com/collections/sentinel-1-grd-rtc-acquisitions-staging"
 
 
 def test_register_adds_related_acquisitions_link() -> None:
-    """The cube item gets one `related` link to its tile's per-acquisition search (derived coll)."""
+    """The cube item gets one `related` link to the browsable per-acquisition collection (derived)."""
     with (
         patch(f"{_MOD}.build_s1_rtc_stac_item", return_value=_make_item()),
         patch(f"{_MOD}.warm_thumbnail_cache"),
@@ -294,9 +292,8 @@ def test_register_adds_related_acquisitions_link() -> None:
     related = [lk for lk in item.links if lk.rel == "related"]
     assert len(related) == 1
     href = related[0].href
-    assert "/search?" in href
-    assert "sentinel-1-grd-rtc-acquisitions-staging" in href  # derived acq collection
-    assert "MGRS-31TCH" in href  # this tile's acquisitions (grid:code filter)
+    assert href.endswith("/collections/sentinel-1-grd-rtc-acquisitions-staging")  # derived coll
+    assert "/search?" not in href  # not a search URL (renders blank in STAC Browser)
 
 
 def test_register_acquisitions_collection_override() -> None:
@@ -319,7 +316,7 @@ def test_register_acquisitions_collection_override() -> None:
 
     item = mock_upsert.call_args[0][2]
     related = next(lk for lk in item.links if lk.rel == "related")
-    assert "collections=custom-acq-coll" in related.href
+    assert related.href.endswith("/collections/custom-acq-coll")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What (follow-up to #300)

Makes the cube tile item navigate to its per-acquisition scenes in STAC Browser. Two links:

1. **Collection link** — a `related` link to the browsable per-acquisition **collection** (a `/search?filter` URL renders blank in Browser; `/items?filter` throws `getLocaleLink` in 4.0.1).
2. **Enumerated acquisition links** — one `related` link per acquisition of this tile (titled by date + orbit, sorted), so the user can open a scene directly from the cube.

**Why enumerate:** investigated the STAC Browser 4.0.1 source — it runs CQL2 filters as a **POST** (never in the URL) and can't render a raw ItemCollection, so a filtered list can't be deep-linked in any version. Direct per-item links are the only way to reach a tile's scenes from the cube. `add_acquisition_links` queries the per-acquisition collection by the cube's `grid:code='MGRS-{tile}'` (a registered queryable since platform-deploy #275), best-effort.

## Verify
- `uv run pytest tests/unit/test_register_v1_s1_rtc.py -q` → 14 passed; ruff/mypy clean.
- Live: re-registered **30TXP** (9 acquisitions) and **30TWM** (5) — both cubes carry the collection link + the enumerated acquisition links + `grid:code`; per-acq items carry `grid:code` + `map.html` viewer + a parent-tile link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z3eVtkSNHhN9vHd8QqGcf