### PR TITLE
feat(s1-migration): in-place legacy→datamodel cube re-derive (code; Tasks 1/1b/2)

### DIFF
--- a/scripts/migrate_s1_rtc_datamodel.py
+++ b/scripts/migrate_s1_rtc_datamodel.py
@@ -60,7 +60,13 @@ class RedriveReport:
 
 
 def _marker_value() -> str:
-    """The writer revision the migration runs against (the completion-marker value)."""
+    """The writer the migration runs against (the completion-marker value).
+
+    Deliberately version-granular (``eopf_geozarr.__version__``), not the exact git rev — two ``0.10.1``
+    builds share a marker. The precise-behaviour guarantee comes from ``assert_writer_pinned`` at run
+    time (version + fill value + OVERVIEW_CHAIN), not from the marker; the marker only answers "did *a*
+    pinned writer already migrate this store" (the option-(b) R5 scope).
+    """
     return str(eopf_geozarr.__version__)
 
 
@@ -101,23 +107,21 @@ def redrive_store(store_path: str | Path, *, dry_run: bool = False) -> RedriveRe
             # rather than crash the fleet driver.
             report.skipped_no_border_mask.append(orbit_name)
             continue
-        border_mask = np.asarray(r10m["border_mask"][:])  # (T, y, x) — authoritative, untouched
-        for band in ("vv", "vh"):
-            native = np.asarray(r10m[band][:])  # (T, y, x); legacy: 0.0 out of swath
-            masked = np.empty_like(native, dtype="float32")
-            overviews: dict[str, list[np.ndarray]] = {lvl: [] for lvl, _, _ in overview_levels}
-            # Per time-slice: mask by border_mask (#202), then walk the writer's 2-D overview chain.
-            for t in range(native.shape[0]):
-                slc = np.where(border_mask[t] == 0, np.nan, native[t]).astype("float32")
-                masked[t] = slc
+        # Re-derive ONE time-slice at a time (mirrors the writer's per-acquisition 2-D path) so peak
+        # memory stays ~one (y, x) slice + its overview chain, not the whole (T, y, x) band — real tiles
+        # are 10980² × T, multiple GB per band. Mask the native by border_mask (#202), then walk the
+        # writer's 2-D overview chain, writing each level's slice directly (no full-band buffering).
+        for t in range(int(r10m["vv"].shape[0])):
+            mask_t = np.asarray(r10m["border_mask"][t])  # (y, x) — authoritative, untouched
+            for band in ("vv", "vh"):
+                slc = np.where(mask_t == 0, np.nan, np.asarray(r10m[band][t])).astype("float32")
+                r10m[band][t] = slc
                 prev = slc
                 for level_name, _parent, factor in overview_levels:
                     prev = _downsample_2d(prev, factor, "average")
-                    overviews[level_name].append(prev)
-            r10m[band][:] = masked
-            for level_name, slices in overviews.items():
-                orbit[level_name][band][:] = np.stack(slices)
-            for level_name, _parent, _factor in OVERVIEW_CHAIN:  # #201 CF attrs at every level
+                    orbit[level_name][band][t] = prev
+        for band in ("vv", "vh"):  # #201 CF attrs at every level, once per band
+            for level_name, _parent, _factor in OVERVIEW_CHAIN:
                 orbit[level_name][band].attrs.update(dict(BACKSCATTER_CF_ATTRS))
             report.bands_rewritten += 1
 
@@ -130,12 +134,15 @@ def redrive_store(store_path: str | Path, *, dry_run: bool = False) -> RedriveRe
                     cond_arr.attrs["_FillValue"] = FLOAT32_NAN_FILL_VALUE
                     report.conditions_fill_value_set += 1
 
-    # Mark complete only if every orbit was re-derived — a store with a skipped (no-border_mask) orbit
-    # stays un-marked so it is revisited rather than recorded as done (R2/R6).
-    if not report.skipped_no_border_mask:
-        root.attrs[MIGRATION_MARKER_KEY] = _marker_value()  # before consolidation so it's captured
+    # Consolidate first (#203 — every orbit + root), then write the completion marker LAST and only if
+    # every orbit was re-derived. Ordering is crash-safety (R2): a crash before the marker leaves the
+    # store consolidated-but-unmarked → re-derived idempotently next run, never marked-but-unconsolidated
+    # (which idempotency would then skip forever). `set_root_attr` edits the root zarr.json directly so
+    # the marker doesn't clobber the consolidated metadata just written.
     if report.orbits:
-        consolidate_s1_store(str(store_path), report.orbits[0])  # #203 — consolidates ALL orbits
+        consolidate_s1_store(str(store_path), report.orbits[0])
+    if not report.skipped_no_border_mask:
+        s1_store_meta.set_root_attr(str(store_path), MIGRATION_MARKER_KEY, _marker_value())
     return report
 
 

--- a/scripts/migrate_s1_rtc_datamodel.py
+++ b/scripts/migrate_s1_rtc_datamodel.py
@@ -26,6 +26,7 @@ import s1_store_meta
 import zarr
 from eopf_geozarr.conversion.s1_ingest import (
     BACKSCATTER_CF_ATTRS,
+    FLOAT32_NAN_FILL_VALUE,
     OVERVIEW_CHAIN,
     _downsample_2d,
     consolidate_s1_store,
@@ -44,6 +45,7 @@ class RedriveReport:
     store: str
     orbits: list[str] = field(default_factory=list)
     bands_rewritten: int = 0  # count of (orbit, band) pairs re-derived
+    conditions_fill_value_set: int = 0  # conditions data arrays given the CF _FillValue attr (#201)
     already_current: bool = False  # marker already at the current writer → no-op
     skipped_no_border_mask: list[str] = field(
         default_factory=list
@@ -104,6 +106,15 @@ def redrive_store(store_path: str | Path) -> RedriveReport:
             for level_name, _parent, _factor in OVERVIEW_CHAIN:  # #201 CF attrs at every level
                 orbit[level_name][band].attrs.update(dict(BACKSCATTER_CF_ATTRS))
             report.bands_rewritten += 1
+
+        # #201 — set the CF `_FillValue` attr (only) on conditions DATA arrays (2-D float gamma_area/
+        # lia). No data re-mask (R4): conditions nodata derives from the GeoTIFF's declared nodata,
+        # which the cube doesn't retain. Coordinate arrays (ndim <= 1) are left untouched.
+        if "conditions" in orbit:
+            for _name, cond_arr in orbit["conditions"].arrays():
+                if cond_arr.ndim >= 2 and np.issubdtype(cond_arr.dtype, np.floating):
+                    cond_arr.attrs["_FillValue"] = FLOAT32_NAN_FILL_VALUE
+                    report.conditions_fill_value_set += 1
 
     # Mark complete only if every orbit was re-derived — a store with a skipped (no-border_mask) orbit
     # stays un-marked so it is revisited rather than recorded as done (R2/R6).

--- a/scripts/migrate_s1_rtc_datamodel.py
+++ b/scripts/migrate_s1_rtc_datamodel.py
@@ -45,6 +45,9 @@ class RedriveReport:
     orbits: list[str] = field(default_factory=list)
     bands_rewritten: int = 0  # count of (orbit, band) pairs re-derived
     already_current: bool = False  # marker already at the current writer → no-op
+    skipped_no_border_mask: list[str] = field(
+        default_factory=list
+    )  # orbits lacking border_mask (R6)
 
 
 def _marker_value() -> str:
@@ -74,8 +77,14 @@ def redrive_store(store_path: str | Path) -> RedriveReport:
     root = zarr.open_group(str(store_path), mode="r+", zarr_format=3)
 
     overview_levels = OVERVIEW_CHAIN[1:]  # (level, parent, factor) below native r10m
-    for _orbit_name, orbit in root.groups():
+    for orbit_name, orbit in root.groups():
         r10m = orbit["r10m"]
+        if "border_mask" not in r10m:
+            # R6: border_mask is the authoritative valid-data mask; a cube lacking it cannot be
+            # re-derived in place. Flag it (the store stays un-marked → revisited / handled separately)
+            # rather than crash the fleet driver.
+            report.skipped_no_border_mask.append(orbit_name)
+            continue
         border_mask = np.asarray(r10m["border_mask"][:])  # (T, y, x) — authoritative, untouched
         for band in ("vv", "vh"):
             native = np.asarray(r10m[band][:])  # (T, y, x); legacy: 0.0 out of swath
@@ -96,7 +105,10 @@ def redrive_store(store_path: str | Path) -> RedriveReport:
                 orbit[level_name][band].attrs.update(dict(BACKSCATTER_CF_ATTRS))
             report.bands_rewritten += 1
 
-    root.attrs[MIGRATION_MARKER_KEY] = _marker_value()  # set before consolidation so it's captured
+    # Mark complete only if every orbit was re-derived — a store with a skipped (no-border_mask) orbit
+    # stays un-marked so it is revisited rather than recorded as done (R2/R6).
+    if not report.skipped_no_border_mask:
+        root.attrs[MIGRATION_MARKER_KEY] = _marker_value()  # before consolidation so it's captured
     if report.orbits:
         consolidate_s1_store(str(store_path), report.orbits[0])  # #203 — consolidates ALL orbits
     return report

--- a/scripts/migrate_s1_rtc_datamodel.py
+++ b/scripts/migrate_s1_rtc_datamodel.py
@@ -17,6 +17,9 @@ refuses to run otherwise. See plan `the-migration-of-the-adaptive-wolf.md`.
 
 from __future__ import annotations
 
+import argparse
+import logging
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -31,6 +34,10 @@ from eopf_geozarr.conversion.s1_ingest import (
     _downsample_2d,
     consolidate_s1_store,
 )
+from migrate_s1_rtc_stac import list_cube_items
+from register_v1 import https_to_s3
+
+log = logging.getLogger("migrate_s1_rtc_datamodel")
 
 # Per-store completion marker (root attr): the migration is idempotent on the *store*, keyed by the
 # writer the re-derive ran against. Writes within a store are not atomic across objects, so a crash
@@ -57,12 +64,13 @@ def _marker_value() -> str:
     return str(eopf_geozarr.__version__)
 
 
-def redrive_store(store_path: str | Path) -> RedriveReport:
+def redrive_store(store_path: str | Path, *, dry_run: bool = False) -> RedriveReport:
     """Re-derive one cube store in place to the current data-model; return what changed.
 
     Idempotent via the per-store completion marker: a store already migrated at the current writer is
     a no-op. Follows the consolidated-metadata dance (drop → reopen ``r+`` → re-derive → marker →
-    ``consolidate_s1_store``) so the writer sees fresh per-array metadata.
+    ``consolidate_s1_store``) so the writer sees fresh per-array metadata. ``dry_run`` reports what
+    would happen (already-current / which orbits, which lack ``border_mask``) and writes **nothing**.
     """
     s1_store_meta.assert_writer_pinned()  # R5 — refuse to run on a drifted writer
     store_path = Path(store_path)
@@ -72,6 +80,12 @@ def redrive_store(store_path: str | Path) -> RedriveReport:
     report.orbits = [name for name, _ in root_ro.groups()]
     if dict(root_ro.attrs).get(MIGRATION_MARKER_KEY) == _marker_value():
         report.already_current = True
+        return report
+
+    if dry_run:  # report-only: no drop-consolidated, no r+, no writes
+        for orbit_name, orbit in root_ro.groups():
+            if "border_mask" not in orbit["r10m"]:
+                report.skipped_no_border_mask.append(orbit_name)
         return report
 
     # C1: a consolidated store serves stale array metadata to writers — drop it before reopening r+.
@@ -123,3 +137,100 @@ def redrive_store(store_path: str | Path) -> RedriveReport:
     if report.orbits:
         consolidate_s1_store(str(store_path), report.orbits[0])  # #203 — consolidates ALL orbits
     return report
+
+
+# =============================================================================
+# Fleet driver — enumerate the cube collection and redrive every store
+# =============================================================================
+
+
+@dataclass
+class FleetReport:
+    """Aggregate outcome across the collection — one item id in exactly one bucket (or ``failed``)."""
+
+    derived: list[str] = field(default_factory=list)
+    already_current: list[str] = field(default_factory=list)
+    skipped_no_border_mask: list[str] = field(default_factory=list)
+    failed: list[tuple[str, str]] = field(default_factory=list)  # (item_id, error message)
+
+
+def run_fleet(
+    stac_api_url: str,
+    cube_collection: str,
+    *,
+    dry_run: bool = False,
+    only_item: str | None = None,
+    skip_tiles: tuple[str, ...] = (),
+) -> FleetReport:
+    """Redrive every cube in ``cube_collection``; one bad store is logged and skipped, never aborting.
+
+    Resumable: a store already at the current writer reports ``already_current`` (the marker) and is a
+    no-op, so a re-run only touches the stores that still need it.
+    """
+    fleet = FleetReport()
+    for item_id, href in list_cube_items(stac_api_url, cube_collection):
+        if only_item is not None and item_id != only_item:
+            continue
+        if any(tile in item_id for tile in skip_tiles):
+            continue
+        store = https_to_s3(href)  # the STAC asset is the https gateway URI; redrive needs s3://
+        try:
+            rpt = redrive_store(store, dry_run=dry_run)
+        except Exception as exc:  # noqa: BLE001 -- the fleet must continue past one unreadable store
+            log.exception("redrive failed for %s (%s)", item_id, store)
+            fleet.failed.append((item_id, str(exc)))
+            continue
+        if rpt.already_current:
+            fleet.already_current.append(item_id)
+        elif rpt.skipped_no_border_mask:
+            fleet.skipped_no_border_mask.append(item_id)
+        else:
+            fleet.derived.append(item_id)
+    return fleet
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Redrive S1 RTC cubes to the current data-model.")
+    parser.add_argument("--stac-api-url", required=True)
+    parser.add_argument("--cube-collection", required=True)
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_only",
+        help="enumerate items + resolved s3 store (STAC only, no S3 open); for laptop verification",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="report would-change; write nothing")
+    parser.add_argument("--item", default=None, help="redrive a single item id only")
+    parser.add_argument(
+        "--skip-tiles", nargs="*", default=[], help="tile substrings to exclude (e.g. hard-defect)"
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+
+    if args.list_only:
+        for item_id, href in list_cube_items(args.stac_api_url, args.cube_collection):
+            print(f"{item_id}\t{https_to_s3(href)}")  # noqa: T201 -- CLI output
+        return 0
+
+    fleet = run_fleet(
+        args.stac_api_url,
+        args.cube_collection,
+        dry_run=args.dry_run,
+        only_item=args.item,
+        skip_tiles=tuple(args.skip_tiles),
+    )
+    log.info(
+        "fleet %s: derived=%d already-current=%d skipped-no-border_mask=%d failed=%d",
+        "DRY-RUN" if args.dry_run else "RUN",
+        len(fleet.derived),
+        len(fleet.already_current),
+        len(fleet.skipped_no_border_mask),
+        len(fleet.failed),
+    )
+    for item_id, err in fleet.failed:
+        log.error("  FAILED %s: %s", item_id, err)
+    return 1 if fleet.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_s1_rtc_datamodel.py
+++ b/scripts/migrate_s1_rtc_datamodel.py
@@ -1,0 +1,102 @@
+"""In-place re-derive of legacy S1 RTC cubes to the current data-model — no re-download/reprocess.
+
+A legacy `sentinel-1-grd-rtc-staging` cube predates three writer fixes and the cron never self-heals
+existing stores (append doesn't recreate arrays):
+
+  - #201 — CF `_FillValue`/`standard_name`/`units` on vv/vh (and conditions);
+  - #202 — out-of-swath nodata stored as `NaN` (not `0.0`) so titiler masks it transparent;
+  - #203 — consolidated metadata on *every* orbit group, not just the last-ingested one.
+
+`redrive_store` reproduces, in place, exactly what a fresh re-ingest would write — by re-deriving each
+present orbit's vv/vh from the cube's own native band masked by its own `border_mask`, regenerating the
+overviews with the writer's `np.nanmean` downsample, restoring the CF attrs, and consolidating every
+orbit. The overview math is the data-model writer's own private `_downsample_2d`/`OVERVIEW_CHAIN`, so
+the result is value-identical to a re-ingest only at the pinned writer — `assert_writer_pinned()` (R5)
+refuses to run otherwise. See plan `the-migration-of-the-adaptive-wolf.md`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import eopf_geozarr
+import numpy as np
+import s1_store_meta
+import zarr
+from eopf_geozarr.conversion.s1_ingest import (
+    BACKSCATTER_CF_ATTRS,
+    OVERVIEW_CHAIN,
+    _downsample_2d,
+    consolidate_s1_store,
+)
+
+# Per-store completion marker (root attr): the migration is idempotent on the *store*, keyed by the
+# writer the re-derive ran against. Writes within a store are not atomic across objects, so a crash
+# mid-store leaves no marker and the store is re-derived in full on the next run (R2).
+MIGRATION_MARKER_KEY = "datamodel_migrated"
+
+
+@dataclass
+class RedriveReport:
+    """Outcome of re-deriving one store."""
+
+    store: str
+    orbits: list[str] = field(default_factory=list)
+    bands_rewritten: int = 0  # count of (orbit, band) pairs re-derived
+    already_current: bool = False  # marker already at the current writer → no-op
+
+
+def _marker_value() -> str:
+    """The writer revision the migration runs against (the completion-marker value)."""
+    return str(eopf_geozarr.__version__)
+
+
+def redrive_store(store_path: str | Path) -> RedriveReport:
+    """Re-derive one cube store in place to the current data-model; return what changed.
+
+    Idempotent via the per-store completion marker: a store already migrated at the current writer is
+    a no-op. Follows the consolidated-metadata dance (drop → reopen ``r+`` → re-derive → marker →
+    ``consolidate_s1_store``) so the writer sees fresh per-array metadata.
+    """
+    s1_store_meta.assert_writer_pinned()  # R5 — refuse to run on a drifted writer
+    store_path = Path(store_path)
+    report = RedriveReport(store=str(store_path))
+
+    root_ro = zarr.open_group(str(store_path), mode="r", zarr_format=3)
+    report.orbits = [name for name, _ in root_ro.groups()]
+    if dict(root_ro.attrs).get(MIGRATION_MARKER_KEY) == _marker_value():
+        report.already_current = True
+        return report
+
+    # C1: a consolidated store serves stale array metadata to writers — drop it before reopening r+.
+    s1_store_meta.drop_consolidated_metadata(store_path)
+    root = zarr.open_group(str(store_path), mode="r+", zarr_format=3)
+
+    overview_levels = OVERVIEW_CHAIN[1:]  # (level, parent, factor) below native r10m
+    for _orbit_name, orbit in root.groups():
+        r10m = orbit["r10m"]
+        border_mask = np.asarray(r10m["border_mask"][:])  # (T, y, x) — authoritative, untouched
+        for band in ("vv", "vh"):
+            native = np.asarray(r10m[band][:])  # (T, y, x); legacy: 0.0 out of swath
+            masked = np.empty_like(native, dtype="float32")
+            overviews: dict[str, list[np.ndarray]] = {lvl: [] for lvl, _, _ in overview_levels}
+            # Per time-slice: mask by border_mask (#202), then walk the writer's 2-D overview chain.
+            for t in range(native.shape[0]):
+                slc = np.where(border_mask[t] == 0, np.nan, native[t]).astype("float32")
+                masked[t] = slc
+                prev = slc
+                for level_name, _parent, factor in overview_levels:
+                    prev = _downsample_2d(prev, factor, "average")
+                    overviews[level_name].append(prev)
+            r10m[band][:] = masked
+            for level_name, slices in overviews.items():
+                orbit[level_name][band][:] = np.stack(slices)
+            for level_name, _parent, _factor in OVERVIEW_CHAIN:  # #201 CF attrs at every level
+                orbit[level_name][band].attrs.update(dict(BACKSCATTER_CF_ATTRS))
+            report.bands_rewritten += 1
+
+    root.attrs[MIGRATION_MARKER_KEY] = _marker_value()  # set before consolidation so it's captured
+    if report.orbits:
+        consolidate_s1_store(str(store_path), report.orbits[0])  # #203 — consolidates ALL orbits
+    return report

--- a/scripts/s1_store_meta.py
+++ b/scripts/s1_store_meta.py
@@ -11,6 +11,9 @@ writer is at the asserted behavior.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 # Pinned writer invariants (R5). `f882a3f` == eopf-geozarr 0.10.1; the float32 NaN fill is the S2-parity
 # encoding (data-model #201); the overview chain is the level/factor ladder the re-derive walks.
 PINNED_EOPF_GEOZARR_VERSION = "0.10.1"
@@ -50,3 +53,20 @@ def assert_writer_pinned() -> None:
             f"OVERVIEW_CHAIN changed: {list(s1_ingest.OVERVIEW_CHAIN)} != {EXPECTED_OVERVIEW_CHAIN}; "
             "overview levels/factors differ from the pinned writer."
         )
+
+
+def drop_consolidated_metadata(store_path: str | Path) -> int:
+    """Strip Zarr-v3 consolidated metadata from every group node of a local store; return the count.
+
+    Reopening a consolidated store ``mode="r+"`` serves the stale consolidated array metadata to
+    writers, so the migration must drop it before re-deriving (mirrors ``ingest_v1_s1_rtc.py``'s
+    pre-append drop). ``eopf_geozarr`` consolidates at the orbit-group level (not just the root), so
+    strip it from *every* group node; ``consolidate_s1_store`` re-consolidates at the end.
+    """
+    dropped = 0
+    for zj in Path(store_path).rglob("zarr.json"):
+        meta = json.loads(zj.read_text())
+        if meta.get("node_type") == "group" and meta.pop("consolidated_metadata", None) is not None:
+            zj.write_text(json.dumps(meta))
+            dropped += 1
+    return dropped

--- a/scripts/s1_store_meta.py
+++ b/scripts/s1_store_meta.py
@@ -1,0 +1,52 @@
+"""Low-level reuse helpers + the writer-pin guard for the S1 RTC datamodel migration.
+
+The migration (`migrate_s1_rtc_datamodel.py`) re-derives each legacy cube's vv/vh + overviews **in
+place** so they are value-identical to a fresh re-ingest. To stay value-identical it reuses the
+data-model writer's own constants and the private `_downsample_2d`/`OVERVIEW_CHAIN` rather than
+re-implementing the overview math. That reuse is only safe at the pinned writer (eopf-geozarr 0.10.1
+== data-model `f882a3f`, the live `v0.8.0-s1rtc-rc2`): a later bump could silently change overview
+values with no semver guard. `assert_writer_pinned()` is the R5 mitigation — refuse to run unless the
+writer is at the asserted behavior.
+"""
+
+from __future__ import annotations
+
+# Pinned writer invariants (R5). `f882a3f` == eopf-geozarr 0.10.1; the float32 NaN fill is the S2-parity
+# encoding (data-model #201); the overview chain is the level/factor ladder the re-derive walks.
+PINNED_EOPF_GEOZARR_VERSION = "0.10.1"
+EXPECTED_FLOAT32_NAN_FILL_VALUE = "AAAAAAAA+H8="
+EXPECTED_OVERVIEW_CHAIN = [
+    ("r10m", None, 1),
+    ("r20m", "r10m", 2),
+    ("r60m", "r20m", 3),
+    ("r120m", "r60m", 2),
+    ("r360m", "r120m", 3),
+    ("r720m", "r360m", 2),
+]
+
+
+def assert_writer_pinned() -> None:
+    """Refuse to run unless the data-model writer is at the pinned, value-identical behavior (R5).
+
+    Reads the live values at call time (not import time) so a drifted dependency is caught on every
+    run. Raises ``RuntimeError`` naming the invariant that drifted.
+    """
+    import eopf_geozarr
+    from eopf_geozarr.conversion import s1_ingest
+
+    if eopf_geozarr.__version__ != PINNED_EOPF_GEOZARR_VERSION:
+        raise RuntimeError(
+            f"eopf-geozarr {eopf_geozarr.__version__} != pinned {PINNED_EOPF_GEOZARR_VERSION} "
+            "(data-model f882a3f); the re-derive is only value-identical to a fresh re-ingest at the "
+            "pinned writer. Re-pin or re-validate before migrating."
+        )
+    if s1_ingest.FLOAT32_NAN_FILL_VALUE != EXPECTED_FLOAT32_NAN_FILL_VALUE:
+        raise RuntimeError(
+            f"FLOAT32_NAN_FILL_VALUE {s1_ingest.FLOAT32_NAN_FILL_VALUE!r} != expected "
+            f"{EXPECTED_FLOAT32_NAN_FILL_VALUE!r}; the float32 NaN encoding changed."
+        )
+    if list(s1_ingest.OVERVIEW_CHAIN) != EXPECTED_OVERVIEW_CHAIN:
+        raise RuntimeError(
+            f"OVERVIEW_CHAIN changed: {list(s1_ingest.OVERVIEW_CHAIN)} != {EXPECTED_OVERVIEW_CHAIN}; "
+            "overview levels/factors differ from the pinned writer."
+        )

--- a/scripts/s1_store_meta.py
+++ b/scripts/s1_store_meta.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import fsspec
+
 # Pinned writer invariants (R5). `f882a3f` == eopf-geozarr 0.10.1; the float32 NaN fill is the S2-parity
 # encoding (data-model #201); the overview chain is the level/factor ladder the re-derive walks.
 PINNED_EOPF_GEOZARR_VERSION = "0.10.1"
@@ -56,17 +58,39 @@ def assert_writer_pinned() -> None:
 
 
 def drop_consolidated_metadata(store_path: str | Path) -> int:
-    """Strip Zarr-v3 consolidated metadata from every group node of a local store; return the count.
+    """Strip Zarr-v3 consolidated metadata from every group node of a store; return the count.
 
     Reopening a consolidated store ``mode="r+"`` serves the stale consolidated array metadata to
     writers, so the migration must drop it before re-deriving (mirrors ``ingest_v1_s1_rtc.py``'s
     pre-append drop). ``eopf_geozarr`` consolidates at the orbit-group level (not just the root), so
     strip it from *every* group node; ``consolidate_s1_store`` re-consolidates at the end.
+
+    Filesystem-agnostic via fsspec so it works on the ``s3://`` stores the fleet driver passes, not
+    just local paths — a plain ``Path.rglob`` silently no-ops on ``s3://`` (C1).
     """
+    fs, root = fsspec.core.url_to_fs(str(store_path))
     dropped = 0
-    for zj in Path(store_path).rglob("zarr.json"):
-        meta = json.loads(zj.read_text())
+    for path in fs.find(root):  # all objects under the store; keep only the group zarr.json files
+        if path.rsplit("/", 1)[-1] != "zarr.json":
+            continue
+        meta = json.loads(fs.cat_file(path))
         if meta.get("node_type") == "group" and meta.pop("consolidated_metadata", None) is not None:
-            zj.write_text(json.dumps(meta))
+            fs.pipe_file(path, json.dumps(meta).encode())
             dropped += 1
     return dropped
+
+
+def set_root_attr(store_path: str | Path, key: str, value: str) -> None:
+    """Set one attribute on a store's ROOT group, preserving its ``consolidated_metadata`` (I1).
+
+    The migration writes its completion marker AFTER consolidation, so a crash before this leaves the
+    store consolidated-but-unmarked (re-derived next run) rather than marked-but-unconsolidated. Editing
+    the root ``zarr.json`` directly — rather than via a zarr handle, which can re-serialise the group
+    without the just-written consolidated metadata — guarantees that block survives. Filesystem-agnostic
+    (fsspec) for ``s3://`` parity with ``drop_consolidated_metadata``.
+    """
+    fs, root = fsspec.core.url_to_fs(str(store_path))
+    zj = f"{root}/zarr.json"
+    meta = json.loads(fs.cat_file(zj))
+    meta.setdefault("attributes", {})[key] = value
+    fs.pipe_file(zj, json.dumps(meta).encode())

--- a/tests/unit/test_migrate_s1_rtc_datamodel.py
+++ b/tests/unit/test_migrate_s1_rtc_datamodel.py
@@ -1,0 +1,200 @@
+"""Unit tests for scripts/migrate_s1_rtc_datamodel.py — `redrive_store` core (Task 1, slice 2).
+
+Oracle = the data-model writer itself (criterion 2 "value-identical to a fresh re-ingest"): build a
+**fresh** cube via `ingest_s1tiling_acquisition`, **de-migrate** it back to a legacy cube (vv/vh nodata
+as 0.0, stale overviews, no CF `_FillValue`, un-consolidated), then `redrive_store` it and assert the
+result reproduces the fresh cube exactly (NaN-aware values + CF attrs + standalone-consolidated orbits).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio
+import zarr
+from eopf_geozarr.conversion.s1_ingest import (
+    BACKSCATTER_CF_ATTRS,
+    OVERVIEW_CHAIN,
+    consolidate_s1_store,
+    ingest_s1tiling_acquisition,
+)
+from rasterio.transform import from_bounds
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import migrate_s1_rtc_datamodel as migrate  # noqa: E402
+import s1_store_meta  # noqa: E402
+
+# --- synthetic-GeoTIFF fixture constants (mirrors data-model tests/test_s1_rtc_ingest.py) ---
+SIZE = 36
+CRS = "EPSG:32633"
+TRANSFORM = from_bounds(500000.0, 4997440.0, 502560.0, 5000000.0, SIZE, SIZE)
+BORDER_ROWS = 10  # rows 0..9 are out-of-swath (border_mask == 0)
+
+
+def _tags(stamp_compact: str, orbit_num: str) -> dict[str, str]:
+    dt = (
+        f"{stamp_compact[0:4]}:{stamp_compact[4:6]}:{stamp_compact[6:8]}"
+        f"T{stamp_compact[9:11]}:{stamp_compact[11:13]}:{stamp_compact[13:15]}Z"
+    )
+    return {
+        "ACQUISITION_DATETIME": dt,
+        "ORBIT_NUMBER": orbit_num,
+        "RELATIVE_ORBIT_NUMBER": "037",
+        "FLYING_UNIT_CODE": "S1A",
+        "CALIBRATION": "gamma_naught",
+    }
+
+
+def _write_geotiff(path: Path, data: np.ndarray, tags: dict[str, str]) -> None:
+    with rasterio.open(
+        str(path),
+        "w",
+        driver="GTiff",
+        height=data.shape[0],
+        width=data.shape[1],
+        count=1,
+        dtype=data.dtype,
+        crs=CRS,
+        transform=TRANSFORM,
+    ) as dst:
+        dst.update_tags(**tags)
+        dst.write(data, 1)
+
+
+def _ingest_one(
+    tmp: Path, store: Path, orbit_dir: str, stamp: str, orbit_num: str, seed: int
+) -> None:
+    """Write vv/vh/mask GeoTIFFs for one acquisition and append it to the store via the writer."""
+    rng = np.random.default_rng(seed)
+    tag = _tags(stamp, orbit_num)
+    code = "ASC" if orbit_dir == "ascending" else "DES"
+    mask = np.ones((SIZE, SIZE), dtype=np.uint8)
+    mask[:BORDER_ROWS, :] = 0
+    paths = {}
+    for pol, lo, hi in (("vv", 0.0, 1.0), ("vh", 0.0, 0.5)):
+        arr = rng.uniform(lo, hi, (SIZE, SIZE)).astype(np.float32)
+        p = tmp / f"s1a_32TQM_{pol}_{code}_037_{stamp}_GammaNaughtRTC.tif"
+        _write_geotiff(p, arr, tag)
+        paths[pol] = p
+    mpath = tmp / f"mask_{code}_{stamp}.tif"
+    _write_geotiff(mpath, mask, tag)
+    ingest_s1tiling_acquisition(paths["vv"], paths["vh"], mpath, str(store), orbit_dir)
+
+
+@pytest.fixture
+def fresh_cube(tmp_path: Path) -> Path:
+    """A fresh new-datamodel cube: ascending (2 acquisitions) + descending (1), consolidated."""
+    store = tmp_path / "s1-rtc-36TEST.zarr"
+    gt = tmp_path / "gt"
+    gt.mkdir()
+    _ingest_one(gt, store, "ascending", "20230115t061234", "47001", seed=1)
+    _ingest_one(gt, store, "ascending", "20230127t061235", "47177", seed=2)
+    _ingest_one(gt, store, "descending", "20230120t180511", "47090", seed=3)
+    consolidate_s1_store(str(store), "ascending")
+    return store
+
+
+def _all_levels() -> list[str]:
+    return [lvl for lvl, _, _ in OVERVIEW_CHAIN]
+
+
+def _snapshot_bands(store: Path) -> dict[tuple[str, str, str], np.ndarray]:
+    """{(orbit, level, band): values} for vv/vh across every orbit/level (read un-consolidated)."""
+    root = zarr.open_group(str(store), mode="r", zarr_format=3)
+    out: dict[tuple[str, str, str], np.ndarray] = {}
+    for orbit, og in root.groups():
+        for level in _all_levels():
+            for band in ("vv", "vh"):
+                out[(orbit, level, band)] = og[level][band][:]
+    return out
+
+
+def _demigrate(store: Path) -> None:
+    """Turn a fresh cube into a legacy one: nodata back to 0.0 at native, ZERO the overviews, strip
+    the CF backscatter attrs, drop consolidated metadata. border_mask / time / coords untouched."""
+    s1_store_meta.drop_consolidated_metadata(store)
+    root = zarr.open_group(str(store), mode="r+", zarr_format=3)
+    for _orbit, og in root.groups():
+        for level in _all_levels():
+            for band in ("vv", "vh"):
+                arr = og[level][band]
+                if level == "r10m":
+                    arr[:] = np.nan_to_num(arr[:], nan=0.0)  # legacy stored 0.0 out of swath
+                else:
+                    arr[:] = 0.0  # stale overviews — redrive must recompute these
+                for k in ("_FillValue", "standard_name", "units"):
+                    arr.attrs.pop(k, None)
+
+
+def test_redrive_reproduces_the_fresh_writer_output(fresh_cube: Path) -> None:
+    """criterion 2: migrated vv/vh values equal a fresh re-ingest at every orbit/level (NaN-aware)."""
+    golden = _snapshot_bands(fresh_cube)
+    _demigrate(fresh_cube)
+
+    report = migrate.redrive_store(fresh_cube)
+
+    assert set(report.orbits) == {"ascending", "descending"}
+    assert report.already_current is False
+    migrated = _snapshot_bands(fresh_cube)
+    for key, expected in golden.items():
+        np.testing.assert_array_equal(migrated[key], expected, err_msg=f"mismatch at {key}")
+
+
+def test_native_nan_iff_border_mask_zero(fresh_cube: Path) -> None:
+    """criterion 1 (native level): vv/vh are NaN exactly where border_mask == 0, valid pixels kept."""
+    _demigrate(fresh_cube)
+    migrate.redrive_store(fresh_cube)
+
+    root = zarr.open_group(str(fresh_cube), mode="r", zarr_format=3)
+    for _orbit, og in root.groups():
+        r10m = og["r10m"]
+        bm = r10m["border_mask"][:]
+        for band in ("vv", "vh"):
+            data = r10m[band][:]
+            assert np.all(np.isnan(data) == (bm == 0)), f"{band}: NaN pattern != border_mask"
+
+
+def test_sets_cf_attrs_and_leaves_border_mask_untouched(fresh_cube: Path) -> None:
+    """criterion 3 (vv/vh): backscatter CF attrs restored at every level; border_mask unchanged."""
+    bm_before = {
+        orbit: og["r10m"]["border_mask"][:]
+        for orbit, og in zarr.open_group(str(fresh_cube), mode="r", zarr_format=3).groups()
+    }
+    _demigrate(fresh_cube)
+    migrate.redrive_store(fresh_cube)
+
+    root = zarr.open_group(str(fresh_cube), mode="r", zarr_format=3)
+    for orbit, og in root.groups():
+        for level in _all_levels():
+            for band in ("vv", "vh"):
+                attrs = dict(og[level][band].attrs)
+                for k, v in BACKSCATTER_CF_ATTRS.items():
+                    assert attrs.get(k) == v, f"{orbit}/{level}/{band} missing CF attr {k}"
+        np.testing.assert_array_equal(og["r10m"]["border_mask"][:], bm_before[orbit])
+
+
+def test_both_orbits_consolidated_standalone(fresh_cube: Path) -> None:
+    """criterion 4: every orbit group is consolidated, openable standalone (not via the root)."""
+    _demigrate(fresh_cube)
+    migrate.redrive_store(fresh_cube)
+
+    for orbit in ("ascending", "descending"):
+        meta = (fresh_cube / orbit / "zarr.json").read_text()
+        assert "consolidated_metadata" in meta, f"{orbit} not standalone-consolidated"
+
+
+def test_idempotent_second_run_is_a_noop(fresh_cube: Path) -> None:
+    """criterion 5: a second redrive on a current store rewrites nothing (completion marker)."""
+    _demigrate(fresh_cube)
+    migrate.redrive_store(fresh_cube)
+    after_first = _snapshot_bands(fresh_cube)
+
+    report2 = migrate.redrive_store(fresh_cube)
+
+    assert report2.already_current is True
+    for key, vals in _snapshot_bands(fresh_cube).items():
+        np.testing.assert_array_equal(vals, after_first[key])

--- a/tests/unit/test_migrate_s1_rtc_datamodel.py
+++ b/tests/unit/test_migrate_s1_rtc_datamodel.py
@@ -8,6 +8,7 @@ result reproduces the fresh cube exactly (NaN-aware values + CF attrs + standalo
 
 from __future__ import annotations
 
+import shutil
 import sys
 from pathlib import Path
 
@@ -113,9 +114,13 @@ def _snapshot_bands(store: Path) -> dict[tuple[str, str, str], np.ndarray]:
     return out
 
 
-def _demigrate(store: Path) -> None:
+def _demigrate(store: Path, *, mask_native: bool = True) -> None:
     """Turn a fresh cube into a legacy one: nodata back to 0.0 at native, ZERO the overviews, strip
-    the CF backscatter attrs, drop consolidated metadata. border_mask / time / coords untouched."""
+    the CF backscatter attrs, drop consolidated metadata. border_mask / time / coords untouched.
+
+    ``mask_native=False`` leaves the native level already NaN-masked (overviews still stale, no marker):
+    a cube left half-migrated by a crash between native and overviews — redrive must re-derive it.
+    """
     s1_store_meta.drop_consolidated_metadata(store)
     root = zarr.open_group(str(store), mode="r+", zarr_format=3)
     for _orbit, og in root.groups():
@@ -123,7 +128,8 @@ def _demigrate(store: Path) -> None:
             for band in ("vv", "vh"):
                 arr = og[level][band]
                 if level == "r10m":
-                    arr[:] = np.nan_to_num(arr[:], nan=0.0)  # legacy stored 0.0 out of swath
+                    if mask_native:
+                        arr[:] = np.nan_to_num(arr[:], nan=0.0)  # legacy stored 0.0 out of swath
                 else:
                     arr[:] = 0.0  # stale overviews — redrive must recompute these
                 for k in ("_FillValue", "standard_name", "units"):
@@ -198,3 +204,38 @@ def test_idempotent_second_run_is_a_noop(fresh_cube: Path) -> None:
     assert report2.already_current is True
     for key, vals in _snapshot_bands(fresh_cube).items():
         np.testing.assert_array_equal(vals, after_first[key])
+
+
+def test_crash_safety_redrives_a_half_migrated_store(fresh_cube: Path) -> None:
+    """criterion 6: native already masked but overviews stale + no marker → still fully re-derived.
+
+    "native is NaN-masked" is not a safe skip key (a crash between native and overviews leaves stale
+    overviews); only the completion marker is. Redrive must reproduce the writer regardless.
+    """
+    golden = _snapshot_bands(fresh_cube)
+    _demigrate(fresh_cube, mask_native=False)  # native left masked, overviews zeroed, no marker
+
+    report = migrate.redrive_store(fresh_cube)
+
+    assert report.already_current is False
+    migrated = _snapshot_bands(fresh_cube)
+    for key, expected in golden.items():
+        np.testing.assert_array_equal(migrated[key], expected, err_msg=f"mismatch at {key}")
+
+
+def test_missing_border_mask_is_skipped_not_crashed(fresh_cube: Path) -> None:
+    """criterion 7 (R6): an orbit lacking border_mask is flagged + skipped; the store is not marked."""
+    _demigrate(fresh_cube)
+    s1_store_meta.drop_consolidated_metadata(
+        fresh_cube
+    )  # so the member listing reflects the rmtree
+    shutil.rmtree(fresh_cube / "descending" / "r10m" / "border_mask")
+
+    report = migrate.redrive_store(fresh_cube)  # must not raise
+
+    assert report.skipped_no_border_mask == ["descending"]
+    # the store stays un-marked → a re-run still re-derives (never recorded as complete)
+    assert migrate.redrive_store(fresh_cube).already_current is False
+    # the present-border_mask orbit was still re-derived (CF attrs restored)
+    asc_vv = zarr.open_group(str(fresh_cube), mode="r", zarr_format=3)["ascending"]["r10m"]["vv"]
+    assert dict(asc_vv.attrs).get("_FillValue") == BACKSCATTER_CF_ATTRS["_FillValue"]

--- a/tests/unit/test_migrate_s1_rtc_datamodel.py
+++ b/tests/unit/test_migrate_s1_rtc_datamodel.py
@@ -239,3 +239,36 @@ def test_missing_border_mask_is_skipped_not_crashed(fresh_cube: Path) -> None:
     # the present-border_mask orbit was still re-derived (CF attrs restored)
     asc_vv = zarr.open_group(str(fresh_cube), mode="r", zarr_format=3)["ascending"]["r10m"]["vv"]
     assert dict(asc_vv.attrs).get("_FillValue") == BACKSCATTER_CF_ATTRS["_FillValue"]
+
+
+def _add_legacy_conditions(store: Path, orbit_name: str, suffix: str = "037") -> None:
+    """Add a legacy `conditions` group: gamma_area/lia 2-D float32 data arrays WITHOUT `_FillValue`,
+    plus a 1-D float64 `y` coordinate (which must NOT receive `_FillValue`)."""
+    s1_store_meta.drop_consolidated_metadata(store)
+    cond = zarr.open_group(str(store), mode="r+", zarr_format=3)[orbit_name].create_group(
+        "conditions"
+    )
+    rng = np.random.default_rng(99)
+    for name in (f"gamma_area_{suffix}", f"lia_{suffix}"):
+        arr = cond.create_array(
+            name, shape=(SIZE, SIZE), dtype="float32", dimension_names=["y", "x"]
+        )
+        arr[:, :] = rng.uniform(0.0, 10.0, (SIZE, SIZE)).astype(np.float32)  # legacy: no _FillValue
+    ycoord = cond.create_array("y", shape=(SIZE,), dtype="float64", dimension_names=["y"])
+    ycoord[:] = np.arange(SIZE, dtype="float64")
+
+
+def test_conditions_get_fill_value_attr_only(fresh_cube: Path) -> None:
+    """Task 1b: redrive sets `_FillValue` on conditions DATA arrays (2-D float) without touching their
+    values, and leaves coordinate arrays (1-D) alone."""
+    _add_legacy_conditions(fresh_cube, "ascending")
+    cond_ro = zarr.open_group(str(fresh_cube), mode="r", zarr_format=3)["ascending"]["conditions"]
+    before = {name: arr[:] for name, arr in cond_ro.arrays()}
+
+    migrate.redrive_store(fresh_cube)
+
+    cond = zarr.open_group(str(fresh_cube), mode="r", zarr_format=3)["ascending"]["conditions"]
+    for name in ("gamma_area_037", "lia_037"):
+        assert dict(cond[name].attrs).get("_FillValue") == BACKSCATTER_CF_ATTRS["_FillValue"]
+        np.testing.assert_array_equal(cond[name][:], before[name])  # data unchanged (R4: attr only)
+    assert "_FillValue" not in dict(cond["y"].attrs)  # 1-D coord must be left alone

--- a/tests/unit/test_migrate_s1_rtc_datamodel.py
+++ b/tests/unit/test_migrate_s1_rtc_datamodel.py
@@ -272,3 +272,18 @@ def test_conditions_get_fill_value_attr_only(fresh_cube: Path) -> None:
         assert dict(cond[name].attrs).get("_FillValue") == BACKSCATTER_CF_ATTRS["_FillValue"]
         np.testing.assert_array_equal(cond[name][:], before[name])  # data unchanged (R4: attr only)
     assert "_FillValue" not in dict(cond["y"].attrs)  # 1-D coord must be left alone
+
+
+def test_dry_run_reports_without_writing(fresh_cube: Path) -> None:
+    """Task 2: `dry_run=True` reports the plan (orbits, not-already-current) and writes nothing."""
+    _demigrate(fresh_cube)
+    before = _snapshot_bands(fresh_cube)
+
+    report = migrate.redrive_store(fresh_cube, dry_run=True)
+
+    assert report.already_current is False
+    assert set(report.orbits) == {"ascending", "descending"}
+    for key, vals in _snapshot_bands(fresh_cube).items():  # nothing re-derived
+        np.testing.assert_array_equal(vals, before[key])
+    root = zarr.open_group(str(fresh_cube), mode="r", zarr_format=3)
+    assert migrate.MIGRATION_MARKER_KEY not in dict(root.attrs)  # not marked complete

--- a/tests/unit/test_migrate_s1_rtc_datamodel.py
+++ b/tests/unit/test_migrate_s1_rtc_datamodel.py
@@ -184,13 +184,19 @@ def test_sets_cf_attrs_and_leaves_border_mask_untouched(fresh_cube: Path) -> Non
 
 
 def test_both_orbits_consolidated_standalone(fresh_cube: Path) -> None:
-    """criterion 4: every orbit group is consolidated, openable standalone (not via the root)."""
+    """criterion 4: every orbit group is consolidated, openable standalone (not via the root).
+
+    Also asserts the completion marker COEXISTS with consolidation (I1) — the marker is written after
+    consolidation via set_root_attr, which must not clobber the consolidated metadata.
+    """
     _demigrate(fresh_cube)
     migrate.redrive_store(fresh_cube)
 
     for orbit in ("ascending", "descending"):
         meta = (fresh_cube / orbit / "zarr.json").read_text()
         assert "consolidated_metadata" in meta, f"{orbit} not standalone-consolidated"
+    root = zarr.open_group(str(fresh_cube), mode="r", zarr_format=3)
+    assert dict(root.attrs).get(migrate.MIGRATION_MARKER_KEY) is not None  # marker + consolidation
 
 
 def test_idempotent_second_run_is_a_noop(fresh_cube: Path) -> None:

--- a/tests/unit/test_migrate_s1_rtc_fleet.py
+++ b/tests/unit/test_migrate_s1_rtc_fleet.py
@@ -1,0 +1,137 @@
+"""Unit tests for the S1 RTC migration fleet driver (`run_fleet`) — Task 2.
+
+The driver's I/O boundaries (`list_cube_items` STAC enumeration, `redrive_store` per-store re-derive)
+are patched, so these tests cover only the orchestration: href→s3 resolution, continue-on-error,
+bucketing (derived / already-current / skipped / failed), dry-run pass-through, and the
+``--item``/``--skip-tiles`` filters. The real S3/STAC I/O is verified in-cluster (plan Task 2 Verify).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import migrate_s1_rtc_datamodel as migrate  # noqa: E402
+
+_GATEWAY = "https://s3.explorer.eopf.copernicus.eu"
+_PREFIX = "esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging"
+
+
+def _href(tile: str) -> str:
+    return f"{_GATEWAY}/{_PREFIX}/s1-rtc-{tile}.zarr"
+
+
+_ITEMS = [
+    ("s1-rtc-30TUM", _href("30TUM")),
+    ("s1-rtc-30TWQ", _href("30TWQ")),
+    ("s1-rtc-31TDG", _href("31TDG")),
+]
+
+
+def _patch_list(monkeypatch, items=_ITEMS) -> None:
+    monkeypatch.setattr(migrate, "list_cube_items", lambda _api, _coll: list(items))
+
+
+def test_continues_past_a_failing_store_and_records_it(monkeypatch) -> None:
+    _patch_list(monkeypatch)
+
+    def fake_redrive(store, *, dry_run=False):
+        if "30TWQ" in store:
+            raise RuntimeError("unreadable store")
+        return migrate.RedriveReport(store=store, orbits=["ascending"])
+
+    monkeypatch.setattr(migrate, "redrive_store", fake_redrive)
+
+    fleet = migrate.run_fleet("http://stac", "coll")
+
+    assert fleet.failed == [("s1-rtc-30TWQ", "unreadable store")]
+    assert set(fleet.derived) == {"s1-rtc-30TUM", "s1-rtc-31TDG"}  # the run did not abort
+
+
+def test_buckets_derived_already_current_and_skipped(monkeypatch) -> None:
+    _patch_list(monkeypatch)
+
+    def fake_redrive(store, *, dry_run=False):
+        if "30TUM" in store:
+            return migrate.RedriveReport(store=store, already_current=True)
+        if "30TWQ" in store:
+            return migrate.RedriveReport(store=store, skipped_no_border_mask=["descending"])
+        return migrate.RedriveReport(store=store, orbits=["ascending"])
+
+    monkeypatch.setattr(migrate, "redrive_store", fake_redrive)
+
+    fleet = migrate.run_fleet("http://stac", "coll")
+
+    assert fleet.already_current == ["s1-rtc-30TUM"]
+    assert fleet.skipped_no_border_mask == ["s1-rtc-30TWQ"]
+    assert fleet.derived == ["s1-rtc-31TDG"]
+    assert fleet.failed == []
+
+
+def test_resolves_each_href_to_s3_before_redriving(monkeypatch) -> None:
+    _patch_list(monkeypatch)
+    seen: list[str] = []
+
+    def fake_redrive(store, *, dry_run=False):
+        seen.append(store)
+        return migrate.RedriveReport(store=store, orbits=["ascending"])
+
+    monkeypatch.setattr(migrate, "redrive_store", fake_redrive)
+
+    migrate.run_fleet("http://stac", "coll")
+
+    assert seen[0] == f"s3://{_PREFIX}/s1-rtc-30TUM.zarr"
+    assert all(s.startswith("s3://") for s in seen)
+
+
+def test_dry_run_threads_through_to_every_store(monkeypatch) -> None:
+    _patch_list(monkeypatch)
+    seen_dry: list[bool] = []
+
+    def fake_redrive(store, *, dry_run=False):
+        seen_dry.append(dry_run)
+        return migrate.RedriveReport(store=store, orbits=["ascending"])
+
+    monkeypatch.setattr(migrate, "redrive_store", fake_redrive)
+
+    migrate.run_fleet("http://stac", "coll", dry_run=True)
+
+    assert seen_dry == [True, True, True]
+
+
+def test_only_item_and_skip_tiles_filter_the_fleet(monkeypatch) -> None:
+    _patch_list(monkeypatch)
+    seen: list[str] = []
+
+    def fake_redrive(store, *, dry_run=False):
+        seen.append(store)
+        return migrate.RedriveReport(store=store, orbits=["ascending"])
+
+    monkeypatch.setattr(migrate, "redrive_store", fake_redrive)
+
+    only = migrate.run_fleet("http://stac", "coll", only_item="s1-rtc-31TDG")
+    assert only.derived == ["s1-rtc-31TDG"] and len(seen) == 1
+
+    seen.clear()
+    skipped = migrate.run_fleet("http://stac", "coll", skip_tiles=("30TWQ",))
+    assert {"s1-rtc-30TUM", "s1-rtc-31TDG"} == set(skipped.derived)
+    assert all("30TWQ" not in s for s in seen)  # the skipped tile was never opened
+
+
+def test_main_list_enumerates_without_opening_stores(monkeypatch, capsys) -> None:
+    """`--list` prints item id + resolved s3 store from STAC only — never calls redrive_store."""
+    _patch_list(monkeypatch)
+
+    def _boom(*_a, **_k):  # redrive must not be touched in --list mode
+        raise AssertionError("redrive_store must not be called for --list")
+
+    monkeypatch.setattr(migrate, "redrive_store", _boom)
+
+    rc = migrate.main(["--stac-api-url", "http://stac", "--cube-collection", "coll", "--list"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"s1-rtc-30TUM\ts3://{_PREFIX}/s1-rtc-30TUM.zarr" in out
+    assert out.count("\n") == len(_ITEMS)

--- a/tests/unit/test_s1_store_meta.py
+++ b/tests/unit/test_s1_store_meta.py
@@ -1,0 +1,46 @@
+"""Unit tests for scripts/s1_store_meta.py — the S1 RTC datamodel-migration low-level helpers.
+
+Slice 1 covers the R5 writer-pin guard (`assert_writer_pinned`): the migration re-derives vv/vh +
+overviews with the data-model writer's private `_downsample_2d`/`OVERVIEW_CHAIN`, so it must refuse to
+run unless the writer is at the pinned, value-identical behavior (eopf-geozarr 0.10.1 == data-model
+f882a3f).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import eopf_geozarr
+import pytest
+from eopf_geozarr.conversion import s1_ingest
+
+# Load the script module by path (scripts/ is not an importable package).
+_SPEC = importlib.util.spec_from_file_location(
+    "s1_store_meta", Path(__file__).resolve().parents[2] / "scripts" / "s1_store_meta.py"
+)
+s1_store_meta = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(s1_store_meta)  # type: ignore[union-attr]
+
+
+def test_passes_on_the_pinned_env() -> None:
+    """The worktree pins f882a3f / 0.10.1, so the guard must accept it (no raise)."""
+    s1_store_meta.assert_writer_pinned()
+
+
+def test_rejects_wrong_eopf_geozarr_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(eopf_geozarr, "__version__", "9.9.9")
+    with pytest.raises(RuntimeError, match="eopf-geozarr"):
+        s1_store_meta.assert_writer_pinned()
+
+
+def test_rejects_changed_float32_nan_fill_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(s1_ingest, "FLOAT32_NAN_FILL_VALUE", "WRONG==")
+    with pytest.raises(RuntimeError, match="FLOAT32_NAN_FILL_VALUE"):
+        s1_store_meta.assert_writer_pinned()
+
+
+def test_rejects_changed_overview_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(s1_ingest, "OVERVIEW_CHAIN", s1_ingest.OVERVIEW_CHAIN[:-1])
+    with pytest.raises(RuntimeError, match="OVERVIEW_CHAIN"):
+        s1_store_meta.assert_writer_pinned()

--- a/tests/unit/test_s1_store_meta.py
+++ b/tests/unit/test_s1_store_meta.py
@@ -44,3 +44,54 @@ def test_rejects_changed_overview_chain(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(s1_ingest, "OVERVIEW_CHAIN", s1_ingest.OVERVIEW_CHAIN[:-1])
     with pytest.raises(RuntimeError, match="OVERVIEW_CHAIN"):
         s1_store_meta.assert_writer_pinned()
+
+
+def test_drop_consolidated_metadata_works_on_a_remote_scheme() -> None:
+    """C1: the real fleet run passes `s3://` stores — the drop must be filesystem-agnostic, not local
+    `Path.rglob` (which silently no-ops on `s3://`). Proven here with fsspec's in-memory scheme, which
+    routes through the same `url_to_fs` path as `s3://`."""
+    import json
+
+    import fsspec
+
+    fs = fsspec.filesystem("memory")
+    base = "/drop-remote-test.zarr"
+    grp = lambda extra: json.dumps({"zarr_format": 3, "node_type": "group", **extra}).encode()  # noqa: E731
+    fs.pipe_file(f"{base}/zarr.json", grp({"consolidated_metadata": {"a": 1}}))
+    fs.pipe_file(f"{base}/ascending/zarr.json", grp({"consolidated_metadata": {"b": 2}}))
+    fs.pipe_file(f"{base}/ascending/r10m/vv/zarr.json", json.dumps({"node_type": "array"}).encode())
+
+    dropped = s1_store_meta.drop_consolidated_metadata(f"memory://{base}")
+
+    assert dropped == 2  # both group nodes stripped; the array node untouched
+    assert "consolidated_metadata" not in json.loads(fs.cat_file(f"{base}/zarr.json"))
+    assert "consolidated_metadata" not in json.loads(fs.cat_file(f"{base}/ascending/zarr.json"))
+
+
+def test_set_root_attr_preserves_consolidated_metadata() -> None:
+    """I1: the completion marker is written AFTER consolidation; set_root_attr must add it to the root
+    group's attributes WITHOUT clobbering the consolidated_metadata block just written."""
+    import json
+
+    import fsspec
+
+    fs = fsspec.filesystem("memory")
+    base = "/set-attr-test.zarr"
+    fs.pipe_file(
+        f"{base}/zarr.json",
+        json.dumps(
+            {
+                "zarr_format": 3,
+                "node_type": "group",
+                "attributes": {"existing": 1},
+                "consolidated_metadata": {"kind": "inline"},
+            }
+        ).encode(),
+    )
+
+    s1_store_meta.set_root_attr(f"memory://{base}", "datamodel_migrated", "0.10.1")
+
+    meta = json.loads(fs.cat_file(f"{base}/zarr.json"))
+    assert meta["attributes"]["datamodel_migrated"] == "0.10.1"
+    assert meta["attributes"]["existing"] == 1  # pre-existing attrs preserved
+    assert meta["consolidated_metadata"] == {"kind": "inline"}  # NOT clobbered (I1)


### PR DESCRIPTION
## What

The **code** for the in-place S1 RTC legacy→new-datamodel migration: re-derive each existing
`sentinel-1-grd-rtc-staging` cube to the current writer **without re-download or reprocessing**, by
re-masking the cube's own native vv/vh from its own `border_mask` and regenerating overviews with the
writer's `np.nanmean` downsample. Brings legacy cubes up to three data-model fixes the cron never
self-heals (append doesn't recreate arrays):

- **EOPF-Explorer/data-model#201** — CF `_FillValue`/`standard_name`/`units` on vv/vh (+ `_FillValue` on conditions)
- **EOPF-Explorer/data-model#202** — out-of-swath nodata stored as `NaN` (not `0.0`) → titiler masks it transparent
- **EOPF-Explorer/data-model#203** — consolidated metadata on **every** orbit group, not just the last-ingested one

Plan: `~/.claude/plans/the-migration-of-the-adaptive-wolf.md` (Tasks 1, 1b, 2).

## What's in this PR

| File | What |
|---|---|
| `scripts/migrate_s1_rtc_datamodel.py` | `redrive_store(store, *, dry_run)` (per-store re-derive) + `run_fleet`/`main` (collection driver) |
| `scripts/s1_store_meta.py` | `assert_writer_pinned` (R5 guard), `drop_consolidated_metadata`, `set_root_attr` (all fsspec-based) |
| `tests/unit/test_*` | 21 unit tests |

**`redrive_store`** — per present orbit: drop consolidated → reopen `r+` → mask vv/vh native by
`border_mask` and stream overviews **one time-slice at a time** → restore CF attrs → consolidate every
orbit → write a per-store completion marker. Idempotent (marker), crash-safe (marker is the only skip
key), skips + flags an orbit lacking `border_mask` rather than crashing.

**`run_fleet`** — enumerate the cube collection, resolve each `zarr-store` href → `s3://`, redrive each
in a per-store try/except (one bad store is logged + recorded, never aborts the fleet); resumable via the
marker. CLI: `--list` / `--dry-run` / `--item` / `--skip-tiles`.

## Reuse / pinning

The overview math is the data-model writer's own private `_downsample_2d`/`OVERVIEW_CHAIN` (R5 decision:
pin + assert, single-repo — no data-model PR). `assert_writer_pinned` refuses to run unless eopf-geozarr
is at the pinned **`0.10.1` (== data-model `f882a3f`, the live `v0.8.0-s1rtc-rc2`)** — version + float32
NaN fill + overview chain — so a dependency bump can't silently shift overview values.

## Verification

**Oracle = the writer itself.** The parity test builds a fresh cube via `ingest_s1tiling_acquisition`,
de-migrates it to legacy state (nodata→0.0, zeroed overviews, no `_FillValue`, un-consolidated), runs
`redrive_store`, and asserts it is **value-identical** to the fresh writer output across every
orbit/level. Plus: NaN⟺`border_mask`, CF attrs + untouched `border_mask`, standalone-consolidated orbits,
marker idempotency, crash-safety, missing-`border_mask` skip, conditions `_FillValue`, and the fleet
driver (continue-on-error / href→s3 / dry-run / filters) with mocked I/O.

**Full unit suite: 549 passed**, ruff + mypy clean.

A five-axis review of this branch found and this PR fixes: **C1** make the metadata ops fsspec-based so
they work on the real `s3://` stores (a `Path.rglob` silently no-opped on `s3://`); **I1** write the
marker *after* consolidation (crash-safety); **I2** stream per-time-slice to bound memory on real
10980²×T tiles.

## NOT in this PR (remaining plan work — needs the cluster)

This is the migration **code**, not the executed migration. Still to do, all gated on cluster creds /
the cron being suspended:

- **Task 3** — rollback/backup (S3-versioning check on `esa-zarr-sentinel-explorer-fra`)
- **Task 4** — one-off Argo `Workflow` + RC image + SealedSecret
- **Checkpoint A** — cron-suspended, in-cluster control-tile derive + value-parity vs a same-tile
  re-ingest; this is also where the C1 (real-S3 drop/write) and I2 (real-tile peak RSS) paths get
  exercised — both structurally untestable in the local unit suite
- **Task 5** — staged fleet run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
