### PR TITLE
fix(s1-migration): don't mangle the s3:// store URI (Path collapses //)

### DIFF
--- a/deploy/migrate-s1-rtc-datamodel-workflow.yaml
+++ b/deploy/migrate-s1-rtc-datamodel-workflow.yaml
@@ -50,6 +50,8 @@ spec:
       value: ""
     - name: skip_tiles                      # optional, space-separated tile substrings
       value: ""
+    - name: item                            # optional single item id, e.g. s1-rtc-30TUM (control tile)
+      value: ""
     - name: rollback                        # "true" → restore every store from backup_prefix
       value: "false"
   templates:
@@ -78,6 +80,7 @@ spec:
         [ "$DRY_RUN" = "true" ] && args+=(--dry-run)
         [ "$ROLLBACK" = "true" ] && args+=(--rollback)
         [ -n "$BACKUP_PREFIX" ] && args+=(--backup-prefix "$BACKUP_PREFIX")
+        [ -n "$ITEM" ] && args+=(--item "$ITEM")
         [ -n "$SKIP_TILES" ] && args+=(--skip-tiles $SKIP_TILES)
         python /app/scripts/migrate_s1_rtc_datamodel.py "${args[@]}"
       resources:
@@ -105,6 +108,8 @@ spec:
         value: "{{workflow.parameters.backup_prefix}}"
       - name: SKIP_TILES
         value: "{{workflow.parameters.skip_tiles}}"
+      - name: ITEM
+        value: "{{workflow.parameters.item}}"
       - name: AWS_ACCESS_KEY_ID
         valueFrom:
           secretKeyRef:

--- a/scripts/migrate_s1_rtc_datamodel.py
+++ b/scripts/migrate_s1_rtc_datamodel.py
@@ -79,10 +79,12 @@ def redrive_store(store_path: str | Path, *, dry_run: bool = False) -> RedriveRe
     would happen (already-current / which orbits, which lack ``border_mask``) and writes **nothing**.
     """
     s1_store_meta.assert_writer_pinned()  # R5 — refuse to run on a drifted writer
-    store_path = Path(store_path)
-    report = RedriveReport(store=str(store_path))
+    # Keep the URI as a string — `Path("s3://b/x")` collapses the `//` to `s3:/b/x` and breaks the s3
+    # store URL. zarr + the fsspec helpers accept the string for both local and s3:// paths.
+    store_path = str(store_path)
+    report = RedriveReport(store=store_path)
 
-    root_ro = zarr.open_group(str(store_path), mode="r", zarr_format=3)
+    root_ro = zarr.open_group(store_path, mode="r", zarr_format=3)
     report.orbits = [name for name, _ in root_ro.groups()]
     if dict(root_ro.attrs).get(MIGRATION_MARKER_KEY) == _marker_value():
         report.already_current = True

--- a/tests/unit/test_migrate_s1_rtc_datamodel.py
+++ b/tests/unit/test_migrate_s1_rtc_datamodel.py
@@ -293,3 +293,21 @@ def test_dry_run_reports_without_writing(fresh_cube: Path) -> None:
         np.testing.assert_array_equal(vals, before[key])
     root = zarr.open_group(str(fresh_cube), mode="r", zarr_format=3)
     assert migrate.MIGRATION_MARKER_KEY not in dict(root.attrs)  # not marked complete
+
+
+def test_redrive_does_not_mangle_an_s3_uri(monkeypatch) -> None:
+    """Regression (real-S3 only): `Path('s3://b/x')` collapses `//` → `s3:/b/x` and breaks the store
+    URL. redrive must pass the URI through unchanged to zarr. Local-path unit fixtures can't catch this."""
+    seen: list[str] = []
+
+    class _FakeRoot:
+        attrs: dict = {}
+
+        def groups(self):
+            return iter(())
+
+    monkeypatch.setattr(migrate.zarr, "open_group", lambda p, **_k: seen.append(p) or _FakeRoot())
+
+    migrate.redrive_store("s3://bucket/sentinel-1-grd-rtc-staging/s1-rtc-X.zarr", dry_run=True)
+
+    assert seen == ["s3://bucket/sentinel-1-grd-rtc-staging/s1-rtc-X.zarr"]  # not s3:/bucket/...


### PR DESCRIPTION
## What

`redrive_store` did `store_path = Path(store_path)`, and `Path("s3://b/x")` collapses the `//` →
`s3:/b/x`, which zarr/s3fs can't open — so **every real (`s3://`) run failed** with `GroupNotFoundError`.

## How it slipped through

The unit fixtures use local `tmp_path`, where `Path()` is a no-op, so this only surfaced on the **first
real-S3 run** — the Checkpoint A dry-run on `s1-rtc-30TUM`. It also means the EOPF-Explorer/data-pipeline#303
C1 fix was incomplete: it made the metadata *helpers* fsspec-based but left this `Path()` in
`redrive_store` itself.

## Fix

Keep the URI as a string — zarr and the fsspec helpers accept it for both local and `s3://` paths.
Regression test asserts the URI reaches `zarr.open_group` unchanged (the local-path fixtures can't catch
this class of bug).

## Verified

The `s1-rtc-30TUM` **dry-run now reads the real cube** (`derived=1, failed=0`, both orbits found). Full
unit suite green.

> Note: this also means **v0.8.0-s1rtc-rc3 is broken** for s3:// — cut a new RC after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)