### PR TITLE
feat(s1-migration): rollback/backup safety + one-off Argo runner (Tasks 3/4)

### DIFF
--- a/deploy/migrate-s1-rtc-datamodel-workflow.yaml
+++ b/deploy/migrate-s1-rtc-datamodel-workflow.yaml
@@ -1,0 +1,121 @@
+# One-off Argo Workflow: in-place S1 RTC legacy→datamodel cube migration (plan Task 4).
+#
+# Runs scripts/migrate_s1_rtc_datamodel.py against the staging cube collection in one container (no
+# fan-out — 104 small-ish stores, driver loops internally with per-store continue-on-error). The cube
+# bucket is owned by the eopfexplorer account; creds come from the in-cluster `geozarr-s3-credentials`
+# SealedSecret (NO literals here), endpoint is OVH `de`.
+#
+# Usage (the s1rtc cron MUST be suspended first — C2 concurrency):
+#   1. DRY-RUN (default, writes nothing):
+#        argo submit -n devseed-staging deploy/migrate-s1-rtc-datamodel-workflow.yaml \
+#          -p pipeline_image_version=<RC-tag>
+#   2. REAL run (only after the dry-run looks right):
+#        argo submit -n devseed-staging deploy/migrate-s1-rtc-datamodel-workflow.yaml \
+#          -p pipeline_image_version=<RC-tag> -p dry_run=false
+#      The driver's pre-flight refuses a real run unless the bucket has S3 versioning OR a
+#      `backup_prefix` is given (C2 rollback safety).
+#   3. ROLLBACK (only if a backup_prefix was used): -p rollback=true -p backup_prefix=<s3://…>
+#
+# pipeline_image_version MUST be an RC build that contains scripts/migrate_s1_rtc_datamodel.py
+# (verify: `docker run --rm <image> python /app/scripts/migrate_s1_rtc_datamodel.py --help`). The live
+# v0.8.0-s1rtc-rc2 predates this script — cut a new RC from feat--s1_grd_phase5 after the migration
+# code merges.
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: migrate-s1-rtc-datamodel-
+  namespace: devseed-staging
+spec:
+  serviceAccountName: operate-workflow-sa
+  entrypoint: migrate
+  # Success cleaned after a day; failures kept 3 days for debugging.
+  ttlStrategy:
+    secondsAfterSuccess: 86400
+    secondsAfterFailure: 259200
+  arguments:
+    parameters:
+    - name: pipeline_image_version          # REQUIRED — RC tag containing migrate_s1_rtc_datamodel.py
+      value: v0.8.0-s1rtc-rc3
+    - name: stac_api_url
+      value: https://api.explorer.eopf.copernicus.eu/stac
+    - name: cube_collection
+      value: sentinel-1-grd-rtc-staging
+    - name: bucket                          # cube bucket — for the S3-versioning pre-flight
+      value: esa-zarr-sentinel-explorer-fra
+    - name: s3_endpoint
+      value: https://s3.de.io.cloud.ovh.net
+    - name: dry_run                         # SAFE DEFAULT: report only, write nothing
+      value: "true"
+    - name: backup_prefix                   # optional s3:// prefix (no-versioning fallback / rollback)
+      value: ""
+    - name: skip_tiles                      # optional, space-separated tile substrings
+      value: ""
+    - name: rollback                        # "true" → restore every store from backup_prefix
+      value: "false"
+  templates:
+  - name: migrate
+    activeDeadlineSeconds: 21600            # 6h ceiling for the whole fleet
+    nodeSelector:
+      nodepool: pipeline
+    tolerations:
+    - key: nodepool
+      operator: Equal
+      value: pipeline
+      effect: NoSchedule
+    script:
+      image: w9mllyot.c1.de1.container-registry.ovh.net/eopf-sentinel-zarr-explorer/data-pipeline:{{workflow.parameters.pipeline_image_version}}
+      imagePullPolicy: Always
+      # Args assembled in a bash array from env (no param interpolated into the shell → no injection).
+      command: [bash]
+      source: |
+        set -uo pipefail
+        args=(
+          --stac-api-url "$STAC_API_URL"
+          --cube-collection "$CUBE_COLLECTION"
+          --bucket "$BUCKET"
+          --s3-endpoint "$S3_ENDPOINT"
+        )
+        [ "$DRY_RUN" = "true" ] && args+=(--dry-run)
+        [ "$ROLLBACK" = "true" ] && args+=(--rollback)
+        [ -n "$BACKUP_PREFIX" ] && args+=(--backup-prefix "$BACKUP_PREFIX")
+        [ -n "$SKIP_TILES" ] && args+=(--skip-tiles $SKIP_TILES)
+        python /app/scripts/migrate_s1_rtc_datamodel.py "${args[@]}"
+      resources:
+        requests:
+          # Per-slice streaming bounds peak memory; this is a starting request — Checkpoint A measures
+          # real-tile peak RSS and right-sizes (plan OQ-2).
+          memory: 8Gi
+          cpu: "2"
+      env:
+      - name: PYTHONUNBUFFERED
+        value: "1"
+      - name: STAC_API_URL
+        value: "{{workflow.parameters.stac_api_url}}"
+      - name: CUBE_COLLECTION
+        value: "{{workflow.parameters.cube_collection}}"
+      - name: BUCKET
+        value: "{{workflow.parameters.bucket}}"
+      - name: S3_ENDPOINT
+        value: "{{workflow.parameters.s3_endpoint}}"
+      - name: DRY_RUN
+        value: "{{workflow.parameters.dry_run}}"
+      - name: ROLLBACK
+        value: "{{workflow.parameters.rollback}}"
+      - name: BACKUP_PREFIX
+        value: "{{workflow.parameters.backup_prefix}}"
+      - name: SKIP_TILES
+        value: "{{workflow.parameters.skip_tiles}}"
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: geozarr-s3-credentials
+            key: AWS_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: geozarr-s3-credentials
+            key: AWS_SECRET_ACCESS_KEY
+      - name: AWS_ENDPOINT_URL
+        value: "{{workflow.parameters.s3_endpoint}}"
+      - name: AWS_DEFAULT_REGION
+        value: "de"

--- a/scripts/migrate_s1_rtc_datamodel.py
+++ b/scripts/migrate_s1_rtc_datamodel.py
@@ -161,6 +161,11 @@ class FleetReport:
     failed: list[tuple[str, str]] = field(default_factory=list)  # (item_id, error message)
 
 
+def _backup_path(backup_prefix: str, item_id: str) -> str:
+    """Per-store backup location under ``backup_prefix`` (e.g. ``s3://bucket/migration-backup``)."""
+    return f"{backup_prefix.rstrip('/')}/{item_id}.zarr"
+
+
 def run_fleet(
     stac_api_url: str,
     cube_collection: str,
@@ -168,11 +173,14 @@ def run_fleet(
     dry_run: bool = False,
     only_item: str | None = None,
     skip_tiles: tuple[str, ...] = (),
+    backup_prefix: str | None = None,
 ) -> FleetReport:
     """Redrive every cube in ``cube_collection``; one bad store is logged and skipped, never aborting.
 
     Resumable: a store already at the current writer reports ``already_current`` (the marker) and is a
-    no-op, so a re-run only touches the stores that still need it.
+    no-op, so a re-run only touches the stores that still need it. When ``backup_prefix`` is set (the
+    no-versioning fallback), each store is copied there *before* it is re-derived; a backup failure marks
+    that store failed and it is not re-derived.
     """
     fleet = FleetReport()
     for item_id, href in list_cube_items(stac_api_url, cube_collection):
@@ -181,7 +189,13 @@ def run_fleet(
         if any(tile in item_id for tile in skip_tiles):
             continue
         store = https_to_s3(href)  # the STAC asset is the https gateway URI; redrive needs s3://
+        if store is None:
+            log.error("unresolvable store href for %s: %s", item_id, href)
+            fleet.failed.append((item_id, f"unresolvable store href: {href}"))
+            continue
         try:
+            if backup_prefix and not dry_run:
+                s1_store_meta.backup_store(store, _backup_path(backup_prefix, item_id))
             rpt = redrive_store(store, dry_run=dry_run)
         except Exception as exc:  # noqa: BLE001 -- the fleet must continue past one unreadable store
             log.exception("redrive failed for %s (%s)", item_id, store)
@@ -193,6 +207,39 @@ def run_fleet(
             fleet.skipped_no_border_mask.append(item_id)
         else:
             fleet.derived.append(item_id)
+    return fleet
+
+
+def run_rollback(
+    stac_api_url: str,
+    cube_collection: str,
+    backup_prefix: str,
+    *,
+    only_item: str | None = None,
+    skip_tiles: tuple[str, ...] = (),
+) -> FleetReport:
+    """Restore every cube from its ``backup_prefix`` copy (``--rollback`` of an unversioned-bucket run).
+
+    Per-store try/except like ``run_fleet``; the returned report's ``derived`` lists the restored items.
+    """
+    fleet = FleetReport()
+    for item_id, href in list_cube_items(stac_api_url, cube_collection):
+        if only_item is not None and item_id != only_item:
+            continue
+        if any(tile in item_id for tile in skip_tiles):
+            continue
+        store = https_to_s3(href)
+        if store is None:
+            log.error("unresolvable store href for %s: %s", item_id, href)
+            fleet.failed.append((item_id, f"unresolvable store href: {href}"))
+            continue
+        try:
+            s1_store_meta.restore_store(_backup_path(backup_prefix, item_id), store)
+        except Exception as exc:  # noqa: BLE001 -- restore one store; keep going
+            log.exception("rollback failed for %s (%s)", item_id, store)
+            fleet.failed.append((item_id, str(exc)))
+            continue
+        fleet.derived.append(item_id)  # "derived" == restored in the rollback report
     return fleet
 
 
@@ -211,6 +258,22 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--skip-tiles", nargs="*", default=[], help="tile substrings to exclude (e.g. hard-defect)"
     )
+    parser.add_argument(
+        "--bucket", default=None, help="cube bucket, for the S3-versioning pre-flight"
+    )
+    parser.add_argument(
+        "--backup-prefix",
+        default=None,
+        help="s3 prefix for pre-write backups (no-versioning fallback) and the --rollback source",
+    )
+    parser.add_argument(
+        "--rollback", action="store_true", help="restore every store from --backup-prefix"
+    )
+    parser.add_argument(
+        "--s3-endpoint",
+        default=None,
+        help="S3 endpoint for the versioning check (else AWS_ENDPOINT_URL)",
+    )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
 
@@ -219,12 +282,41 @@ def main(argv: list[str] | None = None) -> int:
             print(f"{item_id}\t{https_to_s3(href)}")  # noqa: T201 -- CLI output
         return 0
 
+    if args.rollback:
+        if not args.backup_prefix:
+            parser.error("--rollback requires --backup-prefix")
+        rb = run_rollback(
+            args.stac_api_url,
+            args.cube_collection,
+            args.backup_prefix,
+            only_item=args.item,
+            skip_tiles=tuple(args.skip_tiles),
+        )
+        log.info("rollback: restored=%d failed=%d", len(rb.derived), len(rb.failed))
+        for item_id, err in rb.failed:
+            log.error("  FAILED %s: %s", item_id, err)
+        return 1 if rb.failed else 0
+
+    # Pre-flight rollback safety (C2): a real run must be reversible — either the bucket has S3
+    # versioning (per-object restore) or a --backup-prefix is given (each store copied before its first
+    # write). Refuse otherwise. Dry-run writes nothing, so it skips the gate.
+    if not args.dry_run and not args.backup_prefix:
+        if not args.bucket:
+            parser.error("a real run needs --bucket (for the versioning check) or --backup-prefix")
+        if not s1_store_meta.s3_versioning_enabled(args.bucket, s3_endpoint=args.s3_endpoint):
+            log.error(
+                "refusing: bucket %s has S3 versioning OFF and no --backup-prefix (C2 rollback safety)",
+                args.bucket,
+            )
+            return 2
+
     fleet = run_fleet(
         args.stac_api_url,
         args.cube_collection,
         dry_run=args.dry_run,
         only_item=args.item,
         skip_tiles=tuple(args.skip_tiles),
+        backup_prefix=args.backup_prefix,
     )
     log.info(
         "fleet %s: derived=%d already-current=%d skipped-no-border_mask=%d failed=%d",

--- a/scripts/s1_store_meta.py
+++ b/scripts/s1_store_meta.py
@@ -12,6 +12,7 @@ writer is at the asserted behavior.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import fsspec
@@ -94,3 +95,57 @@ def set_root_attr(store_path: str | Path, key: str, value: str) -> None:
     meta = json.loads(fs.cat_file(zj))
     meta.setdefault("attributes", {})[key] = value
     fs.pipe_file(zj, json.dumps(meta).encode())
+
+
+# =============================================================================
+# Rollback / backup (Task 3) — the re-derive rewrites bulk vv/vh objects, so the migration is only
+# safe if it is reversible: prefer the bucket's own S3 versioning; else back up before the first write.
+# =============================================================================
+
+
+def s3_versioning_enabled(bucket: str, *, s3_endpoint: str | None = None) -> bool:
+    """Whether ``bucket`` has S3 object versioning enabled (the preferred per-object rollback path).
+
+    When on, an overwritten object keeps its prior version and a bad migration is reversible without a
+    pre-write copy. Endpoint resolves from ``s3_endpoint`` or ``AWS_ENDPOINT_URL``; credentials from the
+    boto3 default chain (the ``AWS_*`` env the runner sets).
+    """
+    import boto3
+
+    endpoint = s3_endpoint or os.getenv("AWS_ENDPOINT_URL")
+    client = boto3.client("s3", endpoint_url=endpoint) if endpoint else boto3.client("s3")
+    return bool(client.get_bucket_versioning(Bucket=bucket).get("Status") == "Enabled")
+
+
+def backup_store(store_path: str | Path, backup_path: str | Path) -> int:
+    """Copy every object of a store to ``backup_path`` (same filesystem); return the object count.
+
+    The fallback when the bucket has no versioning: a full pre-write copy so ``restore_store`` can bring
+    the store back byte-for-byte. (Backs up all objects, not only the vv/vh the re-derive overwrites —
+    simpler and safe; the re-derive only ever overwrites, never adds.)
+    """
+    fs, root = fsspec.core.url_to_fs(str(store_path))
+    _, dst_root = fsspec.core.url_to_fs(str(backup_path))
+    count = 0
+    for obj in fs.find(root):
+        rel = obj[len(root) :].lstrip("/")
+        fs.pipe_file(f"{dst_root.rstrip('/')}/{rel}", fs.cat_file(obj))
+        count += 1
+    return count
+
+
+def restore_store(backup_path: str | Path, store_path: str | Path) -> int:
+    """Restore a store from a ``backup_store`` copy (``--rollback``); return the object count.
+
+    Copies the backup objects back over the store. Sufficient because the re-derive only overwrites
+    existing objects (never adds), so restoring the originals — including the unmarked root ``zarr.json``
+    — fully reverts the migration.
+    """
+    fs, src_root = fsspec.core.url_to_fs(str(backup_path))
+    _, root = fsspec.core.url_to_fs(str(store_path))
+    count = 0
+    for obj in fs.find(src_root):
+        rel = obj[len(src_root) :].lstrip("/")
+        fs.pipe_file(f"{root.rstrip('/')}/{rel}", fs.cat_file(obj))
+        count += 1
+    return count

--- a/tests/unit/test_migrate_s1_rtc_fleet.py
+++ b/tests/unit/test_migrate_s1_rtc_fleet.py
@@ -135,3 +135,118 @@ def test_main_list_enumerates_without_opening_stores(monkeypatch, capsys) -> Non
     out = capsys.readouterr().out
     assert f"s1-rtc-30TUM\ts3://{_PREFIX}/s1-rtc-30TUM.zarr" in out
     assert out.count("\n") == len(_ITEMS)
+
+
+def _ok_report(store, *, dry_run=False):
+    return migrate.RedriveReport(store=store, orbits=["ascending"])
+
+
+def _must_not_call(*_a, **_k):
+    raise AssertionError("this should not have been called")
+
+
+def test_backup_prefix_backs_up_each_store_before_redrive(monkeypatch) -> None:
+    """Task 3: with a backup prefix, each store is copied (to <prefix>/<item>.zarr) before its redrive."""
+    _patch_list(monkeypatch)
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        migrate.s1_store_meta, "backup_store", lambda s, b: calls.append(("backup", s, b)) or 1
+    )
+
+    def fake_redrive(store, *, dry_run=False):
+        calls.append(("redrive", store))
+        return migrate.RedriveReport(store=store, orbits=["ascending"])
+
+    monkeypatch.setattr(migrate, "redrive_store", fake_redrive)
+
+    migrate.run_fleet("http://stac", "coll", backup_prefix="s3://b/backup")
+
+    assert calls[0] == (
+        "backup",
+        f"s3://{_PREFIX}/s1-rtc-30TUM.zarr",
+        "s3://b/backup/s1-rtc-30TUM.zarr",
+    )
+    assert calls[1] == (
+        "redrive",
+        f"s3://{_PREFIX}/s1-rtc-30TUM.zarr",
+    )  # backup immediately precedes
+    assert [c[0] for c in calls] == ["backup", "redrive"] * len(_ITEMS)
+
+
+def test_dry_run_with_backup_prefix_does_not_back_up(monkeypatch) -> None:
+    """Dry-run writes nothing → no backup even if a prefix is given."""
+    _patch_list(monkeypatch)
+    monkeypatch.setattr(migrate.s1_store_meta, "backup_store", _must_not_call)
+    monkeypatch.setattr(migrate, "redrive_store", _ok_report)
+
+    migrate.run_fleet(
+        "http://stac", "coll", dry_run=True, backup_prefix="s3://b/backup"
+    )  # no raise
+
+
+def test_main_refuses_real_run_when_versioning_off_and_no_backup(monkeypatch) -> None:
+    """C2 pre-flight: a real run with versioning OFF and no --backup-prefix is refused (rc 2), no writes."""
+    _patch_list(monkeypatch)
+    monkeypatch.setattr(migrate.s1_store_meta, "s3_versioning_enabled", lambda *a, **k: False)
+    monkeypatch.setattr(migrate, "redrive_store", _must_not_call)
+
+    rc = migrate.main(["--stac-api-url", "x", "--cube-collection", "y", "--bucket", "b"])
+
+    assert rc == 2
+
+
+def test_main_proceeds_when_versioning_on(monkeypatch) -> None:
+    """C2 pre-flight: versioning ON → rely on it, proceed with the real run."""
+    _patch_list(monkeypatch)
+    monkeypatch.setattr(migrate.s1_store_meta, "s3_versioning_enabled", lambda *a, **k: True)
+    seen: list[str] = []
+    monkeypatch.setattr(
+        migrate, "redrive_store", lambda s, *, dry_run=False: seen.append(s) or _ok_report(s)
+    )
+
+    rc = migrate.main(["--stac-api-url", "x", "--cube-collection", "y", "--bucket", "b"])
+
+    assert rc == 0
+    assert len(seen) == len(_ITEMS)
+
+
+def test_rollback_restores_each_store_from_backup(monkeypatch) -> None:
+    """Task 3 AC: --rollback restores each store from <backup-prefix>/<item>.zarr (never re-derives)."""
+    _patch_list(monkeypatch)
+    restored: list[tuple] = []
+    monkeypatch.setattr(
+        migrate.s1_store_meta, "restore_store", lambda b, s: restored.append((b, s)) or 1
+    )
+    monkeypatch.setattr(migrate, "redrive_store", _must_not_call)
+
+    rc = migrate.main(
+        [
+            "--stac-api-url",
+            "x",
+            "--cube-collection",
+            "y",
+            "--rollback",
+            "--backup-prefix",
+            "s3://b/bk",
+        ]
+    )
+
+    assert rc == 0
+    assert restored[0] == ("s3://b/bk/s1-rtc-30TUM.zarr", f"s3://{_PREFIX}/s1-rtc-30TUM.zarr")
+    assert len(restored) == len(_ITEMS)
+
+
+def test_unresolvable_store_href_is_recorded_as_failed(monkeypatch) -> None:
+    """An href that doesn't resolve to s3:// (https_to_s3 → None) is failed, not crashed on Path(None)."""
+    _patch_list(monkeypatch)
+    monkeypatch.setattr(
+        migrate,
+        "https_to_s3",
+        lambda href: None if "30TWQ" in href else f"s3://{_PREFIX}/{href.rsplit('/', 1)[-1]}",
+    )
+    monkeypatch.setattr(migrate, "redrive_store", _ok_report)
+
+    fleet = migrate.run_fleet("http://stac", "coll")
+
+    assert [item for item, _ in fleet.failed] == ["s1-rtc-30TWQ"]
+    assert {"s1-rtc-30TUM", "s1-rtc-31TDG"} == set(fleet.derived)

--- a/tests/unit/test_s1_store_meta.py
+++ b/tests/unit/test_s1_store_meta.py
@@ -95,3 +95,50 @@ def test_set_root_attr_preserves_consolidated_metadata() -> None:
     assert meta["attributes"]["datamodel_migrated"] == "0.10.1"
     assert meta["attributes"]["existing"] == 1  # pre-existing attrs preserved
     assert meta["consolidated_metadata"] == {"kind": "inline"}  # NOT clobbered (I1)
+
+
+def test_s3_versioning_enabled_reads_bucket_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task 3 pre-flight: reflects the bucket's versioning Status (Enabled → True, else False)."""
+    import boto3
+
+    class _FakeClient:
+        def __init__(self, status: str | None) -> None:
+            self._status = status
+
+        def get_bucket_versioning(self, Bucket: str) -> dict:  # noqa: N803 -- boto3 kwarg name
+            return {"Status": self._status} if self._status else {}
+
+    monkeypatch.setattr(boto3, "client", lambda *a, **k: _FakeClient("Enabled"))
+    assert s1_store_meta.s3_versioning_enabled("a-bucket") is True
+
+    monkeypatch.setattr(boto3, "client", lambda *a, **k: _FakeClient("Suspended"))
+    assert s1_store_meta.s3_versioning_enabled("a-bucket") is False
+
+    monkeypatch.setattr(boto3, "client", lambda *a, **k: _FakeClient(None))  # never enabled
+    assert s1_store_meta.s3_versioning_enabled("a-bucket") is False
+
+
+def test_backup_and_restore_round_trip() -> None:
+    """Task 3 AC: backup copies every store object; restore brings a mutated store back to its bytes."""
+
+    import fsspec
+
+    fs = fsspec.filesystem("memory")
+    store, backup = "/cube.zarr", "/backup/cube.zarr"
+    fs.pipe_file(f"{store}/zarr.json", b'{"node_type":"group","attributes":{}}')
+    fs.pipe_file(f"{store}/ascending/r10m/vv/c/0.0.0", b"ORIGINAL-SHARD")
+
+    n = s1_store_meta.backup_store(f"memory://{store}", f"memory://{backup}")
+    assert n == 2
+
+    # simulate redrive overwriting a vv shard + stamping the completion marker
+    fs.pipe_file(f"{store}/ascending/r10m/vv/c/0.0.0", b"MUTATED-SHARD")
+    fs.pipe_file(
+        f"{store}/zarr.json", b'{"node_type":"group","attributes":{"datamodel_migrated":"0.10.1"}}'
+    )
+
+    restored = s1_store_meta.restore_store(f"memory://{backup}", f"memory://{store}")
+
+    assert restored == 2
+    assert fs.cat_file(f"{store}/ascending/r10m/vv/c/0.0.0") == b"ORIGINAL-SHARD"
+    assert b"datamodel_migrated" not in fs.cat_file(f"{store}/zarr.json")  # marker rolled back


### PR DESCRIPTION
## What

Makes the S1 RTC datamodel migration **safe to run and runnable** — Tasks 3 (rollback/backup) and 4
(the one-off Argo runner) from `~/.claude/plans/the-migration-of-the-adaptive-wolf.md`. Builds on the
migration code merged in EOPF-Explorer/data-pipeline#302.

## Task 3 — rollback / backup (C2 safety)

The re-derive rewrites bulk vv/vh objects, so the migration must be reversible. Adds to `s1_store_meta`:

- `s3_versioning_enabled(bucket)` — the **preferred** per-object rollback path;
- `backup_store` / `restore_store` (fsspec) — the **no-versioning fallback**.

And wires the driver (`migrate_s1_rtc_datamodel.py`):

- `run_fleet --backup-prefix` copies each store **before** its first write (inside the per-store try, so
  a backup failure marks that store failed rather than aborting the fleet);
- `run_rollback` / `--rollback` restores every store from the backup prefix;
- **`main` pre-flight gate**: a real run with no `--backup-prefix` requires `--bucket` with S3 versioning
  **enabled**, else it **refuses (rc 2)** — the migration can never irreversibly overwrite an unversioned
  bucket.

Also hardens an `https_to_s3 → None` href into a recorded failure (was an implicit `Path(None)`).

## Task 4 — one-off Argo Workflow

`deploy/migrate-s1-rtc-datamodel-workflow.yaml` — a `kind: Workflow` (no fan-out) that runs the driver
against `sentinel-1-grd-rtc-staging` in `devseed-staging`, matching the existing ingest template
(`operate-workflow-sa`, `nodepool: pipeline`, OVH `de`). S3 creds come from the in-cluster
`geozarr-s3-credentials` SealedSecret (`secretKeyRef`, **no literals**). Safe default `dry_run=true`
(writes nothing); args are assembled in a bash array from env (no param interpolated into the shell →
no injection).

## Verification

- **Full unit suite: 557 passed**, ruff + mypy clean.
- New tests: versioning-status (mocked boto3), backup/restore byte round-trip (`memory://`), backup-
  precedes-redrive, dry-run-skips-backup, **pre-flight refuses rc 2 when versioning off + no backup**,
  proceed when on, rollback restores, unresolvable-href → failed.
- **`argo lint` passes** on the workflow manifest; YAML + structure validated; confirmed no secret
  literals.

## NOT in this PR (Checkpoint A / Task 5 — cluster-gated)

- A new **RC image** cut from `feat--s1_grd_phase5` after merge (the live `v0.8.0-s1rtc-rc2` predates
  `migrate_s1_rtc_datamodel.py`) — the workflow's `pipeline_image_version` points at it.
- **Checkpoint A** (cron suspended): `argo submit --dry-run`, a real control-tile derive + value-parity
  vs a same-tile re-ingest, the **real-S3 backup/restore rehearsal**, and real-tile **peak-RSS** sizing
  (OQ-2). These are the only places the real-S3 write path and memory get exercised — structurally
  untestable in the local unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
