### PR TITLE
fix(s1-dem): tile_bbox returns the true 109.8 km S2 extent (fixes recurring exit-66)

### DIFF
--- a/scripts/gen_aoi_tiles.py
+++ b/scripts/gen_aoi_tiles.py
@@ -68,6 +68,10 @@ EXCLUDE: dict[str, set[str]] = {
         "30TUT",  # 0.1%  offshore SW Brittany
         "31TFH",  # 1.1%  Gulf of Lion
         "32TLN",  # 1.7%  Ligurian Sea
+        # Surfaced when tile_bbox gained the true 109.8 km S2 extent (their bbox now touches the
+        # part-land N46/W003 cell); the tiles themselves end at −2.87°E, all open sea.
+        "30TVR",  # 0.0%  Bay of Biscay
+        "30TVS",  # 0.0%  Bay of Biscay
     },
 }
 

--- a/scripts/watch_cdse_and_process.py
+++ b/scripts/watch_cdse_and_process.py
@@ -14,6 +14,7 @@ import argparse
 import datetime as dt
 import json
 import logging
+import math
 import os
 import subprocess
 from pathlib import Path
@@ -42,11 +43,27 @@ STATE_FILE = Path("data/.processed_products.json")
 State = dict[str, dict[str, list[dict[str, str]]]]
 
 
-def tile_bbox(tile_id: str) -> list[float]:
-    """Return the WGS84 bbox [lon_min, lat_min, lon_max, lat_max] of an MGRS 100 km square.
+# An S2 tile is a 109.8 km square anchored at the NW corner of its MGRS 100 km square, so it
+# extends 9.8 km beyond the square's east and south edges. `mgrs` only knows the 100 km square;
+# the un-padded bbox starved AgglomerateDEM of the easternmost DEM cell on 32TMT (exit 66,
+# 2026-07-02 — see claude-docs/plans/s1_ensure_dem_true_tile_bbox.md).
+S2_TILE_OVERHANG_M = 109_800.0 - 100_000.0
+# The true tile also pokes past the square-corner bbox on the west/north sides: grid convergence
+# tilts the edges (~9800·tan γ, ≤ ~0.7 km at the 84° MGRS limit) and parallel curvature bows the
+# N/S edges between the sampled corners (sagitta ≈ 236·tan(lat) m, ≤ ~2.3 km at 84°). A flat 3 km
+# tolerance bounds both anywhere the grid exists; measured worst case in the AOI+33H sweep test is
+# ~0.42 km. Cost: the DEM window gains a 1° cell only within 3 km of a degree boundary.
+BBOX_TOLERANCE_M = 3_000.0
+METERS_PER_DEG_LAT = 111_320.0
 
-    The square's corners are not axis-aligned in lat/lon, so the bbox is the min/max over all four
-    corners. Raises ``ValueError`` for a malformed/unknown tile id.
+
+def tile_bbox(tile_id: str) -> list[float]:
+    """Return the WGS84 bbox [lon_min, lat_min, lon_max, lat_max] of the true S2 tile extent.
+
+    The MGRS square's corners are not axis-aligned in lat/lon, so start from the min/max over
+    all four corners, then pad east and south to the 109.8 km S2 extent plus the projection
+    tolerance on every side (the pole-most latitude gives the widest east pad, keeping the bbox
+    conservative). Raises ``ValueError`` for a malformed/unknown tile id.
     """
     m = mgrs.MGRS()
     corners = ["0000000000", "9999900000", "0000099999", "9999999999"]  # SW, SE, NW, NE
@@ -56,7 +73,14 @@ def tile_bbox(tile_id: str) -> list[float]:
         raise ValueError(f"invalid MGRS tile id: {tile_id!r}") from exc
     lats = [lat for lat, _ in latlon]
     lons = [lon for _, lon in latlon]
-    return [min(lons), min(lats), max(lons), max(lats)]
+    meters_per_deg_lon = METERS_PER_DEG_LAT * math.cos(
+        math.radians(max(abs(lat) for lat in lats))  # pole-most latitude ⇒ widest, conservative
+    )
+    dlat = (S2_TILE_OVERHANG_M + BBOX_TOLERANCE_M) / METERS_PER_DEG_LAT
+    dlon = (S2_TILE_OVERHANG_M + BBOX_TOLERANCE_M) / meters_per_deg_lon
+    tol_lat = BBOX_TOLERANCE_M / METERS_PER_DEG_LAT
+    tol_lon = BBOX_TOLERANCE_M / meters_per_deg_lon
+    return [min(lons) - tol_lon, min(lats) - dlat, max(lons) + dlon, max(lats) + tol_lat]
 
 
 def _item_date(item: object) -> str | None:

--- a/tests/unit/test_watch_cdse_and_process.py
+++ b/tests/unit/test_watch_cdse_and_process.py
@@ -27,17 +27,90 @@ from watch_cdse_and_process import (  # noqa: E402
 _MOD = "watch_cdse_and_process"
 
 
-def test_tile_bbox_31tch_matches_mgrs_square() -> None:
-    """31TCH bbox is the MGRS 100 km square corners (min/max), not the spec's rounded AOI.
+def test_tile_bbox_31tch_pads_mgrs_square_east_and_south() -> None:
+    """31TCH bbox = the MGRS 100 km square padded east+south to the true 109.8 km S2 extent.
 
-    Validated against mgrs 1.5.4 on 2026-06-05: the four corners of 31TCH yield
-    [0.533, 42.427, 1.784, 43.346] — intentionally tighter/offset vs the spec's [0,42,2,43].
+    S2 tiles are anchored at the NW corner of their MGRS square, so only the east and south
+    edges move. MGRS square corners (mgrs 1.5.4, 2026-06-05): [0.533, 42.427, 1.784, 43.346].
     """
-    bbox = tile_bbox("31TCH")
-    expected = [0.533, 42.427, 1.784, 43.346]
-    assert len(bbox) == 4
-    for got, want in zip(bbox, expected, strict=True):
-        assert got == pytest.approx(want, abs=0.05)
+    square = [0.533, 42.427, 1.784, 43.346]
+    lon_min, lat_min, lon_max, lat_max = tile_bbox("31TCH")
+    assert 0.0 < square[0] - lon_min < 0.06  # west: tolerance only (~3 km)
+    assert 0.0 < lat_max - square[3] < 0.05  # north: tolerance only (~3 km)
+    assert 0.09 < square[1] - lat_min < 0.16  # south: overhang + tolerance ≈ 12.8 km ≈ 0.115°
+    assert 0.12 < lon_max - square[2] < 0.22  # east: (overhang + tolerance) / cos(lat)
+
+
+def test_tile_bbox_32tmt_covers_true_s2_extent() -> None:
+    """Regression (prod exit-66, 2026-07-02): bbox must cover the tile's TRUE corners.
+
+    32TMT truly spans lon 7.6629..9.1305, lat 46.8582..47.8536 (s1tiling `tile_origin` from the
+    failed run, cross-checked against eotile `s2_with_overlap.gpkg`). The MGRS 100 km square
+    stops at 8.99999°E — 9.8 km short — which starved AgglomerateDEM of N48/E013.
+    """
+    lon_min, lat_min, lon_max, lat_max = tile_bbox("32TMT")
+    assert lon_min <= 7.6629
+    assert lat_min <= 46.8582
+    assert lon_max >= 9.1305
+    assert lat_max >= 47.8536
+
+
+def test_dem_window_32tmt_includes_e013() -> None:
+    """Regression: the exact production failure — the DEM window must reach the N48/E013 cell.
+
+    The S1C desc-168 frame over 32TMT extends to 13.016°E; s1tiling needs
+    Copernicus_DSM_10_N48_00_E013_00 and aborts (exit 66) without it.
+    """
+    from ensure_dem import tiles_for_bbox
+
+    assert (48, 13) in tiles_for_bbox(tile_bbox("32TMT"))
+
+
+def test_dem_window_32upb_includes_n51_n52_e016() -> None:
+    """Regression: second production victim (2026-06-23 run) — 32UPB's window must reach E016.
+
+    The S1A desc frame over 32UPB needs Copernicus_DSM_10_N51_00_E016_00 and
+    N52_00_E016_00; the un-padded MGRS-square bbox stopped the window at E015.
+    """
+    from ensure_dem import tiles_for_bbox
+
+    cells = tiles_for_bbox(tile_bbox("32UPB"))
+    assert (51, 16) in cells
+    assert (52, 16) in cells
+
+
+def test_tile_bbox_covers_eotile_truth_across_aoi_and_south() -> None:
+    """Ground truth sweep: padded bbox ⊇ the real S2 footprint for every western-europe AOI tile.
+
+    Uses eotile's bundled ``s2_with_overlap.gpkg`` (the true 109.8 km footprints) via its sqlite
+    rtree (mins rounded down / maxs rounded up ⇒ conservative). Also sweeps the 33H** tiles as a
+    southern-hemisphere sign check on the east/south pad. Skips when eotile isn't installed
+    (data-only helper, not a project dep): run locally with `uv pip install eotile --no-deps`.
+    """
+    import sqlite3
+    import warnings
+
+    eotile = pytest.importorskip("eotile")
+    gpkg = next(Path(eotile.__file__).parent.rglob("s2_with_overlap.gpkg"))
+    con = sqlite3.connect(str(gpkg))
+    aoi = (-5.2, 42.0, 13.5, 51.2)  # western-europe AOI bbox (platform-deploy ConfigMap)
+    rows = con.execute(
+        "SELECT t.id, r.minx, r.miny, r.maxx, r.maxy FROM s2_with_overlap t "
+        "JOIN rtree_s2_with_overlap_geom r ON t.fid = r.id "
+        "WHERE (r.maxx >= ? AND r.minx <= ? AND r.maxy >= ? AND r.miny <= ?) "
+        "OR t.id LIKE '33H%' ORDER BY t.id",
+        (aoi[0], aoi[2], aoi[1], aoi[3]),
+    ).fetchall()
+    assert len(rows) > 150  # the AOI alone holds 163 tiles
+    for tile_id, minx, miny, maxx, maxy in rows:
+        with warnings.catch_warnings():
+            # mgrs warns when a corner of the 100 km square hangs outside its lat band — benign
+            warnings.simplefilter("ignore", RuntimeWarning)
+            lon_min, lat_min, lon_max, lat_max = tile_bbox(tile_id)
+        assert lon_min <= minx and lat_min <= miny, f"{tile_id}: bbox misses SW of truth"
+        assert lon_max >= maxx and lat_max >= maxy, f"{tile_id}: bbox misses NE of truth"
+        for over in (minx - lon_min, miny - lat_min, lon_max - maxx, lat_max - maxy):
+            assert over < 0.1, f"{tile_id}: over-pad {over:.4f}° — pad model drifted"
 
 
 def test_tile_bbox_order_is_lonmin_latmin_lonmax_latmax() -> None:


### PR DESCRIPTION
## Problem

`tile_bbox()` returned the **MGRS 100 km square**, but an S2 tile is a **109.8 km** square anchored at the NW corner of its MGRS square — every tile truly extends ~9.8 km further east and south. Two production consequences:

1. **Deterministic exit-66 every 12 days.** `ensure_dem` computes the DEM download window as `floor(bbox ± 4°)`. On **32TMT** the under-reported east edge (8.99999° vs true 9.1305°) dropped the E013 column → `AgglomerateDEM` aborted with `Copernicus_DSM_10_N48_00_E013_00.tif missing` (exit 66, all 4 retries, wf `…-cron-npbgq`, 2026-07-02). Same class on **32UPB** (missing N51/N52 E016, 2026-06-23, wf `…-cron-xkcms`). S1 orbits repeat with the same footprint every 12 days → these tiles failed every revisit.
2. **Discovery silently missed overlap-strip products.** The same short bbox feeds CDSE discovery (`trigger_cdse`/watcher). Verified: re-running the 32TMT search with the corrected bbox returns a strict superset — including `S1C_…_010741_8223`, *the exact frame that crashed the tile*.

## Fix

Pad east+south by the 9.8 km overhang, and all sides by a **3 km tolerance** that provably bounds the two projection effects anywhere the MGRS grid exists (grid convergence ≤ ~0.7 km, parallel-curvature bowing ≤ ~2.3 km at the 84° limit; measured worst case in our AOI is 0.42 km). No new dependencies (~10 lines, stdlib `math`).

## Evidence

- **Red→green**: 3 new regression tests fail on the old code, pass on the fix — incl. the literal production failures: `(48,13) ∈ tiles_for_bbox(tile_bbox("32TMT"))` and `(51,16),(52,16) ∈ … ("32UPB")`.
- **Ground-truth sweep** (`importorskip("eotile")`, run locally): padded bbox ⊇ the real footprint from `s2_with_overlap.gpkg` for **243/243 tiles** (all western-europe AOI + the 33H southern-hemisphere band as a pad-sign check), over-pad < 0.1°.
- **AOI list byte-identical to production (163 tiles)**: the corrected bbox surfaced 2 all-ocean Bay-of-Biscay tiles (30TVR/30TVS, footprints end at −2.87°E, nearest land −2.3°E) via the known coarse-1°-cell false positive → added to the existing ocean denylist with the other 9.
- **Discovery diff** (CDSE STAC, desc, 2026-06-28..30): 32TMT 4→6 products (superset ✔), 32UPB 7→8 (superset ✔; the extra is an S1D that the platform filter drops at download anyway).
- Full suite: **711 passed** (`uv run pytest`).

## Rollout

After merge: tag `v0.8.0-s1rtc-rc10` → image → platform-deploy pin bump → resubmit 32TMT (desc, S1C, 2026-06-28..30) and 32UPB (desc, S1A, 2026-06-22..24), which fell out of the cron lookback window.

Plan: `claude-docs/plans/s1_ensure_dem_true_tile_bbox.md` (session-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)