### PR TITLE
fix(s1-caching): key frame cache by acquisition + fix SAFE layout (T10 finding)

### DIFF
--- a/claude-docs/plans/s1_input_data_caching.md
+++ b/claude-docs/plans/s1_input_data_caching.md
@@ -305,7 +305,29 @@ adjacent tiles sharing a frame — second after first — the second cache-hits 
 **Acceptance criteria**:
 - [ ] Policy defined + applied; a dry-run lists exactly the stale objects it would remove.
 
-### Task 10 — A/B canary: cached vs current, 6 frame-sharing tiles  <status: blocked: T7>
+### Task 10 — A/B canary: cached vs current, 6 frame-sharing tiles  <status: 1-tile smoke run 2026-07-01 — CAUGHT + FIXED a fatal parity bug; needs re-smoke on the fix image>
+
+**⚠️ RUNTIME FINDING (1-tile smoke `s1canary-wn-cold`, 33TWN) — the cache would NEVER hit as first built.**
+The smoke SUCCEEDED as a *test*: cache-pull + `list_tile_frames` ran correctly (2 candidate frames, 2 misses
+on the cold cache), process produced valid GeoTIFFs, but **cache-populate uploaded 0** and the cache stayed
+empty. Root cause (from the archived s1processor + cache-populate logs) = two parity bugs:
+1. **Frame-id source mismatch (fatal).** `list_tile_frames` reads the CDSE **STAC `sentinel-1-grd`** collection
+   → **COG** ids (`…_0831D4_8DC1_COG`). eodag/S1Tiling downloads the **classic SAFE** (`…_0831D4_19B8` — no
+   `_COG`, *different trailing hash*). Both coexist in CDSE OData (mid-migration). STAC id ≠ SAFE dir → cache
+   key never matches → pull always misses. (An earlier OData spot-check *seemed* to confirm parity — it
+   matched on the shared datatake fragment and hit the COG record, not eodag's classic one. Only running it
+   for real exposed the truth.)
+2. **SAFE layout mismatch.** Real on-disk: `data_raw/{prod_id}/manifest.safe` (measurement/ directly under
+   `{prod_id}/`). `cache_frames` assumed `data_raw/{prod_id}/{prod_id}.SAFE/manifest.safe` → discover found 0.
+
+**✅ FIX (branch `fix/s1-caching-frame-key`, `cache_frames.py` only, 57 tests green):** key the cache by the
+**acquisition** (`acquisition_key` = first 8 id fields = mission_mode_type_class_start_stop_orbit_datatake),
+so the classic id eodag downloads and the COG id the STAC lists map to the **same** `{acq}.tar`; the tar
+preserves the real (classic) dir name so pull restores exactly what S1Tiling's scan skips. Plus the layout
+fix (`data_raw/{prod_id}/manifest.safe`, tar arcname = the real product dir). `list_tile_frames` + the T7
+template are unchanged. Proven by `test_cog_id_pulls_classic_cached_frame` (classic-populate → COG-pull = hit).
+Needs a fresh image (rc9) + an off-peak **re-smoke** to confirm the live cache-hit end-to-end.
+
 **What**: Prove the win by A/B comparison on a **6-tile canary**, not by re-asserting §4. **Both arms are
 GeoTIFF-only (skip the ingest template) and override `s3_output_bucket` to an isolated canary prefix** —
 perf comparison, no prod cube/STAC writes (see **Isolation invariants**). Both use the same image / window /

--- a/scripts/cache_frames.py
+++ b/scripts/cache_frames.py
@@ -199,10 +199,23 @@ def pull_frame(s3: Any, bucket: str, prefix: str, prod_id: str, data_raw: str | 
             buf.seek(0)
             with tarfile.open(fileobj=buf, mode="r:*") as tar:
                 _safe_extract(tar, staging)
-        safes = [p for p in sorted(staging.iterdir()) if p.is_dir() and _has_manifest(p)]
-        if not safes:
-            raise RuntimeError(f"cache tar for {acq} did not yield a product with manifest.safe")
-        for safe in safes:
+        # Restore ONLY the product dir whose acquisition matches the key we pulled — a
+        # well-formed cache tar holds exactly that one; refusing to move any other dir
+        # keeps a malformed/multi-dir object from splattering unrelated SAFEs into data_raw.
+        matching, extras = [], []
+        for p in sorted(staging.iterdir()):
+            if not (p.is_dir() and _has_manifest(p)):
+                continue
+            try:
+                is_match = acquisition_key(p.name) == acq
+            except ValueError:
+                is_match = False
+            (matching if is_match else extras).append(p)
+        if not matching:
+            raise RuntimeError(f"cache tar for {acq} did not yield a matching product with manifest.safe")
+        for extra in extras:
+            log.warning("cache tar for %s carried an unexpected product %s; ignoring it", acq, extra.name)
+        for safe in matching:
             final = target_root / safe.name
             if final.exists():
                 shutil.rmtree(final)

--- a/scripts/cache_frames.py
+++ b/scripts/cache_frames.py
@@ -49,6 +49,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -86,14 +87,11 @@ def validate_prod_id(prod_id: str) -> str:
 
 
 def acquisition_key(prod_id: str) -> str:
-    """The per-acquisition cache key: the product id minus its trailing unique-id
-    field (and any ``_COG`` format tag). CDSE serves each acquisition as BOTH a classic
-    SAFE (e.g. ``…_064700_ABCD``) and a COG (``…_064700_9F3E_COG``) with *different*
-    trailing ids; eodag downloads the classic while the STAC (``list_tile_frames``)
-    lists the COG. Keying by the shared acquisition — the first 8 underscore fields,
-    ``mission_mode_type_class_start_stop_orbit_datatake`` — lets a frame cached from the
-    classic id be found by the COG id. Idempotent: an id already trimmed to 8 fields
-    returns unchanged."""
+    """The per-acquisition cache key: the first 8 underscore fields of the product id
+    (``mission_mode_type_class_start_stop_orbit_datatake``), dropping the trailing
+    unique-id and any ``_COG`` tag — so CDSE's classic-SAFE and COG representations of
+    one frame (see the module docstring) map to the same cache object. Idempotent on an
+    8-field key; raises if the id has fewer than 8 fields."""
     validate_prod_id(prod_id)
     fields = prod_id.split("_")
     if len(fields) < 8:
@@ -106,32 +104,32 @@ def frame_key(prefix: str, prod_id: str) -> str:
     return f"{prefix.rstrip('/')}/{acquisition_key(prod_id)}.tar"
 
 
-def _safe_dir(data_raw: str | Path, prod_id: str) -> Path:
-    """The extracted product dir: eodag-4 puts manifest.safe + measurement/ DIRECTLY
-    under data_raw/{prod_id}/ (no nested {prod_id}.SAFE/)."""
-    return Path(data_raw) / prod_id
-
-
 def _has_manifest(safe_dir: str | Path) -> bool:
     return (Path(safe_dir) / "manifest.safe").is_file()
+
+
+def _manifest_dirs_by_acq(root: str | Path) -> Iterator[tuple[Path, str | None]]:
+    """Yield ``(dir, acquisition_key)`` for each extracted product dir under ``root``
+    (a child holding manifest.safe). The key is None for a dir whose name isn't a valid
+    S1 product id. The single scan of the classic on-disk names shared by the pull
+    present-check and the post-extract restore."""
+    base = Path(root)
+    if not base.is_dir():
+        return
+    for child in sorted(base.iterdir()):
+        if not (child.is_dir() and _has_manifest(child)):
+            continue
+        try:
+            yield child, acquisition_key(child.name)
+        except ValueError:
+            yield child, None
 
 
 def _present_dir_for_key(data_raw: str | Path, acq_key: str) -> Path | None:
     """An extracted product dir already in data_raw whose acquisition_key == acq_key,
     or None. The on-disk dir is named with the classic product id (…_ABCD); a pull
     keyed by the COG id must still recognise it as already present (idempotency)."""
-    root = Path(data_raw)
-    if not root.is_dir():
-        return None
-    for child in sorted(root.iterdir()):
-        if not (child.is_dir() and _has_manifest(child)):
-            continue
-        try:
-            if acquisition_key(child.name) == acq_key:
-                return child
-        except ValueError:
-            continue
-    return None
+    return next((d for d, k in _manifest_dirs_by_acq(data_raw) if k == acq_key), None)
 
 
 def cache_has(s3: Any, bucket: str, key: str) -> bool:
@@ -202,24 +200,18 @@ def pull_frame(s3: Any, bucket: str, prefix: str, prod_id: str, data_raw: str | 
         # Restore ONLY the product dir whose acquisition matches the key we pulled — a
         # well-formed cache tar holds exactly that one; refusing to move any other dir
         # keeps a malformed/multi-dir object from splattering unrelated SAFEs into data_raw.
-        matching, extras = [], []
-        for p in sorted(staging.iterdir()):
-            if not (p.is_dir() and _has_manifest(p)):
-                continue
-            try:
-                is_match = acquisition_key(p.name) == acq
-            except ValueError:
-                is_match = False
-            (matching if is_match else extras).append(p)
-        if not matching:
+        matched: Path | None = None
+        for cand, cand_key in _manifest_dirs_by_acq(staging):
+            if matched is None and cand_key == acq:
+                matched = cand
+            else:
+                log.warning("cache tar for %s carried an unexpected product %s; ignoring it", acq, cand.name)
+        if matched is None:
             raise RuntimeError(f"cache tar for {acq} did not yield a matching product with manifest.safe")
-        for extra in extras:
-            log.warning("cache tar for %s carried an unexpected product %s; ignoring it", acq, extra.name)
-        for safe in matching:
-            final = target_root / safe.name
-            if final.exists():
-                shutil.rmtree(final)
-            os.replace(safe, final)  # atomic on the same filesystem
+        final = target_root / matched.name
+        if final.exists():
+            shutil.rmtree(final)
+        os.replace(matched, final)  # atomic on the same filesystem
     finally:
         shutil.rmtree(staging, ignore_errors=True)
     return "hit"
@@ -269,7 +261,8 @@ def populate_frame(
     an upload size mismatch (silent partial — the failure mode of the old
     csi-rclone writeback this design replaces)."""
     validate_prod_id(prod_id)
-    safe_dir = _safe_dir(data_raw, prod_id)
+    # eodag-4 puts manifest.safe + measurement/ directly under data_raw/{prod_id}/.
+    safe_dir = Path(data_raw) / prod_id
     if not _has_manifest(safe_dir):
         return "absent"
     key = frame_key(prefix, prod_id)
@@ -335,7 +328,7 @@ def discover_downloaded_frames(data_raw: str | Path) -> list[str]:
     if not root.is_dir():
         return out
     for child in sorted(root.iterdir()):
-        if child.is_dir() and (child / "manifest.safe").is_file():
+        if child.is_dir() and _has_manifest(child):
             try:
                 out.append(validate_prod_id(child.name))
             except ValueError:

--- a/scripts/cache_frames.py
+++ b/scripts/cache_frames.py
@@ -6,7 +6,15 @@ per-tile S1Tiling workflows each re-download the same frame from CDSE. This modu
 caches the *extracted SAFE tree* of each frame as one tar object in an in-region S3
 prefix, keyed by product id:
 
-    {prefix}/{prod_id}.tar      <-  tar of  data_raw/{prod_id}/{prod_id}.SAFE/
+    {prefix}/{acquisition_key}.tar   <-  tar of  data_raw/{prod_id}/
+
+The tar's root dir is the real downloaded product id (`{prod_id}/`), whose extracted
+SAFE contents (`manifest.safe`, `measurement/` …) live DIRECTLY inside it — the eodag-4
+cop_dataspace layout, NOT a nested `{prod_id}.SAFE/`. The object is keyed by the
+*acquisition* (see ``acquisition_key``), not the full product id: CDSE serves each
+acquisition as both a classic SAFE (which eodag downloads) and a COG (which the STAC
+lists) with different trailing ids, so keying by what they share lets a frame cached
+from one be found by the other.
 
 Operations: pull/populate are wired around s1processor by the Argo template (T7);
 evict runs periodically (e.g. a small scheduled step) to bound the cache.
@@ -77,20 +85,53 @@ def validate_prod_id(prod_id: str) -> str:
     return prod_id
 
 
-def frame_key(prefix: str, prod_id: str) -> str:
-    """S3 key for a frame's cache tar. Validates prod_id first."""
+def acquisition_key(prod_id: str) -> str:
+    """The per-acquisition cache key: the product id minus its trailing unique-id
+    field (and any ``_COG`` format tag). CDSE serves each acquisition as BOTH a classic
+    SAFE (e.g. ``…_064700_ABCD``) and a COG (``…_064700_9F3E_COG``) with *different*
+    trailing ids; eodag downloads the classic while the STAC (``list_tile_frames``)
+    lists the COG. Keying by the shared acquisition — the first 8 underscore fields,
+    ``mission_mode_type_class_start_stop_orbit_datatake`` — lets a frame cached from the
+    classic id be found by the COG id. Idempotent: an id already trimmed to 8 fields
+    returns unchanged."""
     validate_prod_id(prod_id)
-    return f"{prefix.rstrip('/')}/{prod_id}.tar"
+    fields = prod_id.split("_")
+    if len(fields) < 8:
+        raise ValueError(f"S1 product id has too few fields for an acquisition key: {prod_id!r}")
+    return "_".join(fields[:8])
+
+
+def frame_key(prefix: str, prod_id: str) -> str:
+    """S3 key for a frame's cache tar, keyed by acquisition (classic/COG-agnostic)."""
+    return f"{prefix.rstrip('/')}/{acquisition_key(prod_id)}.tar"
 
 
 def _safe_dir(data_raw: str | Path, prod_id: str) -> Path:
-    return Path(data_raw) / prod_id / f"{prod_id}.SAFE"
+    """The extracted product dir: eodag-4 puts manifest.safe + measurement/ DIRECTLY
+    under data_raw/{prod_id}/ (no nested {prod_id}.SAFE/)."""
+    return Path(data_raw) / prod_id
 
 
-def _is_present(data_raw: str | Path, prod_id: str) -> bool:
-    """True if the extracted SAFE is already on disk (S1Tiling's skip condition:
-    a valid manifest.safe under {prod_id}.SAFE/)."""
-    return (_safe_dir(data_raw, prod_id) / "manifest.safe").is_file()
+def _has_manifest(safe_dir: str | Path) -> bool:
+    return (Path(safe_dir) / "manifest.safe").is_file()
+
+
+def _present_dir_for_key(data_raw: str | Path, acq_key: str) -> Path | None:
+    """An extracted product dir already in data_raw whose acquisition_key == acq_key,
+    or None. The on-disk dir is named with the classic product id (…_ABCD); a pull
+    keyed by the COG id must still recognise it as already present (idempotency)."""
+    root = Path(data_raw)
+    if not root.is_dir():
+        return None
+    for child in sorted(root.iterdir()):
+        if not (child.is_dir() and _has_manifest(child)):
+            continue
+        try:
+            if acquisition_key(child.name) == acq_key:
+                return child
+        except ValueError:
+            continue
+    return None
 
 
 def cache_has(s3: Any, bucket: str, key: str) -> bool:
@@ -136,34 +177,36 @@ def pull_frame(s3: Any, bucket: str, prefix: str, prod_id: str, data_raw: str | 
     on an invalid id or a tar that does not yield a valid SAFE (integrity failure).
     """
     validate_prod_id(prod_id)
-    if _is_present(data_raw, prod_id):
+    acq = acquisition_key(prod_id)
+    if _present_dir_for_key(data_raw, acq) is not None:
         return "present"
     key = frame_key(prefix, prod_id)
     if not cache_has(s3, bucket, key):
         return "miss"
-    target = Path(data_raw) / prod_id
-    target.mkdir(parents=True, exist_ok=True)
+    target_root = Path(data_raw)
+    target_root.mkdir(parents=True, exist_ok=True)
     # Stage into a temp dir on the SAME volume, verify the manifest, then swap the
-    # SAFE in atomically. A failed or truncated pull must NOT leave a partial SAFE in
-    # data_raw — s1processor would then see a manifest-less tree and mishandle it. The
-    # tar buffer and the staging tree both live under data_raw (sized for SAFEs), not
-    # /tmp (a small emptyDir/overlay that 8-way concurrency could exhaust).
-    staging = Path(tempfile.mkdtemp(dir=target, prefix=".cache-stage-"))
+    # product dir in atomically. A failed or truncated pull must NOT leave a partial
+    # tree in data_raw — s1processor would then see a manifest-less product and mishandle
+    # it. The tar buffer and the staging tree both live under data_raw (sized for SAFEs),
+    # not /tmp (a small emptyDir/overlay that 8-way concurrency could exhaust). The tar's
+    # top dir is the real (classic) product id, which we restore as-is so S1Tiling's disk
+    # scan recognises the frame even though we looked it up by the COG id.
+    staging = Path(tempfile.mkdtemp(dir=target_root, prefix=".cache-stage-"))
     try:
-        with tempfile.TemporaryFile(dir=target) as buf:
+        with tempfile.TemporaryFile(dir=target_root) as buf:
             s3.download_fileobj(bucket, key, buf)
             buf.seek(0)
             with tarfile.open(fileobj=buf, mode="r:*") as tar:
                 _safe_extract(tar, staging)
-        staged_safe = staging / f"{prod_id}.SAFE"
-        if not (staged_safe / "manifest.safe").is_file():
-            raise RuntimeError(
-                f"cache tar for {prod_id} did not yield {prod_id}.SAFE/manifest.safe"
-            )
-        final = target / f"{prod_id}.SAFE"
-        if final.exists():
-            shutil.rmtree(final)
-        os.replace(staged_safe, final)  # atomic on the same filesystem
+        safes = [p for p in sorted(staging.iterdir()) if p.is_dir() and _has_manifest(p)]
+        if not safes:
+            raise RuntimeError(f"cache tar for {acq} did not yield a product with manifest.safe")
+        for safe in safes:
+            final = target_root / safe.name
+            if final.exists():
+                shutil.rmtree(final)
+            os.replace(safe, final)  # atomic on the same filesystem
     finally:
         shutil.rmtree(staging, ignore_errors=True)
     return "hit"
@@ -214,16 +257,18 @@ def populate_frame(
     csi-rclone writeback this design replaces)."""
     validate_prod_id(prod_id)
     safe_dir = _safe_dir(data_raw, prod_id)
-    if not (safe_dir / "manifest.safe").is_file():
+    if not _has_manifest(safe_dir):
         return "absent"
     key = frame_key(prefix, prod_id)
     if not overwrite and cache_has(s3, bucket, key):
         return "cached"
     with tempfile.TemporaryFile() as buf:
         with tarfile.open(fileobj=buf, mode="w") as tar:
-            # arcname starts at {prod_id}.SAFE so a pull extracts into
-            # data_raw/{prod_id}/{prod_id}.SAFE/ — symmetric with pull_frame.
-            tar.add(safe_dir, arcname=f"{prod_id}.SAFE")
+            # arcname = the real product dir so a pull restores data_raw/{prod_id}/
+            # (manifest.safe + measurement/ directly inside — the eodag-4 layout that
+            # S1Tiling's disk scan skips). Keyed by acquisition (frame_key) so a sibling
+            # tile that lists this frame as a COG id still finds this classic-SAFE tar.
+            tar.add(safe_dir, arcname=prod_id)
         size = buf.tell()
         buf.seek(0)
         s3.upload_fileobj(buf, bucket, key)
@@ -277,7 +322,7 @@ def discover_downloaded_frames(data_raw: str | Path) -> list[str]:
     if not root.is_dir():
         return out
     for child in sorted(root.iterdir()):
-        if child.is_dir() and (child / f"{child.name}.SAFE" / "manifest.safe").is_file():
+        if child.is_dir() and (child / "manifest.safe").is_file():
             try:
                 out.append(validate_prod_id(child.name))
             except ValueError:

--- a/tests/unit/test_cache_frames.py
+++ b/tests/unit/test_cache_frames.py
@@ -120,6 +120,12 @@ class TestAcquisitionKey:
         with pytest.raises(ValueError):
             cf.acquisition_key("../evil")
 
+    def test_rejects_too_few_fields(self):
+        # valid id grammar (passes validate_prod_id) but not enough fields to name an
+        # acquisition — must fail loud rather than silently key on a truncated prefix.
+        with pytest.raises(ValueError, match="too few fields"):
+            cf.acquisition_key("S1A_IW_GRDH_TOOSHORT")
+
 
 # --------------------------------------------------------------------------- #
 # Pull
@@ -172,6 +178,26 @@ class TestPull:
         _make_safe(tmp_path, CLASSIC_ID)
         s3 = FakeS3()
         assert cf.pull_frame(s3, "b", "fc", COG_ID, tmp_path) == "present"
+
+    def test_pull_moves_only_matching_acquisition_dir(self, tmp_path):
+        # Defence: a (malformed) cache tar carrying an extra unrelated SAFE must restore
+        # ONLY the frame we asked for, never splatter the extra into data_raw.
+        other_id = "S1A_IW_GRDH_1SDV_20260618T052000_20260618T052025_065019_0831D4_9999"
+        src, dst = tmp_path / "src", tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        _make_safe(src, CLASSIC_ID, tiff=b"want")
+        _make_safe(src, other_id, tiff=b"unwanted")
+        s3 = FakeS3()
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tar:
+            tar.add(src / CLASSIC_ID, arcname=CLASSIC_ID)
+            tar.add(src / other_id, arcname=other_id)  # extra, different acquisition
+        s3.store[cf.frame_key("fc", CLASSIC_ID)] = buf.getvalue()
+
+        assert cf.pull_frame(s3, "b", "fc", COG_ID, dst) == "hit"
+        assert (dst / CLASSIC_ID / "manifest.safe").is_file()
+        assert not (dst / other_id).exists()  # unrelated SAFE ignored
 
     def test_pull_rejects_invalid_id_before_io(self, tmp_path):
         s3 = FakeS3()

--- a/tests/unit/test_cache_frames.py
+++ b/tests/unit/test_cache_frames.py
@@ -53,10 +53,16 @@ VALID_ID = "S1A_IW_GRDH_1SDV_20240101T060000_20240101T060025_052000_064700_ABCD"
 VALID_ID_2 = "S1A_IW_GRDH_1SDV_20240113T060000_20240113T060025_052100_064800_EF01"
 S1D_ID = "S1D_IW_GRDH_1SDV_20240102T060000_20240102T060025_001000_002000_BEEF"
 
+# The same acquisition served two ways by CDSE: eodag downloads the classic SAFE,
+# list_tile_frames lists the COG. They share the first 8 fields (the acquisition key).
+CLASSIC_ID = "S1A_IW_GRDH_1SDV_20260618T051026_20260618T051051_065019_0831D4_19B8"
+COG_ID = "S1A_IW_GRDH_1SDV_20260618T051026_20260618T051051_065019_0831D4_8DC1_COG"
+
 
 def _make_safe(data_raw, prod_id, tiff=b"raster-bytes"):
-    """Create a minimal extracted SAFE tree on disk."""
-    safe = Path(data_raw) / prod_id / f"{prod_id}.SAFE"
+    """Create a minimal extracted SAFE tree on disk (eodag-4 layout: manifest.safe +
+    measurement/ live DIRECTLY under data_raw/{prod_id}/, no nested {prod_id}.SAFE/)."""
+    safe = Path(data_raw) / prod_id
     (safe / "measurement").mkdir(parents=True)
     (safe / "manifest.safe").write_bytes(b"<xfdu:XFDU/>")
     (safe / "measurement" / "iw-vv.tiff").write_bytes(tiff)
@@ -89,10 +95,30 @@ class TestValidateProdId:
             cf.validate_prod_id(bad)
 
     def test_frame_key_validates_and_formats(self):
-        assert cf.frame_key("frame-cache", VALID_ID) == f"frame-cache/{VALID_ID}.tar"
-        assert cf.frame_key("frame-cache/", VALID_ID) == f"frame-cache/{VALID_ID}.tar"
+        acq = cf.acquisition_key(VALID_ID)
+        assert cf.frame_key("frame-cache", VALID_ID) == f"frame-cache/{acq}.tar"
+        assert cf.frame_key("frame-cache/", VALID_ID) == f"frame-cache/{acq}.tar"
         with pytest.raises(ValueError):
             cf.frame_key("frame-cache", "../evil")
+
+
+class TestAcquisitionKey:
+    def test_strips_trailing_unique_id(self):
+        assert cf.acquisition_key(CLASSIC_ID) == (
+            "S1A_IW_GRDH_1SDV_20260618T051026_20260618T051051_065019_0831D4"
+        )
+
+    def test_classic_and_cog_map_to_same_key(self):
+        # the whole point: eodag's classic id and the STAC's COG id key the same tar.
+        assert cf.acquisition_key(CLASSIC_ID) == cf.acquisition_key(COG_ID)
+
+    def test_idempotent_on_a_key(self):
+        k = cf.acquisition_key(CLASSIC_ID)
+        assert cf.acquisition_key(k) == k
+
+    def test_rejects_invalid_id(self):
+        with pytest.raises(ValueError):
+            cf.acquisition_key("../evil")
 
 
 # --------------------------------------------------------------------------- #
@@ -119,9 +145,33 @@ class TestPull:
         assert cf.populate_frame(s3, "b", "fc", VALID_ID, src) == "uploaded"
 
         assert cf.pull_frame(s3, "b", "fc", VALID_ID, dst) == "hit"
-        restored = dst / VALID_ID / f"{VALID_ID}.SAFE"
+        restored = dst / VALID_ID
         assert (restored / "manifest.safe").is_file()
         assert (restored / "measurement" / "iw-vv.tiff").read_bytes() == b"unique-pixels"
+
+    def test_cog_id_pulls_classic_cached_frame(self, tmp_path):
+        # THE parity fix: eodag downloads the classic SAFE (…_19B8); the next tile lists
+        # the same frame as a COG id (…_8DC1_COG). Populating from the classic id must be
+        # a cache HIT when pulled by the COG id, restored under the real classic dir name
+        # so S1Tiling's scan skips it.
+        src, dst = tmp_path / "src", tmp_path / "dst"
+        src.mkdir()
+        dst.mkdir()
+        _make_safe(src, CLASSIC_ID, tiff=b"classic-pixels")
+        s3 = FakeS3()
+        assert cf.populate_frame(s3, "b", "fc", CLASSIC_ID, src) == "uploaded"
+
+        assert cf.pull_frame(s3, "b", "fc", COG_ID, dst) == "hit"
+        restored = dst / CLASSIC_ID  # real classic dir name, not the COG id
+        assert (restored / "manifest.safe").is_file()
+        assert (restored / "measurement" / "iw-vv.tiff").read_bytes() == b"classic-pixels"
+        assert not (dst / COG_ID).exists()
+
+    def test_present_recognised_across_classic_cog(self, tmp_path):
+        # If the classic SAFE is already on disk, a pull by the COG id is a "present" no-op.
+        _make_safe(tmp_path, CLASSIC_ID)
+        s3 = FakeS3()
+        assert cf.pull_frame(s3, "b", "fc", COG_ID, tmp_path) == "present"
 
     def test_pull_rejects_invalid_id_before_io(self, tmp_path):
         s3 = FakeS3()
@@ -154,10 +204,8 @@ class TestPull:
         s3.store[cf.frame_key("fc", VALID_ID)] = buf.getvalue()
         with pytest.raises(RuntimeError):
             cf.pull_frame(s3, "b", "fc", VALID_ID, tmp_path)
-        assert not (tmp_path / VALID_ID / f"{VALID_ID}.SAFE").exists()
-        prod_dir = tmp_path / VALID_ID
-        leftovers = list(prod_dir.glob(".cache-stage-*")) if prod_dir.exists() else []
-        assert leftovers == []  # staging cleaned up
+        assert not (tmp_path / VALID_ID).exists()  # no partial product dir
+        assert list(tmp_path.glob(".cache-stage-*")) == []  # staging (under data_raw) cleaned up
 
     def test_failed_pull_via_pull_frames_degrades_to_miss_and_clean(self, tmp_path):
         s3 = FakeS3()
@@ -169,7 +217,7 @@ class TestPull:
         s3.store[cf.frame_key("fc", VALID_ID)] = buf.getvalue()
         results = cf.pull_frames(s3, "b", "fc", [VALID_ID], tmp_path)
         assert results[VALID_ID] == "miss"
-        assert not (tmp_path / VALID_ID / f"{VALID_ID}.SAFE").exists()
+        assert not (tmp_path / VALID_ID).exists()
 
 
 class TestPullFramesParallel:
@@ -351,13 +399,13 @@ class TestSafeExtract:
         _make_safe(src, VALID_ID)
         buf = io.BytesIO()
         with tarfile.open(fileobj=buf, mode="w") as tar:
-            tar.add(src / VALID_ID / f"{VALID_ID}.SAFE", arcname=f"{VALID_ID}.SAFE")
+            tar.add(src / VALID_ID, arcname=VALID_ID)
         buf.seek(0)
         dest = tmp_path / "dest"
         dest.mkdir()
         with tarfile.open(fileobj=buf, mode="r") as tar:
             cf._safe_extract(tar, dest)
-        assert (dest / f"{VALID_ID}.SAFE" / "manifest.safe").is_file()
+        assert (dest / VALID_ID / "manifest.safe").is_file()
 
 
 # --------------------------------------------------------------------------- #
@@ -388,7 +436,10 @@ class TestListCachedFrames:
         _seed_cache(s3, "fc", VALID_ID, VALID_ID_2)
         s3.store["fc/not-a-tar.txt"] = b"x"          # ignored (not .tar)
         s3.store["fc/garbage.tar"] = b"x"            # ignored (invalid id)
-        assert sorted(cf.list_cached_frames(s3, "b", "fc")) == sorted([VALID_ID, VALID_ID_2])
+        # cache objects are keyed by acquisition (the tar name), so list returns those.
+        assert sorted(cf.list_cached_frames(s3, "b", "fc")) == sorted(
+            [cf.acquisition_key(VALID_ID), cf.acquisition_key(VALID_ID_2)]
+        )
 
     def test_paginates(self):
         class PagedS3(FakeS3):
@@ -401,7 +452,9 @@ class TestListCachedFrames:
                         "IsTruncated": more, "NextContinuationToken": str(start + 1)}
         s3 = PagedS3()
         _seed_cache(s3, "fc", VALID_ID, VALID_ID_2, S1D_ID)
-        assert sorted(cf.list_cached_frames(s3, "b", "fc")) == sorted([VALID_ID, VALID_ID_2, S1D_ID])
+        assert sorted(cf.list_cached_frames(s3, "b", "fc")) == sorted(
+            [cf.acquisition_key(i) for i in (VALID_ID, VALID_ID_2, S1D_ID)]
+        )
 
 
 class TestEvictStale:
@@ -415,8 +468,8 @@ class TestEvictStale:
         s3 = self._seeded()
         # today=2024-01-20, keep 10 days -> cutoff 2024-01-10: 01-01 & 01-02 stale, 01-13 kept
         res = cf.evict_stale(s3, "b", "fc", keep_days=10, today=date(2024, 1, 20))
-        assert res["stale"] == sorted([VALID_ID, S1D_ID])
-        assert res["removed"] == sorted([VALID_ID, S1D_ID])
+        assert res["stale"] == sorted([cf.acquisition_key(VALID_ID), cf.acquisition_key(S1D_ID)])
+        assert res["removed"] == sorted([cf.acquisition_key(VALID_ID), cf.acquisition_key(S1D_ID)])
         assert res["kept"] == 1
         assert cf.frame_key("fc", VALID_ID) not in s3.store      # actually deleted
         assert cf.frame_key("fc", VALID_ID_2) in s3.store        # in-window retained
@@ -425,7 +478,7 @@ class TestEvictStale:
         s3 = self._seeded()
         before = dict(s3.store)
         res = cf.evict_stale(s3, "b", "fc", keep_days=10, today=date(2024, 1, 20), dry_run=True)
-        assert res["stale"] == sorted([VALID_ID, S1D_ID])   # reports what WOULD go
+        assert res["stale"] == sorted([cf.acquisition_key(VALID_ID), cf.acquisition_key(S1D_ID)])
         assert res["removed"] == []
         assert s3.store == before                            # nothing deleted
 
@@ -439,7 +492,9 @@ class TestEvictStale:
         # An on-disk key that passes id validation but whose date can't be parsed must
         # never be deleted (conservative — same principle as pull/T1).
         s3 = FakeS3()
-        weird = "S1A_NO_TIMESTAMP_AT_ALL_PADDING_XXXXXXXX"
+        # valid grammar + >=8 fields (so it forms an acquisition key), but no parseable
+        # YYYYMMDDThhmmss so its acquisition date can't be derived.
+        weird = "S1A_IW_GRDH_1SDV_NODATE_NOSTOP_052000_064700_ABCD"
         assert cf.validate_prod_id(weird) == weird  # passes the id grammar
         s3.store[cf.frame_key("fc", weird)] = b"x"
         res = cf.evict_stale(s3, "b", "fc", keep_days=1, today=date(2024, 1, 20))
@@ -458,8 +513,8 @@ class TestEvictCLI:
                           "--keep-days", "10", "--today", "2024-01-20", "--dry-run"])
         assert rc == 0
         out = capsys.readouterr().out
-        assert VALID_ID in out          # stale (2024-01-01) printed
-        assert VALID_ID_2 not in out    # in-window not printed
+        assert cf.acquisition_key(VALID_ID) in out          # stale (2024-01-01) printed
+        assert cf.acquisition_key(VALID_ID_2) not in out    # in-window not printed
 
     def test_pull_still_requires_data_raw(self):
         s3 = FakeS3()


### PR DESCRIPTION
## What

Fixes two parity bugs in `scripts/cache_frames.py` that the **1-tile canary smoke (33TWN)** exposed — the frame cache would **never hit** as first built. Part of S1 input-data caching (#319, plan Task 10).

## The finding (runtime, not seems-right)

The smoke succeeded as a *test*: `cache-pull` + `list_tile_frames` ran correctly (2 candidate frames, 2 cold misses), `process` produced valid GeoTIFFs — but `cache-populate` uploaded **0** and the cache stayed empty. Archived logs showed:

1. **Frame-id mismatch (fatal).** `list_tile_frames` reads the CDSE **STAC `sentinel-1-grd`** collection → **COG** ids (`…_0831D4_8DC1_COG`). eodag/S1Tiling downloads the **classic SAFE** (`…_0831D4_19B8` — no `_COG`, *different trailing hash*). Both coexist in CDSE OData (mid-migration). The STAC id can't be transformed to the SAFE id → cache key never matched.
2. **SAFE layout.** eodag-4 extracts to `data_raw/{prod_id}/manifest.safe` (measurement/ directly inside), not the assumed `…/{prod_id}/{prod_id}.SAFE/`. So `discover_downloaded_frames` found nothing.

(An earlier OData spot-check *seemed* to confirm parity — it matched the shared datatake fragment and hit the COG record, not eodag's classic one. Only running it live exposed it. This is the plan's T8 gate — *parity fails → stop and rethink the source* — hit at runtime.)

## The fix (cache_frames.py only)

- **`acquisition_key(prod_id)`** = the first 8 id fields (`mission_mode_type_class_start_stop_orbit_datatake`), dropping the trailing unique id + any `_COG`. The classic id eodag downloads and the COG id the STAC lists map to the **same `{acq}.tar`**, so a frame cached from one is found by the other.
- The tar's root dir is the **real (classic) product id**, restored as-is, so S1Tiling's disk scan recognises the frame even though pull looked it up by the COG id.
- Correct the on-disk layout to `data_raw/{prod_id}/manifest.safe` throughout (discover, populate arcname, pull extract, present-check).

`list_tile_frames` and the T7 template are **unchanged** (still yield/pipe COG ids; the mapping is internal to `cache_frames`).

## Tests

57 unit tests green, incl. **`test_cog_id_pulls_classic_cached_frame`** (classic-populate → COG-pull = hit), the acquisition-key mapping/idempotency tests, and the updated layout/evict assertions. ruff clean.

## Follow-up

Needs a fresh image (rc9) + an **off-peak re-smoke** to confirm the live cache-hit end-to-end (the cron was contending during the first smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)