### PR TITLE
fix(s1-306): -180..180 geoid + tile wipe tooling for reprocess

### DIFF
--- a/deploy/wipe-s1rtc-tiles-workflow.yaml
+++ b/deploy/wipe-s1rtc-tiles-workflow.yaml
@@ -1,0 +1,150 @@
+# One-off Argo Workflow: wipe S1 RTC tiles (cube store + STAC items, both orbits) for the #306
+# geoid reprocess (plan T3/T5).
+#
+# Per --tiles entry it FAIL-CLOSED backs up then removes the cube store, then deletes the STAC items:
+#   1. aws s3 cp --recursive <store> <backup>   (backup MUST land first)
+#   2. verify the backup object count >= the source count   (versioning is OFF on the cube bucket;
+#      never rm on an incomplete backup — plan I3)
+#   3. aws s3 rm --recursive <store>
+#   4. python /app/scripts/wipe_s1rtc_tiles.py --tiles … --execute   (cube item + ALL per-acq items,
+#      both orbits)
+# The cube bucket is owned by the eopfexplorer account; creds come from the in-cluster
+# `geozarr-s3-credentials` SealedSecret (NO literals here), endpoint is OVH `de`. STAC writes use the
+# pipeline's own (currently unauthenticated) write context — same as migrate-s1-rtc-datamodel-workflow.
+#
+# Usage (the s1rtc cron MUST be suspended — C2 concurrency):
+#   1. DRY-RUN (default, writes nothing — lists store object counts + the exact STAC ids):
+#        argo submit -n devseed-staging deploy/wipe-s1rtc-tiles-workflow.yaml \
+#          -p pipeline_image_version=<RC-tag> -p tiles=30UVU
+#   2. REAL wipe (only after the dry-run looks right — a backup_prefix is REQUIRED):
+#        argo submit -n devseed-staging deploy/wipe-s1rtc-tiles-workflow.yaml \
+#          -p pipeline_image_version=<RC-tag> -p tiles=30UVU -p dry_run=false \
+#          -p backup_prefix=s3://esa-zarr-sentinel-explorer-fra/backups/s1-306-geoid-20260626
+#
+# pipeline_image_version MUST be an RC build that contains scripts/wipe_s1rtc_tiles.py
+# (verify: `docker run --rm <image> python /app/scripts/wipe_s1rtc_tiles.py --help`).
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: wipe-s1rtc-tiles-
+  namespace: devseed-staging
+spec:
+  serviceAccountName: operate-workflow-sa
+  entrypoint: wipe
+  # Success cleaned after a day; failures kept 3 days for debugging.
+  ttlStrategy:
+    secondsAfterSuccess: 86400
+    secondsAfterFailure: 259200
+  arguments:
+    parameters:
+    - name: pipeline_image_version          # REQUIRED — RC tag containing scripts/wipe_s1rtc_tiles.py
+      value: v0.8.0-s1rtc-rc5
+    - name: tiles                           # REQUIRED — comma-separated MGRS tiles, e.g. 30UVU,30UWB
+      value: ""
+    - name: stac_api_url
+      value: https://api.explorer.eopf.copernicus.eu/stac
+    - name: cube_collection
+      value: sentinel-1-grd-rtc-staging
+    - name: acq_collection
+      value: sentinel-1-grd-rtc-acquisitions-staging
+    - name: bucket                          # cube bucket
+      value: esa-zarr-sentinel-explorer-fra
+    - name: store_prefix                    # path under the bucket to the cube stores
+      value: tests-output/sentinel-1-grd-rtc-staging
+    - name: s3_endpoint
+      value: https://s3.de.io.cloud.ovh.net
+    - name: dry_run                         # SAFE DEFAULT: list only, write nothing
+      value: "true"
+    - name: backup_prefix                   # REQUIRED for a real run (s3:// prefix; versioning is OFF)
+      value: ""
+  templates:
+  - name: wipe
+    activeDeadlineSeconds: 7200             # 2h ceiling
+    nodeSelector:
+      nodepool: pipeline
+    tolerations:
+    - key: nodepool
+      operator: Equal
+      value: pipeline
+      effect: NoSchedule
+    script:
+      image: w9mllyot.c1.de1.container-registry.ovh.net/eopf-sentinel-zarr-explorer/data-pipeline:{{workflow.parameters.pipeline_image_version}}
+      imagePullPolicy: Always
+      # All params arrive via env (never interpolated into the shell → no injection). The S3 endpoint
+      # is taken from AWS_ENDPOINT_URL, so the aws commands need no --endpoint-url.
+      command: [bash]
+      source: |
+        set -uo pipefail
+        if [ -z "$TILES" ]; then echo "ERROR: -p tiles is required"; exit 2; fi
+        IFS=',' read -ra TILE_ARR <<< "$TILES"
+
+        # --- Phase 1: per-tile cube store backup -> verify -> rm (fail-closed) -------------------
+        for tile in "${TILE_ARR[@]}"; do
+          store="s3://${BUCKET}/${STORE_PREFIX}/s1-rtc-${tile}.zarr"
+          src_count=$(aws s3 ls --recursive "$store" | wc -l | tr -d ' ')
+          echo "tile ${tile}: ${store} has ${src_count} objects"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "[dry-run] would back up ${store} -> ${BACKUP_PREFIX:-<backup_prefix>}/s1-rtc-${tile}.zarr then rm it"
+            continue
+          fi
+          if [ -z "$BACKUP_PREFIX" ]; then echo "ERROR: backup_prefix is required for a real wipe"; exit 1; fi
+          if [ "$src_count" -eq 0 ]; then echo "ERROR: ${store} empty/missing — refusing to back up+rm ${tile}"; exit 1; fi
+          backup="${BACKUP_PREFIX%/}/s1-rtc-${tile}.zarr"
+          echo "backing up ${store} -> ${backup}"
+          aws s3 cp --recursive "$store" "$backup"
+          bkp_count=$(aws s3 ls --recursive "$backup" | wc -l | tr -d ' ')
+          if [ "$bkp_count" -lt "$src_count" ]; then
+            echo "ERROR: backup incomplete (${bkp_count} < ${src_count}) — refusing to rm ${tile}"; exit 1
+          fi
+          echo "backup verified (${bkp_count} objects); removing ${store}"
+          aws s3 rm --recursive "$store"
+        done
+
+        # --- Phase 2: STAC deletes (cube item + ALL per-acq items, both orbits) ------------------
+        args=(
+          --stac-api-url "$STAC_API_URL"
+          --tiles "$TILES"
+          --cube-collection "$CUBE_COLLECTION"
+          --acq-collection "$ACQ_COLLECTION"
+        )
+        [ "$DRY_RUN" = "false" ] && args+=(--execute)
+        python /app/scripts/wipe_s1rtc_tiles.py "${args[@]}"
+      resources:
+        requests:
+          memory: 2Gi
+          cpu: "1"
+      env:
+      - name: PYTHONUNBUFFERED
+        value: "1"
+      - name: TILES
+        value: "{{workflow.parameters.tiles}}"
+      - name: STAC_API_URL
+        value: "{{workflow.parameters.stac_api_url}}"
+      - name: CUBE_COLLECTION
+        value: "{{workflow.parameters.cube_collection}}"
+      - name: ACQ_COLLECTION
+        value: "{{workflow.parameters.acq_collection}}"
+      - name: BUCKET
+        value: "{{workflow.parameters.bucket}}"
+      - name: STORE_PREFIX
+        value: "{{workflow.parameters.store_prefix}}"
+      - name: S3_ENDPOINT
+        value: "{{workflow.parameters.s3_endpoint}}"
+      - name: DRY_RUN
+        value: "{{workflow.parameters.dry_run}}"
+      - name: BACKUP_PREFIX
+        value: "{{workflow.parameters.backup_prefix}}"
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: geozarr-s3-credentials
+            key: AWS_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: geozarr-s3-credentials
+            key: AWS_SECRET_ACCESS_KEY
+      - name: AWS_ENDPOINT_URL
+        value: "{{workflow.parameters.s3_endpoint}}"
+      - name: AWS_DEFAULT_REGION
+        value: "de"

--- a/scripts/convert_egm2008_pgm_to_grd.py
+++ b/scripts/convert_egm2008_pgm_to_grd.py
@@ -1,4 +1,8 @@
-"""Convert GeographicLib EGM2008 PGM to OTB binary .grd format.
+"""Convert GeographicLib EGM2008 PGM to OTB binary .grd format (-180..180 longitude).
+
+The output grid spans -180..180E. This matters: a 0..360 geoid leaves the entire western
+hemisphere uncovered, so OTB Superimpose returns nodata over negative longitudes (all of
+western Europe) -> the summed DEM+GEOID is dead -> the gamma0 near-range wedge (issue #306).
 
 Usage:
   python scripts/convert_egm2008_pgm_to_grd.py \
@@ -60,19 +64,24 @@ def convert(pgm: pathlib.Path, out: pathlib.Path, step: int) -> None:
 
     pixels = read_pgm_data(pgm, data_offset, pgm_height, pgm_width)
 
-    # Subsample: rows 0..pgm_height-1 step=step, cols 0..pgm_width step=step
-    # Col pgm_width wraps to 0 (360E == 0E) — duplicate the first column
-    row_idx = np.arange(0, pgm_height, step)
-    col_idx = np.arange(0, pgm_width + 1, step)  # +1 to include 360E = 0E wrap
-    col_idx_wrapped = col_idx % pgm_width
-
-    sub = pixels[np.ix_(row_idx, col_idx_wrapped)].astype(np.float32) * scale + offset
-
-    n_lat, n_lon = sub.shape
+    # Subsample rows; emit a -180..180 longitude grid (NOT 0..360).
+    # The PGM source spans 0..360E. A 0..360 output leaves the whole western hemisphere
+    # uncovered, so OTB Superimpose returns nodata over negative longitudes (all of W
+    # Europe) -> dead DEM+GEOID -> the gamma0 near-range wedge (issue #306). lon -L(W) ==
+    # 360-L(E) is the same point, so we map each -180..180 output column to the matching
+    # PGM column. Node-registered, n_lon columns incl. the wrap (-180 == +180).
     dlat = dlon = step / 60.0
+    row_idx = np.arange(0, pgm_height, step)
+    n_lon = len(np.arange(0, pgm_width + 1, step))  # same column count as 0..360 (incl. wrap)
+    out_lons = -180.0 + np.arange(n_lon) * dlon
+    pgm_cols = (np.round((out_lons % 360.0) / dlon).astype(int) * step) % pgm_width
+
+    sub = pixels[np.ix_(row_idx, pgm_cols)].astype(np.float32) * scale + offset
+
+    n_lat = sub.shape[0]
     lat_max = 90.0
     lat_min = lat_max - (n_lat - 1) * dlat
-    lon_min, lon_max = 0.0, (n_lon - 1) * dlon
+    lon_min, lon_max = -180.0, -180.0 + (n_lon - 1) * dlon
 
     print(f"  output grid: {n_lat} lat × {n_lon} lon, dlat=dlon={dlat:.4f}°")
     print(f"  lat [{lat_min}, {lat_max}]  lon [{lon_min}, {lon_max}]")
@@ -147,6 +156,21 @@ def validate(out: pathlib.Path, step: int, egm96_grd: pathlib.Path | None) -> bo
         print(
             f"  [{status}] {label:35s} expected={expected:7.3f}  got={got:7.3f}  diff={diff:.3f} m"
         )
+
+    # #306 regression guard: the grid MUST span -180..180 and cover the western hemisphere.
+    # A 0..360 grid leaves negative longitudes as nodata -> dead DEM+GEOID -> gamma0 wedge.
+    span_ok = abs(lon_min + 180.0) < 1e-4 and abs(lon_max - 180.0) < 1e-4
+    bret_row = round((lat_max - 48.75) / dlat)
+    bret_col = round((-3.75 - lon_min) / dlon) % n_lon
+    bret = float(grid[bret_row, bret_col])
+    bret_ok = 40.0 < bret < 60.0  # EGM2008 geoid over Brittany ~48-51 m
+    ok = ok and span_ok and bret_ok
+    print(
+        f"\n  [{'OK' if span_ok else 'FAIL'}] longitude span: [{lon_min:.3f}, {lon_max:.3f}] "
+        f"(must be -180..180)\n"
+        f"  [{'OK' if bret_ok else 'FAIL'}] W-hemisphere covered (Brittany 48.75N -3.75E): "
+        f"{bret:.2f} m (expect ~48-51; was nodata on the 0..360 grid)"
+    )
 
     if egm96_grd and egm96_grd.exists() and step == 15:
         expected_size = egm96_grd.stat().st_size

--- a/scripts/wipe_s1rtc_tiles.py
+++ b/scripts/wipe_s1rtc_tiles.py
@@ -1,0 +1,182 @@
+"""Wipe (delete) all STAC items for a set of S1 RTC tiles — both orbits (plan T1/T3, issue #306).
+
+To reprocess a tile with the corrected -180..180 geoid, its already-published STAC items must be
+removed first: ``trigger_cdse.py`` dedups against the per-acquisition collection, so leaving the
+per-acq items in place would make ``discover`` skip the tile. For each ``--tiles`` entry this deletes:
+
+  * the **cube** item ``s1-rtc-<tile>`` in ``--cube-collection``; and
+  * **every** per-acquisition item ``s1-rtc-<tile>-<datetime>`` (both ascending and descending) in
+    ``--acq-collection``.
+
+Per-acq items are STAC-only pointers that render the shared cube via ``sel=time`` (no per-item S3
+data), so deleting the STAC item is a clean wipe; the cube store itself is removed separately (the
+in-cluster wipe Workflow does the S3 ``cp`` backup + ``rm`` before calling this script).
+
+SCOPE: only the listed tiles, **both orbits** (no ``sat:orbit_state`` filter — unlike
+``retract_ascending_acquisitions.py``, this is a full per-tile wipe). Per-acq items are enumerated by
+a server-side ``grid:code = MGRS-<tile>`` filter, then guarded client-side by
+``id.startswith("s1-rtc-<tile>-")`` so an over-broad server response can never delete another tile's
+items.
+
+SAFETY: **dry-run by default** — lists the resolved cube + per-acq ids and exits without writing. Pass
+``--execute`` to actually delete (needs sign-off; the deletes are immediate). Idempotent: a missing
+item (HTTP 404) counts as already-wiped.
+
+Usage:
+    # dry-run (read-only — lists exactly what would be deleted):
+    uv run python scripts/wipe_s1rtc_tiles.py --tiles 30UVU --stac-api-url https://api.../stac
+    # delete (destructive — after sign-off):
+    uv run python scripts/wipe_s1rtc_tiles.py --tiles 30UVU,30UWB --stac-api-url https://api.../stac --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("wipe_s1rtc_tiles")
+
+DEFAULT_CUBE_COLLECTION = "sentinel-1-grd-rtc-staging"
+DEFAULT_ACQ_COLLECTION = "sentinel-1-grd-rtc-acquisitions-staging"
+_OK_STATUS = (200, 202, 204, 404)  # 404 == already gone (idempotent)
+
+
+def cube_item_id(tile: str) -> str:
+    """The cube STAC item id for a tile (e.g. ``s1-rtc-30UVU``)."""
+    return f"s1-rtc-{tile}"
+
+
+def grid_code_filter(tile: str) -> dict:
+    """CQL2-json filter selecting items of a single MGRS tile (both orbits — no orbit constraint)."""
+    return {"op": "=", "args": [{"property": "grid:code"}, f"MGRS-{tile}"]}
+
+
+def item_delete_url(base: str, collection: str, item_id: str) -> str:
+    return f"{base.rstrip('/')}/collections/{collection}/items/{item_id}"
+
+
+def filter_tile_items(items: list[dict[str, Any]], tile: str) -> list[str]:
+    """Keep only this tile's per-acquisition ids (``s1-rtc-<tile>-<datetime>``), drop everything else.
+
+    The trailing ``-`` is the safety net: it excludes the bare cube item (``s1-rtc-<tile>``) and any
+    superstring tile (``s1-rtc-<tile>X-…``) an over-broad server filter might return.
+    """
+    prefix = f"s1-rtc-{tile}-"
+    return [it["id"] for it in items if str(it["id"]).startswith(prefix)]
+
+
+def find_acquisition_items(stac_api_url: str, acq_collection: str, tile: str) -> list[str]:
+    """Per-acq item ids in ``acq_collection`` for ``tile`` (both orbits; follows pagination)."""
+    from pystac_client import Client
+
+    client = Client.open(stac_api_url)
+    search = client.search(
+        collections=[acq_collection],
+        filter=grid_code_filter(tile),
+        filter_lang="cql2-json",
+    )
+    return filter_tile_items(list(search.items_as_dicts()), tile)
+
+
+def _open_session(stac_api_url: str) -> tuple[Any, str]:
+    """Return ``(session, self_href)`` from pystac-client (mirrors retract_ascending_acquisitions)."""
+    from pystac_client import Client
+
+    client = Client.open(stac_api_url)
+    io = client._stac_io
+    assert io is not None  # noqa: S101  # nosec B101 -- pystac-client sets this after open()
+    return io.session, str(client.self_href).rstrip("/")
+
+
+def delete_items(
+    session: Any, base: str, collection: str, item_ids: list[str], *, execute: bool
+) -> int:
+    """DELETE each item id from ``collection`` (idempotent). Dry-run (``execute=False``) deletes nothing.
+
+    Returns the number of in-scope items (processed/deleted).
+    """
+    for item_id in item_ids:
+        url = item_delete_url(base, collection, item_id)
+        if not execute:
+            log.info("[dry-run] would DELETE %s/%s", collection, item_id)
+            continue
+        resp = session.delete(url, timeout=30)
+        if resp.status_code not in _OK_STATUS:
+            resp.raise_for_status()
+        log.info("deleted %s/%s (HTTP %s)", collection, item_id, resp.status_code)
+    return len(item_ids)
+
+
+def wipe_tile(
+    session: Any,
+    base: str,
+    *,
+    cube_collection: str,
+    acq_collection: str,
+    cube_id: str,
+    acq_ids: list[str],
+    execute: bool,
+) -> dict[str, int]:
+    """Delete the cube item, then every per-acq item (both orbits). Returns per-collection counts."""
+    cube = delete_items(session, base, cube_collection, [cube_id], execute=execute)
+    acq = delete_items(session, base, acq_collection, acq_ids, execute=execute)
+    return {"cube": cube, "acq": acq}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--stac-api-url", required=True)
+    ap.add_argument("--tiles", required=True, help="comma-separated MGRS tiles, e.g. 30UVU,30UWB")
+    ap.add_argument("--cube-collection", default=DEFAULT_CUBE_COLLECTION)
+    ap.add_argument("--acq-collection", default=DEFAULT_ACQ_COLLECTION)
+    ap.add_argument(
+        "--execute",
+        action="store_true",
+        help="actually delete (default: dry-run, which only lists the resolved cube + per-acq ids)",
+    )
+    args = ap.parse_args()
+
+    tiles = [t.strip() for t in args.tiles.split(",") if t.strip()]
+
+    # Enumeration is read-only; only open a write session when actually deleting.
+    session, base = (None, args.stac_api_url)
+    if args.execute:
+        session, base = _open_session(args.stac_api_url)
+
+    grand_total = 0
+    for tile in tiles:
+        cube_id = cube_item_id(tile)
+        acq_ids = find_acquisition_items(args.stac_api_url, args.acq_collection, tile)
+        verb = "deleting" if args.execute else "[dry-run] would delete"
+        log.info(
+            "%s tile %s: 1 cube item (%s) + %d per-acq items (both orbits)",
+            verb,
+            tile,
+            cube_id,
+            len(acq_ids),
+        )
+        counts = wipe_tile(
+            session,
+            base,
+            cube_collection=args.cube_collection,
+            acq_collection=args.acq_collection,
+            cube_id=cube_id,
+            acq_ids=acq_ids,
+            execute=args.execute,
+        )
+        grand_total += counts["cube"] + counts["acq"]
+
+    if not args.execute:
+        log.info(
+            "[dry-run] %d items across %d tile(s) would be wiped — pass --execute to delete",
+            grand_total,
+            len(tiles),
+        )
+        return
+    log.info("wiped %d items across %d tile(s)", grand_total, len(tiles))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_convert_egm2008_pgm_to_grd.py
+++ b/tests/unit/test_convert_egm2008_pgm_to_grd.py
@@ -1,0 +1,105 @@
+"""Unit tests for scripts/convert_egm2008_pgm_to_grd.py (issue #306 geoid longitude fix).
+
+The bug: the converter emitted a 0..360E geoid grid, so OTB Superimpose returned nodata over every
+negative longitude (all of western Europe) -> dead DEM+GEOID -> the gamma0 near-range wedge. The fix
+emits a -180..180E grid. These tests guard the longitude span and prove the western hemisphere maps to
+the correct source column (a -L W node reads the 360-L E source node) — the exact mechanism the 0..360
+grid got wrong.
+
+No real PGM is used (the 1-arcmin source is ~466 MB). A synthetic full-width (21601-col), few-row PGM
+whose pixel value encodes its own column index lets us assert the western-hemisphere remapping exactly:
+since height(col) is monotonic, the geoid value at an output node uniquely identifies the source column
+it was sampled from.
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+sys.path.insert(0, str(scripts_dir))
+
+import convert_egm2008_pgm_to_grd as c  # noqa: E402
+
+PGM_WIDTH = (
+    21601  # 1-arcmin globe incl. the 0==360 wrap column; the converter assumes this resolution
+)
+SCALE = 0.001
+OFFSET = 29.0  # height(col) = col*SCALE + OFFSET -> unique per source column, ~50 m at 356.25E
+
+
+def _write_synthetic_pgm(path: Path, *, height: int) -> None:
+    """A GeographicLib-style PGM spanning 0..360E whose pixel value == its column index.
+
+    Latitude is irrelevant to the longitude-wrap bug, so the grid is only `height` rows tall and
+    constant down each column.
+    """
+    cols = np.arange(PGM_WIDTH, dtype=np.uint16)  # 0..21600 fits in uint16
+    pixels = np.broadcast_to(cols, (height, PGM_WIDTH))
+    header = (
+        b"P5\n"
+        b"# Description synthetic EGM-like geoid for tests\n"
+        b"# Origin 90N 0E\n"
+        + f"# Scale {SCALE}\n".encode("ascii")
+        + f"# Offset {OFFSET}\n".encode("ascii")
+        + f"{PGM_WIDTH} {height}\n".encode("ascii")
+        + b"65535\n"
+    )
+    with open(path, "wb") as f:
+        f.write(header)
+        f.write(pixels.astype(">u2").tobytes())  # big-endian, matches read_pgm_data
+
+
+def _read_grd(path: Path):
+    with open(path, "rb") as f:
+        lat_min, lat_max, lon_min, lon_max, dlat, dlon = struct.unpack(">6f", f.read(24))
+    n_lat = round((lat_max - lat_min) / dlat) + 1
+    n_lon = round((lon_max - lon_min) / dlon) + 1
+    grid = np.memmap(path, dtype=">f4", mode="r", offset=24).reshape(n_lat, n_lon)
+    return (lat_min, lat_max, lon_min, lon_max, dlat, dlon), grid
+
+
+@pytest.fixture
+def converted(tmp_path: Path):
+    pgm = tmp_path / "egm.pgm"
+    out = tmp_path / "egm.grd"
+    _write_synthetic_pgm(pgm, height=16)
+    c.convert(pgm, out, step=15)
+    return _read_grd(out)
+
+
+def test_output_spans_minus180_to_180(converted):
+    """The fix: the grid must span -180..180E (the 0..360 grid was the #306 bug)."""
+    (_, _, lon_min, lon_max, _, _), _ = converted
+    assert lon_min == pytest.approx(-180.0, abs=1e-3)
+    assert lon_max == pytest.approx(180.0, abs=1e-3)
+
+
+def test_western_hemisphere_is_finite_and_realistic(converted):
+    """Western-hemisphere node (-3.75E) is finite and a plausible geoid height — not nodata.
+
+    On the 0..360 grid this longitude was off the grid (nodata in OTB Superimpose); here it must read
+    the matching 356.25E source node (~50 m).
+    """
+    (_, _, lon_min, _, _, dlon), grid = converted
+    col = round((-3.75 - lon_min) / dlon)
+    assert col >= 0  # a 0..360 grid (lon_min=0) would put this western node off the grid
+    val = float(grid[0, col])
+    assert np.isfinite(val)
+    assert 48.0 < val < 51.0  # 356.25E source: 21375*0.001 + 29 = 50.375
+
+
+def test_negative_longitude_reads_the_wrapped_source_node(converted):
+    """-L W must sample the 360-L E source column (the exact remap the 0..360 grid got wrong)."""
+    (_, _, lon_min, _, _, dlon), grid = converted
+    # -3.75E -> source col 356.25*60 = 21375 -> height 21375*SCALE + OFFSET
+    west = float(grid[0, round((-3.75 - lon_min) / dlon)])
+    assert west == pytest.approx(21375 * SCALE + OFFSET, abs=1e-3)
+    # +3.75E (eastern, unaffected by the bug) -> source col 3.75*60 = 225
+    east = float(grid[0, round((3.75 - lon_min) / dlon)])
+    assert east == pytest.approx(225 * SCALE + OFFSET, abs=1e-3)

--- a/tests/unit/test_wipe_s1rtc_tiles.py
+++ b/tests/unit/test_wipe_s1rtc_tiles.py
@@ -1,0 +1,135 @@
+"""Unit tests for scripts/wipe_s1rtc_tiles.py (plan T1/T3, issue #306 geoid reprocess).
+
+Covers the destructive boundary: dry-run deletes nothing, --execute deletes BOTH the cube item and
+every per-acquisition item (both orbits), the delete is idempotent (404 = already gone), other HTTP
+errors propagate, and enumeration is tile-scoped (grid:code = MGRS-<tile> server filter + a client-side
+id.startswith("s1-rtc-<tile>-") guard, never an orbit filter). No network — the HTTP session is
+injected and the STAC item dicts are faked.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+sys.path.insert(0, str(scripts_dir))
+
+import wipe_s1rtc_tiles as w  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _Session:
+    """Records DELETE calls; returns a configurable status."""
+
+    def __init__(self, status: int = 204) -> None:
+        self.status = status
+        self.deleted: list[str] = []
+
+    def delete(self, url: str, timeout: int | None = None) -> _Resp:
+        self.deleted.append(url)
+        return _Resp(self.status)
+
+
+def test_cube_item_id():
+    assert w.cube_item_id("30UVU") == "s1-rtc-30UVU"
+
+
+def test_grid_code_filter_is_tile_scoped_no_orbit():
+    # Both-orbit guarantee: the filter constrains only the tile, never sat:orbit_state.
+    assert w.grid_code_filter("30UVU") == {
+        "op": "=",
+        "args": [{"property": "grid:code"}, "MGRS-30UVU"],
+    }
+
+
+def test_item_delete_url_shape():
+    url = w.item_delete_url("https://api/stac", "acq", "s1-rtc-30UVU-20260611t180505")
+    assert url == "https://api/stac/collections/acq/items/s1-rtc-30UVU-20260611t180505"
+
+
+def test_filter_tile_items_guards_prefix():
+    """Client-side safety net: keep only this tile's per-acq ids (both orbits), drop everything else."""
+    items = [
+        {"id": "s1-rtc-30UVU-20260611t180505"},  # ascending
+        {"id": "s1-rtc-30UVU-20260613t060000"},  # descending, same tile -> both orbits kept
+        {"id": "s1-rtc-30UWB-20260611t180505"},  # other tile
+        {"id": "s1-rtc-30UVUX-20260611t180505"},  # superstring tile, must NOT match
+        {"id": "s1-rtc-30UVU"},  # the cube item id, not a per-acq id
+    ]
+    assert w.filter_tile_items(items, "30UVU") == [
+        "s1-rtc-30UVU-20260611t180505",
+        "s1-rtc-30UVU-20260613t060000",
+    ]
+
+
+def test_dry_run_deletes_nothing():
+    sess = _Session()
+    n = w.delete_items(sess, "https://api/stac", "acq", ["a", "b"], execute=False)
+    assert sess.deleted == []  # nothing deleted
+    assert n == 2  # but reports the in-scope count
+
+
+def test_execute_deletes_each_item():
+    sess = _Session(204)
+    n = w.delete_items(sess, "https://api/stac", "coll", ["a", "b"], execute=True)
+    assert sess.deleted == [
+        "https://api/stac/collections/coll/items/a",
+        "https://api/stac/collections/coll/items/b",
+    ]
+    assert n == 2
+
+
+def test_idempotent_on_404():
+    sess = _Session(404)  # already gone
+    assert w.delete_items(sess, "https://api/stac", "coll", ["gone"], execute=True) == 1
+
+
+def test_other_http_error_propagates():
+    sess = _Session(500)
+    with pytest.raises(RuntimeError):
+        w.delete_items(sess, "https://api/stac", "coll", ["boom"], execute=True)
+
+
+def test_wipe_tile_deletes_cube_then_all_acq_both_orbits():
+    sess = _Session(204)
+    res = w.wipe_tile(
+        sess,
+        "https://api/stac",
+        cube_collection="cube",
+        acq_collection="acq",
+        cube_id="s1-rtc-30UVU",
+        acq_ids=["s1-rtc-30UVU-20260611t180505", "s1-rtc-30UVU-20260613t060000"],
+        execute=True,
+    )
+    assert sess.deleted == [
+        "https://api/stac/collections/cube/items/s1-rtc-30UVU",
+        "https://api/stac/collections/acq/items/s1-rtc-30UVU-20260611t180505",
+        "https://api/stac/collections/acq/items/s1-rtc-30UVU-20260613t060000",
+    ]
+    assert res == {"cube": 1, "acq": 2}
+
+
+def test_wipe_tile_dry_run_deletes_nothing():
+    sess = _Session(204)
+    res = w.wipe_tile(
+        sess,
+        "https://api/stac",
+        cube_collection="cube",
+        acq_collection="acq",
+        cube_id="s1-rtc-30UVU",
+        acq_ids=["s1-rtc-30UVU-20260611t180505"],
+        execute=False,
+    )
+    assert sess.deleted == []
+    assert res == {"cube": 1, "acq": 1}  # reports in-scope counts, deletes nothing


### PR DESCRIPTION
## Why (refs #306)

The S1 γ⁰-RTC gamma chain reads the geoid from `/MNT/geoid/egm2008.grd`. That `.grd` was written by
`scripts/convert_egm2008_pgm_to_grd.py` in **0..360° longitude**. OTB `Superimpose` then returns
nodata (−32768) for every **negative** longitude — i.e. all of western Europe — so the summed
`DEM+GEOID = realDEM − 32768 ≈ −32700 m` on every land pixel. The gamma-area projection lands those
bogus heights ~+3757 columns off → the near-range **LAND wedge** (and the apparent "ascending ~47 km
shift", which is the near-range wedge eating the western coast, not a geolocation error).

This was proven this session end-to-end: the analytic SAR model is **correct** (GCP residual 0.1 px),
the DEM was **dead** (0% valid over land), and rolling the geoid to −180..180 fixes it:
**gamma0 land coverage 61.2% → 99.1%**, GCP column residual **+3757 → −6**, Brittany geoid 50.6 m.
σ⁰ is geoid-independent, so it was never shifted. (We are **not** switching to NORMLIM — the root
cause is in our own pipeline, so γ⁰-RTC stays.)

## What

- **`scripts/convert_egm2008_pgm_to_grd.py`** — emit a **−180..180E** grid: each output column `−L°W`
  maps to the matching `360−L°E` source node, covering the western hemisphere. `validate()` gains a
  #306 regression guard (span must be −180..180 + a Brittany sample must be a finite ~50 m geoid
  height, not nodata).
- **`scripts/wipe_s1rtc_tiles.py`** (new) — to reprocess a tile with the corrected geoid its published
  STAC items must be deleted first (`trigger_cdse.py` dedups against the per-acq collection). Deletes,
  per `--tiles` entry, the cube item `s1-rtc-<tile>` + **every** per-acq item (**both orbits**) via STAC
  Transactions DELETE. Enumeration: server-side `grid:code = MGRS-<tile>` filter + client-side
  `id.startswith("s1-rtc-<tile>-")` guard (the trailing `-` excludes the bare cube id and superstring
  tiles). Dry-run by default; idempotent (404 = already wiped). Mirrors
  `retract_ascending_acquisitions.py` but tile-scoped + both-orbit.
- **`deploy/wipe-s1rtc-tiles-workflow.yaml`** (new) — in-cluster wipe Workflow modeled on
  `migrate-s1-rtc-datamodel-workflow.yaml`. Per tile it is **fail-closed**: `aws s3 cp --recursive`
  backup → verify backup object count ≥ source → only then `aws s3 rm --recursive` → STAC delete (the
  cube bucket has versioning **off**; never rm on an incomplete backup). Refuses a real run without a
  `backup_prefix`.

## Tests / verification

- `tests/unit/test_convert_egm2008_pgm_to_grd.py` (new) — a synthetic full-width PGM proves the output
  spans −180..180 and that `−3.75°E` reads the `356.25°E` source node. All three assertions **fail on
  the old 0..360 converter** and pass on the fix (Prove-It).
- `tests/unit/test_wipe_s1rtc_tiles.py` (new) — dry-run deletes nothing, `--execute` deletes the cube
  item + all per-acq items (both orbits), idempotent on 404, other HTTP errors propagate, prefix guard.
- `deploy/wipe-s1rtc-tiles-workflow.yaml`: `argo lint --offline` clean; the fail-closed bash was
  exercised with a mocked `aws` (dry-run does no cp/rm; rm refused when backup incomplete or
  `backup_prefix` unset).
- Full unit suite green (`uv run pytest tests/unit`: 580+ passed), pre-commit hooks pass.

Root-cause report + before/after, dead-DEM, asc/desc and coastline-overlay figures are held locally in
the research dir and can be attached on request (kept out of the diff to avoid binaries/research scratch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)