### PR TITLE
feat(s1-migration): --allow-no-backup to opt out of the C2 rollback gate

### DIFF
--- a/deploy/migrate-s1-rtc-datamodel-workflow.yaml
+++ b/deploy/migrate-s1-rtc-datamodel-workflow.yaml
@@ -54,6 +54,8 @@ spec:
       value: ""
     - name: rollback                        # "true" → restore every store from backup_prefix
       value: "false"
+    - name: allow_no_backup                 # "true" → real run with NO backup (recovery = re-ingest)
+      value: "false"
   templates:
   - name: migrate
     activeDeadlineSeconds: 21600            # 6h ceiling for the whole fleet
@@ -79,6 +81,7 @@ spec:
         )
         [ "$DRY_RUN" = "true" ] && args+=(--dry-run)
         [ "$ROLLBACK" = "true" ] && args+=(--rollback)
+        [ "$ALLOW_NO_BACKUP" = "true" ] && args+=(--allow-no-backup)
         [ -n "$BACKUP_PREFIX" ] && args+=(--backup-prefix "$BACKUP_PREFIX")
         [ -n "$ITEM" ] && args+=(--item "$ITEM")
         [ -n "$SKIP_TILES" ] && args+=(--skip-tiles $SKIP_TILES)
@@ -110,6 +113,8 @@ spec:
         value: "{{workflow.parameters.skip_tiles}}"
       - name: ITEM
         value: "{{workflow.parameters.item}}"
+      - name: ALLOW_NO_BACKUP
+        value: "{{workflow.parameters.allow_no_backup}}"
       - name: AWS_ACCESS_KEY_ID
         valueFrom:
           secretKeyRef:

--- a/scripts/migrate_s1_rtc_datamodel.py
+++ b/scripts/migrate_s1_rtc_datamodel.py
@@ -272,6 +272,12 @@ def main(argv: list[str] | None = None) -> int:
         "--rollback", action="store_true", help="restore every store from --backup-prefix"
     )
     parser.add_argument(
+        "--allow-no-backup",
+        action="store_true",
+        help="proceed with a real run despite no versioning and no --backup-prefix; recovery is by "
+        "re-ingest only (the re-derive is value-identical to a re-ingest). Explicit opt-out of C2.",
+    )
+    parser.add_argument(
         "--s3-endpoint",
         default=None,
         help="S3 endpoint for the versioning check (else AWS_ENDPOINT_URL)",
@@ -301,16 +307,22 @@ def main(argv: list[str] | None = None) -> int:
 
     # Pre-flight rollback safety (C2): a real run must be reversible — either the bucket has S3
     # versioning (per-object restore) or a --backup-prefix is given (each store copied before its first
-    # write). Refuse otherwise. Dry-run writes nothing, so it skips the gate.
-    if not args.dry_run and not args.backup_prefix:
+    # write). Refuse otherwise, unless --allow-no-backup explicitly opts out (recovery = re-ingest).
+    # Dry-run writes nothing, so it skips the gate.
+    if not args.dry_run and not args.backup_prefix and not args.allow_no_backup:
         if not args.bucket:
             parser.error("a real run needs --bucket (for the versioning check) or --backup-prefix")
         if not s1_store_meta.s3_versioning_enabled(args.bucket, s3_endpoint=args.s3_endpoint):
             log.error(
-                "refusing: bucket %s has S3 versioning OFF and no --backup-prefix (C2 rollback safety)",
+                "refusing: bucket %s has S3 versioning OFF and no --backup-prefix (C2 rollback safety); "
+                "pass --allow-no-backup to proceed with re-ingest as the only recovery path.",
                 args.bucket,
             )
             return 2
+    if args.allow_no_backup and not args.dry_run and not args.backup_prefix:
+        log.warning(
+            "--allow-no-backup: real run with NO rollback backup; recovery is re-ingest only"
+        )
 
     fleet = run_fleet(
         args.stac_api_url,

--- a/tests/unit/test_migrate_s1_rtc_fleet.py
+++ b/tests/unit/test_migrate_s1_rtc_fleet.py
@@ -250,3 +250,21 @@ def test_unresolvable_store_href_is_recorded_as_failed(monkeypatch) -> None:
 
     assert [item for item, _ in fleet.failed] == ["s1-rtc-30TWQ"]
     assert {"s1-rtc-30TUM", "s1-rtc-31TDG"} == set(fleet.derived)
+
+
+def test_main_allow_no_backup_bypasses_the_gate(monkeypatch) -> None:
+    """--allow-no-backup proceeds with a real run despite no versioning + no backup (explicit C2 opt-out);
+    the versioning check is not even called."""
+    _patch_list(monkeypatch)
+    monkeypatch.setattr(migrate.s1_store_meta, "s3_versioning_enabled", _must_not_call)
+    seen: list[str] = []
+    monkeypatch.setattr(
+        migrate, "redrive_store", lambda s, *, dry_run=False: seen.append(s) or _ok_report(s)
+    )
+
+    rc = migrate.main(
+        ["--stac-api-url", "x", "--cube-collection", "y", "--bucket", "b", "--allow-no-backup"]
+    )
+
+    assert rc == 0
+    assert len(seen) == len(_ITEMS)  # ran the fleet, gate bypassed


### PR DESCRIPTION
In-cluster confirmed `esa-zarr-sentinel-explorer-fra` has **S3 versioning OFF**, so the pre-flight gate correctly refuses a real run with no `--backup-prefix`. Per the operator decision to rely on the migration's proven correctness + re-ingest as the recovery path (the re-derive is value-identical to a re-ingest), `--allow-no-backup` bypasses the gate with a logged warning. Wired into the workflow as `allow_no_backup`. argo lint + 13 fleet unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)