### PR TITLE
feat(s1-caching): cache eviction / retention — evict op (T9)

### DIFF
--- a/scripts/cache_frames.py
+++ b/scripts/cache_frames.py
@@ -8,7 +8,8 @@ prefix, keyed by product id:
 
     {prefix}/{prod_id}.tar      <-  tar of  data_raw/{prod_id}/{prod_id}.SAFE/
 
-Two operations, wired around s1processor by the Argo template (T7):
+Operations: pull/populate are wired around s1processor by the Argo template (T7);
+evict runs periodically (e.g. a small scheduled step) to bound the cache.
 
   pull      (pre-step)   for each needed frame present in the cache, download its
                          tar and extract it into data_raw/{prod_id}/{prod_id}.SAFE/
@@ -17,6 +18,9 @@ Two operations, wired around s1processor by the Argo template (T7):
   populate  (post-step)  tar each SAFE s1processor freshly downloaded (a cache miss)
                          and upload it, so the next tile reuses it. Already-cached
                          frames are skipped.
+  evict     (retention)  delete frames whose acquisition date is older than the
+                         rolling window (--keep-days), so the cache never grows
+                         unbounded; --dry-run lists exactly what would go (T9).
 
 One tar per frame keeps the spike's single-object throughput (a SAFE is hundreds of
 small files). A pull failure degrades to a miss (s1processor just downloads it) — it
@@ -38,6 +42,7 @@ import sys
 import tarfile
 import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +54,10 @@ log = logging.getLogger("cache_frames")
 DEFAULT_ENDPOINT = "https://s3.de.io.cloud.ovh.net"
 DEFAULT_PREFIX = "frame-cache"
 DEFAULT_MAX_WORKERS = 8
+# Evict frames whose acquisition is older than this; the cron only reprocesses a
+# rolling window (lookback_days=7), so a few weeks of margin keeps recently-revisited
+# frames while bounding the cache. Tune via --keep-days.
+DEFAULT_KEEP_DAYS = 21
 
 # S1 GRD product ids look like S1A_IW_GRDH_1SDV_20240101T... — uppercase letters,
 # digits and underscores only. Anchoring + this charset rejects path traversal
@@ -276,6 +285,88 @@ def discover_downloaded_frames(data_raw: str | Path) -> list[str]:
     return out
 
 
+def _acq_date(prod_id: str) -> date:
+    """Acquisition (start) date parsed from the product id, e.g.
+    S1A_IW_GRDH_1SDV_20240101T060000_... -> 2024-01-01. The first `YYYYMMDDThhmmss`
+    field is the sensing start. Raises ValueError if absent (unexpected id shape)."""
+    m = re.search(r"_(\d{8})T\d{6}_", prod_id)
+    if not m:
+        raise ValueError(f"no acquisition timestamp in product id: {prod_id!r}")
+    return datetime.strptime(m.group(1), "%Y%m%d").date()
+
+
+def list_cached_frames(s3: Any, bucket: str, prefix: str) -> list[str]:
+    """List the product ids of frames currently in the cache (paginated). Keys that
+    aren't `{prefix}/{prod_id}.tar` with a valid id are skipped with a warning."""
+    pfx = prefix.rstrip("/") + "/"
+    out: list[str] = []
+    token: str | None = None
+    while True:
+        kw: dict[str, Any] = {"Bucket": bucket, "Prefix": pfx}
+        if token:
+            kw["ContinuationToken"] = token
+        resp = s3.list_objects_v2(**kw)
+        for obj in resp.get("Contents", []):
+            key = obj["Key"]
+            if not key.startswith(pfx) or not key.endswith(".tar"):
+                continue
+            pid = key[len(pfx):-len(".tar")]
+            try:
+                out.append(validate_prod_id(pid))
+            except ValueError:
+                log.warning("skipping unrecognised cache key: %s", key)
+        if not resp.get("IsTruncated"):
+            break
+        token = resp.get("NextContinuationToken")
+    return out
+
+
+def evict_stale(
+    s3: Any,
+    bucket: str,
+    prefix: str,
+    keep_days: int = DEFAULT_KEEP_DAYS,
+    today: date | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Remove cache frames whose acquisition date is older than `today - keep_days`,
+    so the cache tracks the rolling reprocessing window and never grows unbounded.
+
+    Keyed to the *acquisition* date (from the product id), not S3 LastModified — a
+    frame reused (pulled) many times never has its mtime refreshed, so an mtime rule
+    would wrongly evict still-in-window frames. Conservative: a frame whose date
+    can't be parsed is KEPT (never delete what we can't classify). With dry_run the
+    stale set is computed and returned but nothing is deleted.
+    """
+    today = today or date.today()
+    cutoff = today - timedelta(days=keep_days)
+    stale: list[str] = []
+    kept = 0
+    for pid in list_cached_frames(s3, bucket, prefix):
+        try:
+            acq = _acq_date(pid)
+        except ValueError:
+            log.warning("cannot parse acquisition date from %s; keeping it", pid)
+            kept += 1
+            continue
+        if acq < cutoff:
+            stale.append(pid)
+        else:
+            kept += 1
+    removed: list[str] = []
+    if not dry_run:
+        for pid in stale:
+            s3.delete_object(Bucket=bucket, Key=frame_key(prefix, pid))
+            removed.append(pid)
+    return {
+        "cutoff": cutoff.isoformat(),
+        "stale": sorted(stale),
+        "kept": kept,
+        "removed": sorted(removed),
+        "dry_run": dry_run,
+    }
+
+
 def make_s3_client(endpoint: str | None) -> Any:
     """boto3 S3 client (matches the repo convention: explicit endpoint, else the
     AWS_ENDPOINT_URL env, else AWS default). Credentials via the standard chain.
@@ -302,15 +393,19 @@ def _read_frames(args: argparse.Namespace) -> list[str]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument("op", choices=("pull", "populate"))
+    parser.add_argument("op", choices=("pull", "populate", "evict"))
     parser.add_argument("--bucket", required=True)
     parser.add_argument("--prefix", default=DEFAULT_PREFIX)
     parser.add_argument("--endpoint", default=DEFAULT_ENDPOINT)
-    parser.add_argument("--data-raw", required=True, help="S1Tiling data_raw directory")
+    parser.add_argument("--data-raw", help="S1Tiling data_raw directory (pull/populate)")
     parser.add_argument("--frames", help="comma/space-separated product ids")
     parser.add_argument("--frames-file", help="file with one product id per line")
     parser.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
     parser.add_argument("--overwrite", action="store_true", help="(populate) re-upload cached frames")
+    parser.add_argument("--keep-days", type=int, default=DEFAULT_KEEP_DAYS,
+                        help="(evict) keep frames acquired within this many days")
+    parser.add_argument("--today", help="(evict) override 'today' as YYYY-MM-DD (testing/repeatable runs)")
+    parser.add_argument("--dry-run", action="store_true", help="(evict) list stale frames without deleting")
     return parser
 
 
@@ -318,6 +413,19 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s", stream=sys.stderr)
     args = build_parser().parse_args(argv)
     s3 = make_s3_client(args.endpoint)
+
+    if args.op == "evict":
+        today = date.fromisoformat(args.today) if args.today else None
+        res = evict_stale(s3, args.bucket, args.prefix, args.keep_days, today, args.dry_run)
+        log.info("frame cache evict (keep %dd, cutoff %s): %d stale, %d kept%s",
+                 args.keep_days, res["cutoff"], len(res["stale"]), res["kept"],
+                 " — dry-run, nothing deleted" if args.dry_run else f", {len(res['removed'])} removed")
+        for pid in res["stale"]:  # stdout = exactly what is (or would be) removed
+            print(pid)
+        return 0
+
+    if not args.data_raw:
+        build_parser().error(f"--data-raw is required for '{args.op}'")
 
     if args.op == "pull":
         frames = _read_frames(args)

--- a/tests/unit/test_cache_frames.py
+++ b/tests/unit/test_cache_frames.py
@@ -41,6 +41,13 @@ class FakeS3:
             raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "GetObject")
         Fileobj.write(self.store[Key])
 
+    def list_objects_v2(self, Bucket, Prefix="", ContinuationToken=None):
+        keys = sorted(k for k in self.store if k.startswith(Prefix))
+        return {"Contents": [{"Key": k} for k in keys], "IsTruncated": False}
+
+    def delete_object(self, Bucket, Key):
+        self.store.pop(Key, None)
+
 
 VALID_ID = "S1A_IW_GRDH_1SDV_20240101T060000_20240101T060025_052000_064700_ABCD"
 VALID_ID_2 = "S1A_IW_GRDH_1SDV_20240113T060000_20240113T060025_052100_064800_EF01"
@@ -351,3 +358,111 @@ class TestSafeExtract:
         with tarfile.open(fileobj=buf, mode="r") as tar:
             cf._safe_extract(tar, dest)
         assert (dest / f"{VALID_ID}.SAFE" / "manifest.safe").is_file()
+
+
+# --------------------------------------------------------------------------- #
+# Eviction / retention (T9)
+# --------------------------------------------------------------------------- #
+from datetime import date  # noqa: E402
+
+
+def _seed_cache(s3, prefix, *prod_ids):
+    for pid in prod_ids:
+        s3.store[cf.frame_key(prefix, pid)] = b"tarbytes"
+
+
+class TestAcqDate:
+    def test_parses_start_date(self):
+        # VALID_ID acquisition start = 2024-01-01
+        assert cf._acq_date(VALID_ID) == date(2024, 1, 1)
+        assert cf._acq_date(VALID_ID_2) == date(2024, 1, 13)
+
+    def test_raises_on_no_timestamp(self):
+        with pytest.raises(ValueError):
+            cf._acq_date("S1A_IW_GRDH_no_timestamp_here_xxxxxxxxxx")
+
+
+class TestListCachedFrames:
+    def test_lists_tar_keys_only(self, tmp_path):
+        s3 = FakeS3()
+        _seed_cache(s3, "fc", VALID_ID, VALID_ID_2)
+        s3.store["fc/not-a-tar.txt"] = b"x"          # ignored (not .tar)
+        s3.store["fc/garbage.tar"] = b"x"            # ignored (invalid id)
+        assert sorted(cf.list_cached_frames(s3, "b", "fc")) == sorted([VALID_ID, VALID_ID_2])
+
+    def test_paginates(self):
+        class PagedS3(FakeS3):
+            def list_objects_v2(self, Bucket, Prefix="", ContinuationToken=None):
+                keys = sorted(k for k in self.store if k.startswith(Prefix))
+                start = int(ContinuationToken or 0)
+                page = keys[start:start + 1]
+                more = start + 1 < len(keys)
+                return {"Contents": [{"Key": k} for k in page],
+                        "IsTruncated": more, "NextContinuationToken": str(start + 1)}
+        s3 = PagedS3()
+        _seed_cache(s3, "fc", VALID_ID, VALID_ID_2, S1D_ID)
+        assert sorted(cf.list_cached_frames(s3, "b", "fc")) == sorted([VALID_ID, VALID_ID_2, S1D_ID])
+
+
+class TestEvictStale:
+    # cache holds frames acquired 2024-01-01, 2024-01-02, 2024-01-13
+    def _seeded(self):
+        s3 = FakeS3()
+        _seed_cache(s3, "fc", VALID_ID, S1D_ID, VALID_ID_2)
+        return s3
+
+    def test_removes_only_stale(self):
+        s3 = self._seeded()
+        # today=2024-01-20, keep 10 days -> cutoff 2024-01-10: 01-01 & 01-02 stale, 01-13 kept
+        res = cf.evict_stale(s3, "b", "fc", keep_days=10, today=date(2024, 1, 20))
+        assert res["stale"] == sorted([VALID_ID, S1D_ID])
+        assert res["removed"] == sorted([VALID_ID, S1D_ID])
+        assert res["kept"] == 1
+        assert cf.frame_key("fc", VALID_ID) not in s3.store      # actually deleted
+        assert cf.frame_key("fc", VALID_ID_2) in s3.store        # in-window retained
+
+    def test_dry_run_deletes_nothing(self):
+        s3 = self._seeded()
+        before = dict(s3.store)
+        res = cf.evict_stale(s3, "b", "fc", keep_days=10, today=date(2024, 1, 20), dry_run=True)
+        assert res["stale"] == sorted([VALID_ID, S1D_ID])   # reports what WOULD go
+        assert res["removed"] == []
+        assert s3.store == before                            # nothing deleted
+
+    def test_keeps_everything_within_window(self):
+        s3 = self._seeded()
+        res = cf.evict_stale(s3, "b", "fc", keep_days=3650, today=date(2024, 1, 20))
+        assert res["stale"] == []
+        assert res["kept"] == 3
+
+    def test_unparseable_acq_date_is_kept(self):
+        # An on-disk key that passes id validation but whose date can't be parsed must
+        # never be deleted (conservative — same principle as pull/T1).
+        s3 = FakeS3()
+        weird = "S1A_NO_TIMESTAMP_AT_ALL_PADDING_XXXXXXXX"
+        assert cf.validate_prod_id(weird) == weird  # passes the id grammar
+        s3.store[cf.frame_key("fc", weird)] = b"x"
+        res = cf.evict_stale(s3, "b", "fc", keep_days=1, today=date(2024, 1, 20))
+        assert res["stale"] == []
+        assert res["kept"] == 1
+        assert cf.frame_key("fc", weird) in s3.store
+
+
+class TestEvictCLI:
+    def test_evict_does_not_require_data_raw(self, capsys):
+        s3 = FakeS3()
+        _seed_cache(s3, "fc", VALID_ID, VALID_ID_2)
+        import unittest.mock as mock
+        with mock.patch.object(cf, "make_s3_client", return_value=s3):
+            rc = cf.main(["evict", "--bucket", "b", "--prefix", "fc",
+                          "--keep-days", "10", "--today", "2024-01-20", "--dry-run"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert VALID_ID in out          # stale (2024-01-01) printed
+        assert VALID_ID_2 not in out    # in-window not printed
+
+    def test_pull_still_requires_data_raw(self):
+        s3 = FakeS3()
+        import unittest.mock as mock
+        with mock.patch.object(cf, "make_s3_client", return_value=s3), pytest.raises(SystemExit):
+            cf.main(["pull", "--bucket", "b", "--frames", VALID_ID])


### PR DESCRIPTION
Adds the **T9** cache-eviction op to `scripts/cache_frames.py` so the in-region S3 frame cache stays bounded — a prerequisite for deploying the cache safely. Feeds the S1 GRD Phases 5+6 integration line (#186); part of the caching effort (#319).

## What
`cache_frames.py evict` — delete frames whose **acquisition date** (parsed from the product id) is older than `today - keep_days` (default 21 = cron lookback 7 + margin).

```
cache_frames.py evict --bucket <b> --prefix frame-cache --dry-run            # list what would go
cache_frames.py evict --bucket <b> --prefix frame-cache --keep-days 21       # delete stale
```

## Design (ai-engineering)
- **Acquisition date, not S3 LastModified.** A frame pulled (read) many times never refreshes its mtime, so an mtime rule would wrongly evict still-in-window frames. Acquisition date is deterministic from the id and matches "keyed to the lookback window".
- **`--dry-run`** prints exactly the stale set without deleting — the T9 acceptance criterion.
- **Conservative**: a key passing id validation but with an unparseable date is **kept** (never delete what we can't classify — same principle as pull/T1).
- `--data-raw` made optional (evict doesn't need it; pull/populate still require it). Paginated listing.

## Verify
- **10 new unit tests** (acq-date parse, paginated listing, removes-stale / keeps-in-window / dry-run-deletes-nothing / conservative-keep-unparseable, CLI evict-without-data-raw, pull-still-requires-data-raw) — in-memory fake S3, no moto.
- **Full unit suite green (630)**; ruff clean; CLI smoke (`{pull,populate,evict}`).

## Scope
Inert until the cache is wired (T7) + provisioned (T4) — ships ready so eviction exists *before* the cache goes live. T7 deliberately deferred until T4 + the cluster make it runtime-testable (not shipped blind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)