### PR TITLE
feat(stac): rel=xyz tile links + grouped Additional Resources for S1 RTC items

### DIFF
--- a/operator-tools/README_MIGRATIONS.md
+++ b/operator-tools/README_MIGRATIONS.md
@@ -14,6 +14,7 @@ is shown when the API supports `numberMatched`.
 | `fix_url_encoding` | Replace `+` with `%20` in asset/link href query strings (RFC 3986 compliance) |
 | `fix_zarr_media_type` | Fix zarr media types (`vnd+zarr` → `vnd.zarr`, `version=2` → `version=3`, add missing `version=3`) and remove `zipped_product` asset |
 | `add_xyz_link` | Add a `rel=xyz` `{z}/{x}/{y}.png` tile template after the `tilejson` link (derived from the tilejson href). Idempotent + S2-safe; skips the known-legacy items whose tilejson is a bare `.../WebMercatorQuad` href. |
+| `align_visualization_links` | Align viewer/tilejson/xyz link titles + order to the canonical cube form (render title for viewer/xyz, `TileJSON for {id}`, order store→viewer→tilejson→xyz). No-op on already-canonical cube items and on S2 (no render config). Compose with `add_xyz_link` to backfill the xyz link too. |
 
 ## Safe Migration Procedure
 

--- a/operator-tools/README_MIGRATIONS.md
+++ b/operator-tools/README_MIGRATIONS.md
@@ -13,6 +13,7 @@ is shown when the API supports `numberMatched`.
 |---|---|
 | `fix_url_encoding` | Replace `+` with `%20` in asset/link href query strings (RFC 3986 compliance) |
 | `fix_zarr_media_type` | Fix zarr media types (`vnd+zarr` → `vnd.zarr`, `version=2` → `version=3`, add missing `version=3`) and remove `zipped_product` asset |
+| `add_xyz_link` | Add a `rel=xyz` `{z}/{x}/{y}.png` tile template after the `tilejson` link (derived from the tilejson href). Idempotent + S2-safe; skips the known-legacy items whose tilejson is a bare `.../WebMercatorQuad` href. |
 
 ## Safe Migration Procedure
 
@@ -103,6 +104,7 @@ Commands:
     --dry-run                              Preview changes without updating
     --yes / -y                             Skip confirmation prompt
     --page-size INT   (default: 100)       Items fetched per API page
+    --ids TEXT        (repeatable)         Restrict the run to specific item ids (canary)
   verify COLLECTION_ID                     Check if migration is fully applied
     --migration TEXT  (repeatable)         Migration(s) to verify
     --page-size INT   (default: 100)       Items fetched per API page

--- a/operator-tools/README_MIGRATIONS.md
+++ b/operator-tools/README_MIGRATIONS.md
@@ -15,6 +15,7 @@ is shown when the API supports `numberMatched`.
 | `fix_zarr_media_type` | Fix zarr media types (`vnd+zarr` → `vnd.zarr`, `version=2` → `version=3`, add missing `version=3`) and remove `zipped_product` asset |
 | `add_xyz_link` | Add a `rel=xyz` `{z}/{x}/{y}.png` tile template after the `tilejson` link (derived from the tilejson href). Idempotent + S2-safe; skips the known-legacy items whose tilejson is a bare `.../WebMercatorQuad` href. |
 | `align_visualization_links` | Align viewer/tilejson/xyz link titles + order to the canonical cube form (render title for viewer/xyz, `TileJSON for {id}`, order store→viewer→tilejson→xyz). No-op on already-canonical cube items and on S2 (no render config). Compose with `add_xyz_link` to backfill the xyz link too. |
+| `add_acquisitions_filter_link` | Add the sibling-collection `Per-acquisition items (filter by tile grid:code)` related link to acquisition items, giving `related` ≥2 entries so STAC Browser renders the grouped "Additional Resources" categories. Scoped to acquisition items (identified by their `Parent tile datacube` link); no-op on cube/S2. |
 
 ## Safe Migration Procedure
 

--- a/operator-tools/_migrate_catalog/cli.py
+++ b/operator-tools/_migrate_catalog/cli.py
@@ -47,6 +47,12 @@ def cli(ctx: click.Context, api_url: str | None, history_file: str | None) -> No
 @click.option("--dry-run", is_flag=True, help="Show changes without updating")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.option("--page-size", default=100, show_default=True, help="Items per page when fetching")
+@click.option(
+    "--ids",
+    "ids",
+    multiple=True,
+    help="Restrict the run to specific item ids (repeatable) — e.g. a single-tile canary",
+)
 @click.pass_context
 def run(
     ctx: click.Context,
@@ -55,6 +61,7 @@ def run(
     dry_run: bool,
     yes: bool,
     page_size: int,
+    ids: tuple[str, ...],
 ) -> None:
     """Run one or more migrations on a collection."""
     for name in migration_names:
@@ -86,13 +93,20 @@ def run(
         click.echo(f"Description: {description}")
         click.echo(f"Collection:  {collection_id}")
         click.echo(f"API:         {api_url}")
+        if ids:
+            click.echo(f"IDs:         {', '.join(ids)}")
         if not click.confirm("Proceed?", default=False):
             click.echo("Aborted.")
             return
 
     runner = STACMigrationRunner(api_url, recovery_dir=history_file.parent)
     result = runner.run_migration(
-        collection_id, migration_fn, migration_name, dry_run=dry_run, page_size=page_size
+        collection_id,
+        migration_fn,
+        migration_name,
+        dry_run=dry_run,
+        page_size=page_size,
+        ids=list(ids) or None,
     )
 
     click.echo()

--- a/operator-tools/_migrate_catalog/migrations/__init__.py
+++ b/operator-tools/_migrate_catalog/migrations/__init__.py
@@ -1,5 +1,6 @@
 # Import migration modules to trigger @migration registration
 from _migrate_catalog.migrations import add_xyz_link as ___  # noqa: F401
+from _migrate_catalog.migrations import align_visualization_links as ____  # noqa: F401
 from _migrate_catalog.migrations import fix_url_encoding as _  # noqa: F401
 from _migrate_catalog.migrations import fix_zarr_media_type as __  # noqa: F401
 from _migrate_catalog.migrations._registry import MIGRATIONS, migration

--- a/operator-tools/_migrate_catalog/migrations/__init__.py
+++ b/operator-tools/_migrate_catalog/migrations/__init__.py
@@ -1,4 +1,5 @@
 # Import migration modules to trigger @migration registration
+from _migrate_catalog.migrations import add_xyz_link as ___  # noqa: F401
 from _migrate_catalog.migrations import fix_url_encoding as _  # noqa: F401
 from _migrate_catalog.migrations import fix_zarr_media_type as __  # noqa: F401
 from _migrate_catalog.migrations._registry import MIGRATIONS, migration

--- a/operator-tools/_migrate_catalog/migrations/__init__.py
+++ b/operator-tools/_migrate_catalog/migrations/__init__.py
@@ -1,4 +1,5 @@
 # Import migration modules to trigger @migration registration
+from _migrate_catalog.migrations import add_acquisitions_filter_link as _____  # noqa: F401
 from _migrate_catalog.migrations import add_xyz_link as ___  # noqa: F401
 from _migrate_catalog.migrations import align_visualization_links as ____  # noqa: F401
 from _migrate_catalog.migrations import fix_url_encoding as _  # noqa: F401

--- a/operator-tools/_migrate_catalog/migrations/add_acquisitions_filter_link.py
+++ b/operator-tools/_migrate_catalog/migrations/add_acquisitions_filter_link.py
@@ -3,6 +3,10 @@ from typing import Any
 from _migrate_catalog.migrations._registry import migration
 from _migrate_catalog.types import apply_item_transform
 
+# These MUST match scripts.stac_link_titles (the registration emitters) — the migration gates on
+# _PARENT_TITLE, so a drift would make it silently skip every item. A drift-guard test in
+# tests/unit/test_migrate_catalog.py asserts they stay in sync (the two live in separate packages,
+# so they can't share an import at runtime).
 _FILTER_TITLE = "Per-acquisition items (filter by tile grid:code)"
 _PARENT_TITLE = "Parent tile datacube"
 

--- a/operator-tools/_migrate_catalog/migrations/add_acquisitions_filter_link.py
+++ b/operator-tools/_migrate_catalog/migrations/add_acquisitions_filter_link.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+from _migrate_catalog.migrations._registry import migration
+from _migrate_catalog.types import apply_item_transform
+
+_FILTER_TITLE = "Per-acquisition items (filter by tile grid:code)"
+_PARENT_TITLE = "Parent tile datacube"
+
+
+def _transform(item: dict[str, Any]) -> bool:
+    links = item.get("links", [])
+
+    # Idempotent: never add a second filter link.
+    if any(lk.get("rel") == "related" and lk.get("title") == _FILTER_TITLE for lk in links):
+        return False
+
+    # Only acquisition items — identified by their parent-datacube related link. Cube and S2 items
+    # don't carry it, so they're left alone (the cube already has its own filter link).
+    parent = next(
+        (lk for lk in links if lk.get("rel") == "related" and lk.get("title") == _PARENT_TITLE),
+        None,
+    )
+    collection = item.get("collection")
+    if parent is None or not collection or "/collections/" not in parent.get("href", ""):
+        return False
+
+    # Derive the STAC API base from the parent link href (…/collections/{cube}/items/{id}); the
+    # filter link points at this acquisition's own (sibling) collection.
+    stac_base = parent["href"].split("/collections/", 1)[0]
+    parent_index = links.index(parent)
+    links.insert(
+        parent_index + 1,
+        {
+            "rel": "related",
+            "type": "application/json",
+            "href": f"{stac_base}/collections/{collection}",
+            "title": _FILTER_TITLE,
+        },
+    )
+    return True
+
+
+@migration(
+    "add_acquisitions_filter_link",
+    "Add the sibling-collection 'Per-acquisition items (filter by tile grid:code)' related link to "
+    "acquisition items, so a rel group has >=2 entries and STAC Browser renders grouped categories",
+)
+def add_acquisitions_filter_link(item: dict[str, Any]) -> dict[str, Any] | None:
+    """Give acquisition items a second ``related`` link (the sibling acquisitions collection).
+
+    STAC Browser's LinkList only renders the grouped "Additional Resources" section (category
+    headers) when some ``rel`` has >=2 links (its ``hasGroups`` check). Acquisition items otherwise
+    carry exactly one link per rel, so they render as a flat list. Adding the sibling-collection
+    filter link (mirroring the cube via register_v1_s1_rtc) gives ``related`` two entries and flips
+    the rendering to grouped.
+
+    Idempotent (skips items that already have the filter link) and scoped to acquisition items
+    (identified by their "Parent tile datacube" related link); no-op on cube and S2 items.
+    """
+    return apply_item_transform(item, _transform)

--- a/operator-tools/_migrate_catalog/migrations/add_xyz_link.py
+++ b/operator-tools/_migrate_catalog/migrations/add_xyz_link.py
@@ -1,0 +1,83 @@
+import logging
+from typing import Any
+
+from _migrate_catalog.migrations._registry import migration
+from _migrate_catalog.types import apply_item_transform
+
+logger = logging.getLogger(__name__)
+
+_TILEJSON_MARK = "/WebMercatorQuad/tilejson.json?"
+_XYZ_MARK = "/tiles/WebMercatorQuad/{z}/{x}/{y}.png?"
+
+
+def _xyz_title(item: dict[str, Any], links: list[dict[str, Any]]) -> str:
+    """Title for the xyz link: viewer-link title first, else the render title, else a fallback.
+
+    Viewer-first gives exact parity for both item types: fresh per-acquisition registrations hardcode
+    the viewer title ("Sentinel-1 GRD RGB composite") while carrying a *different* renders.rgb.title
+    ("VV, VH, VV/VH composite"), and cube items use the render title for both viewer and xyz — so
+    deriving from the viewer link matches fresh registrations in every case.
+    """
+    for link in links:
+        if link.get("rel") == "viewer" and link.get("title"):
+            return str(link["title"])
+    render = item.get("properties", {}).get("renders", {}).get("rgb", {})
+    if isinstance(render, dict) and render.get("title"):
+        return str(render["title"])
+    return "XYZ tile template"
+
+
+def _transform(item: dict[str, Any]) -> bool:
+    links = item.get("links", [])
+
+    # 1. Idempotent + inherently S2-safe: never add a second xyz.
+    if any(link.get("rel") == "xyz" for link in links):
+        return False
+
+    # 2. Find the tilejson link; skip (don't emit garbage) if it isn't the render-path form.
+    tj_index = next((i for i, link in enumerate(links) if link.get("rel") == "tilejson"), None)
+    if tj_index is None:
+        logger.warning("Skipping %s: no tilejson link", item.get("id", "unknown"))
+        return False
+    tj_href = links[tj_index].get("href", "")
+    if _TILEJSON_MARK not in tj_href:
+        # The 3 known-legacy items (31TCJ/30TXM/30TXN + their acqs) carry bare .../WebMercatorQuad
+        # hrefs — deriving xyz would be garbage; they're slated for wipe+re-ingest.
+        logger.warning(
+            "Skipping %s: tilejson href is not the render-path form (%r)",
+            item.get("id", "unknown"),
+            tj_href,
+        )
+        return False
+
+    # 3. Exact substitution validated live (query, incl. sel=time, unchanged).
+    xyz_href = tj_href.replace(_TILEJSON_MARK, _XYZ_MARK, 1)
+
+    # 4. Insert immediately after tilejson.
+    links.insert(
+        tj_index + 1,
+        {
+            "rel": "xyz",
+            "type": "image/png",
+            "href": xyz_href,
+            "title": _xyz_title(item, links),
+        },
+    )
+    return True
+
+
+@migration(
+    "add_xyz_link",
+    "Add a rel=xyz {z}/{x}/{y}.png tile template after tilejson (derived from the tilejson href)",
+)
+def add_xyz_link(item: dict[str, Any]) -> dict[str, Any] | None:
+    """Backfill the machine-facing rel=xyz tile-template link on S1 RTC items missing it.
+
+    Derives the xyz href from the item's existing tilejson link (same endpoint + query, incl.
+    sel=time), so it matches what fresh registrations now emit natively. Idempotent (skips items that
+    already carry xyz — including S2, which keeps its own hardcoded xyz) and skips the known-legacy
+    items whose tilejson is a bare .../WebMercatorQuad href.
+
+    See: https://github.com/EOPF-Explorer/data-pipeline (S1 RTC xyz tile links)
+    """
+    return apply_item_transform(item, _transform)

--- a/operator-tools/_migrate_catalog/migrations/align_visualization_links.py
+++ b/operator-tools/_migrate_catalog/migrations/align_visualization_links.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+from _migrate_catalog.migrations._registry import migration
+from _migrate_catalog.types import apply_item_transform
+
+# STAC Browser renders each non-navigation link's title as an "Additional Resources" header. The cube
+# path (register_v1) is the canonical form; this brings older per-acquisition items to the same shape.
+_NAV = {"self", "root", "parent", "collection"}
+# Canonical order of the non-nav visualization links (unknown rels sort last, keeping their order).
+_ORDER = {"store": 0, "viewer": 1, "tilejson": 2, "xyz": 3, "via": 4, "related": 5}
+
+
+def _transform(item: dict[str, Any]) -> bool:
+    render = item.get("properties", {}).get("renders", {}).get("rgb")
+    if not isinstance(render, dict):
+        # No producer render config (e.g. S2 hardcoded visualization) — nothing to align.
+        return False
+    links = item.get("links", [])
+    item_id = item.get("id", "")
+    render_title = render.get("title") or f"Visualization for {item_id}"
+    targets = {
+        "viewer": render_title,
+        "tilejson": f"TileJSON for {item_id}",
+        "xyz": render_title,
+    }
+
+    changed = False
+    for link in links:
+        rel = link.get("rel")
+        if rel in targets and link.get("title") != targets[rel]:
+            link["title"] = targets[rel]
+            changed = True
+
+    # Reorder the non-nav links into the canonical sequence; nav links keep their (front) positions.
+    before = [link.get("rel") for link in links]
+    nav = [link for link in links if link.get("rel") in _NAV]
+    rest = [link for link in links if link.get("rel") not in _NAV]
+    rest.sort(key=lambda link: _ORDER.get(link.get("rel"), 99))  # stable: ties keep input order
+    reordered = nav + rest
+    if [link.get("rel") for link in reordered] != before:
+        item["links"] = reordered
+        changed = True
+
+    return changed
+
+
+@migration(
+    "align_visualization_links",
+    "Align viewer/tilejson/xyz link titles + order to the canonical cube form "
+    "(render title for viewer/xyz, 'TileJSON for {id}', order store→viewer→tilejson→xyz)",
+)
+def align_visualization_links(item: dict[str, Any]) -> dict[str, Any] | None:
+    """Normalize an S1 RTC item's visualization links to the cube convention.
+
+    STAC Browser shows each non-nav link's title as an "Additional Resources" header, so older
+    per-acquisition items (tilejson titled "tilejson", viewer/xyz hardcoded, order
+    tilejson→xyz→viewer) read differently from the cube. This retitles viewer/xyz to the render
+    composite title, tilejson to "TileJSON for {id}", and reorders to store→viewer→tilejson→xyz.
+
+    No-op (returns None) on items already in canonical form (cube items) and on items without a
+    producer render config (S2). Compose with ``add_xyz_link`` to also backfill a missing xyz link.
+    """
+    return apply_item_transform(item, _transform)

--- a/operator-tools/_migrate_catalog/runner.py
+++ b/operator-tools/_migrate_catalog/runner.py
@@ -15,19 +15,20 @@ from _migrate_catalog.types import MigrationFn, MigrationResult
 logger = logging.getLogger(__name__)
 
 
-def _transaction_body(item_dict: dict[str, Any]) -> dict[str, Any]:
-    """A transaction-valid POST body for a raw STAC-API item dict.
+def _transaction_body(item_dict: dict[str, Any]) -> dict[str, Any] | None:
+    """A transaction-valid POST body for a raw STAC-API item dict, or ``None`` if one can't be built.
 
     The GET/search representation omits nullable-but-required fields — notably
     ``properties.datetime`` on datacube items (null datetime) — which the transaction POST
-    rejects with 400. pystac re-materializes them (and preserves link order). Fall back to the
-    raw dict for items pystac can't model (e.g. an asset with no href), so such an item fails its
-    own POST in isolation rather than aborting the whole run.
+    rejects with 400. pystac re-materializes them (and preserves link order). Returns ``None`` for
+    items pystac can't model (e.g. an asset with no href): such an item can't be safely round-tripped
+    through the transaction API, so the caller must skip it WITHOUT deleting — a delete-then-failed
+    POST would lose the item.
     """
     try:
         return pystac.Item.from_dict(item_dict).to_dict()
     except Exception:
-        return item_dict
+        return None
 
 
 def compose_migrations(fns: list[MigrationFn]) -> MigrationFn:
@@ -130,8 +131,21 @@ class STACMigrationRunner:
                     elif dry_run:
                         result.items_modified += 1
                     else:
-                        self._update_item(collection_id, item_id, _transaction_body(modified))
-                        result.items_modified += 1
+                        body = _transaction_body(modified)
+                        if body is None:
+                            # Can't build a valid POST body — skip WITHOUT deleting (a
+                            # delete-then-failed-POST would lose the item).
+                            result.items_failed += 1
+                            result.errors.append(
+                                {
+                                    "item_id": item_id,
+                                    "error": "cannot build a transaction-valid POST body "
+                                    "(pystac can't model it); skipped without deleting",
+                                }
+                            )
+                        else:
+                            self._update_item(collection_id, item_id, body)
+                            result.items_modified += 1
                 except Exception as e:
                     result.items_failed += 1
                     result.errors.append({"item_id": item_id, "error": str(e)})

--- a/operator-tools/_migrate_catalog/runner.py
+++ b/operator-tools/_migrate_catalog/runner.py
@@ -6,12 +6,28 @@ from pathlib import Path
 from typing import Any
 
 import click
+import pystac
 import requests
 from pystac_client import Client
 
 from _migrate_catalog.types import MigrationFn, MigrationResult
 
 logger = logging.getLogger(__name__)
+
+
+def _transaction_body(item_dict: dict[str, Any]) -> dict[str, Any]:
+    """A transaction-valid POST body for a raw STAC-API item dict.
+
+    The GET/search representation omits nullable-but-required fields — notably
+    ``properties.datetime`` on datacube items (null datetime) — which the transaction POST
+    rejects with 400. pystac re-materializes them (and preserves link order). Fall back to the
+    raw dict for items pystac can't model (e.g. an asset with no href), so such an item fails its
+    own POST in isolation rather than aborting the whole run.
+    """
+    try:
+        return pystac.Item.from_dict(item_dict).to_dict()
+    except Exception:
+        return item_dict
 
 
 def compose_migrations(fns: list[MigrationFn]) -> MigrationFn:
@@ -100,24 +116,26 @@ class STACMigrationRunner:
                 f"Processing items from '{collection_id}'{' (dry run)' if dry_run else ''}..."
             )
 
+        # Iterate raw item dicts, not pystac Item objects: some live items carry an asset with no
+        # href (e.g. s1-rtc-30TWQ) that pystac's Item.from_dict rejects, and one such item must not
+        # abort the whole run. The migration functions operate on dicts anyway.
         with click.progressbar(length=total, show_pos=True, show_percent=True) as bar:
-            for page in search.pages():
-                for item_dict in (item.to_dict() for item in page.items):
-                    item_id = item_dict.get("id", "unknown")
-                    result.items_processed += 1
-                    try:
-                        modified = migration_fn(item_dict)
-                        if modified is None:
-                            result.items_skipped += 1
-                        elif dry_run:
-                            result.items_modified += 1
-                        else:
-                            self._update_item(collection_id, item_id, modified)
-                            result.items_modified += 1
-                    except Exception as e:
-                        result.items_failed += 1
-                        result.errors.append({"item_id": item_id, "error": str(e)})
-                    bar.update(1)
+            for item_dict in search.items_as_dicts():
+                item_id = item_dict.get("id", "unknown")
+                result.items_processed += 1
+                try:
+                    modified = migration_fn(item_dict)
+                    if modified is None:
+                        result.items_skipped += 1
+                    elif dry_run:
+                        result.items_modified += 1
+                    else:
+                        self._update_item(collection_id, item_id, _transaction_body(modified))
+                        result.items_modified += 1
+                except Exception as e:
+                    result.items_failed += 1
+                    result.errors.append({"item_id": item_id, "error": str(e)})
+                bar.update(1)
 
         result.completed_at = datetime.now(UTC).isoformat()
         return result

--- a/operator-tools/_migrate_catalog/runner.py
+++ b/operator-tools/_migrate_catalog/runner.py
@@ -62,6 +62,7 @@ class STACMigrationRunner:
         migration_name: str,
         dry_run: bool = False,
         page_size: int = 100,
+        ids: list[str] | None = None,
     ) -> MigrationResult:
         started_at = datetime.now(UTC).isoformat()
         result = MigrationResult(
@@ -78,7 +79,15 @@ class STACMigrationRunner:
         )
 
         catalog = Client.open(self.api_url)
-        search = catalog.search(collections=[collection_id], max_items=None, limit=page_size)
+        # `ids` restricts the run to specific items (the canary path) via the same code path,
+        # recovery JSONL, and history as the full run. Omitted from the call when unset so the
+        # full-collection search stays byte-identical (backcompat).
+        if ids:
+            search = catalog.search(
+                collections=[collection_id], ids=ids, max_items=None, limit=page_size
+            )
+        else:
+            search = catalog.search(collections=[collection_id], max_items=None, limit=page_size)
 
         total = search.matched()
         if total is not None:

--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -114,9 +114,11 @@ def decorate_acquisition_item(
     ``sel=time={datetime}`` — no data duplication; the acquisition item is a reference into the cube,
     and the render stays slice-correct regardless of the cube's physical slice order. The ``viewer``
     link is a ``map.html`` deep-link into this acquisition's slice (``sel=time`` makes that possible).
-    A ``related`` link points at this acquisition's parent **tile datacube** STAC item
-    (``stac_api_url``/collections/``cube_collection``/items/``s1-rtc-{tile}``) for browser navigation.
-    Any ``store`` link / S3 ``alternate`` blocks the caller already added are preserved.
+    Two ``related`` links are added: the parent **tile datacube** STAC item
+    (``stac_api_url``/collections/``cube_collection``/items/``s1-rtc-{tile}``) and the sibling
+    **acquisitions collection** ("Per-acquisition items (filter by tile grid:code)"). Two links on
+    one rel is what makes STAC Browser render the grouped "Additional Resources" section (category
+    headers) rather than a flat list. Any ``store`` link / S3 ``alternate`` blocks are preserved.
     """
     when = item.datetime
     if when is None:  # per-acquisition items always carry a single datetime
@@ -163,6 +165,16 @@ def decorate_acquisition_item(
             "type": "application/json",
             "href": f"{stac_api_url.rstrip('/')}/collections/{cube_collection}/items/s1-rtc-{tile_id}",
             "title": "Parent tile datacube",
+        },
+        # Second related link (mirrors register_v1_s1_rtc on the cube): points at the sibling
+        # acquisitions collection. Two related links give STAC Browser a rel group with >=2 entries,
+        # which is what flips its LinkList to the grouped "Additional Resources" rendering (category
+        # headers) instead of a flat list.
+        {
+            "rel": "related",
+            "type": "application/json",
+            "href": f"{stac_api_url.rstrip('/')}/collections/{collection}",
+            "title": "Per-acquisition items (filter by tile grid:code)",
         },
     ]
     d.setdefault("assets", {})["thumbnail"] = {

--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -127,26 +127,30 @@ def decorate_acquisition_item(
     item_id = d["id"]
     collection = d.get("collection", "")
     render = d["properties"]["renders"]["rgb"]
+    # Mirror the cube's link conventions (register_v1.add_visualization_links) so both item types
+    # render an identical "Additional Resources" section in STAC Browser: order
+    # store→viewer→tilejson→xyz, viewer/xyz titled by the render composite, tilejson "TileJSON for {id}".
+    render_title = render.get("title") or f"Visualization for {item_id}"
     store_links = [lk for lk in d.get("links", []) if lk.get("rel") == "store"]
     d["links"] = [
         *store_links,
         {
+            "rel": "viewer",
+            "type": "text/html",
+            "href": render_viewer(raster_api, cube_collection, tile_id, render, sel_time),
+            "title": render_title,
+        },
+        {
             "rel": "tilejson",
             "type": "application/json",
             "href": render_tilejson(raster_api, cube_collection, tile_id, render, sel_time),
-            "title": "tilejson",
+            "title": f"TileJSON for {item_id}",
         },
         {
             "rel": "xyz",
             "type": "image/png",
             "href": render_xyz(raster_api, cube_collection, tile_id, render, sel_time),
-            "title": "Sentinel-1 GRD RGB composite",
-        },
-        {
-            "rel": "viewer",
-            "type": "text/html",
-            "href": render_viewer(raster_api, cube_collection, tile_id, render, sel_time),
-            "title": "Sentinel-1 GRD RGB composite",
+            "title": render_title,
         },
         {
             "rel": "via",

--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -28,6 +28,7 @@ from eopf_geozarr.stac.s1_rtc import acquisition_id as acquisition_id  # re-expo
 from eopf_geozarr.stac.s1_rtc import build_s1_rtc_per_acquisition_items
 from pystac import Item
 from register_v1 import EXPLORER_BASE, _render_to_query
+from stac_link_titles import ACQUISITIONS_FILTER_TITLE, PARENT_DATACUBE_TITLE
 
 # Per-acquisition collections are env-split like the cube collections (…-tests/-staging/-prod). The
 # code default targets the test env (local/CP-A runs); the Argo cron passes --collection …-staging.
@@ -164,7 +165,7 @@ def decorate_acquisition_item(
             "rel": "related",
             "type": "application/json",
             "href": f"{stac_api_url.rstrip('/')}/collections/{cube_collection}/items/s1-rtc-{tile_id}",
-            "title": "Parent tile datacube",
+            "title": PARENT_DATACUBE_TITLE,
         },
         # Second related link (mirrors register_v1_s1_rtc on the cube): points at the sibling
         # acquisitions collection. Two related links give STAC Browser a rel group with >=2 entries,
@@ -174,7 +175,7 @@ def decorate_acquisition_item(
             "rel": "related",
             "type": "application/json",
             "href": f"{stac_api_url.rstrip('/')}/collections/{collection}",
-            "title": "Per-acquisition items (filter by tile grid:code)",
+            "title": ACQUISITIONS_FILTER_TITLE,
         },
     ]
     d.setdefault("assets", {})["thumbnail"] = {

--- a/scripts/register_per_acquisition.py
+++ b/scripts/register_per_acquisition.py
@@ -67,14 +67,28 @@ def render_tilejson(
     return f"{base}/WebMercatorQuad/tilejson.json?{_render_to_query(render, include_tilesize=True)}&{_sel_time(sel_time)}"
 
 
+def render_xyz(
+    raster_api: str, cube_collection: str, tile_id: str, render: dict, sel_time: str
+) -> str:
+    """``{z}/{x}/{y}.png`` tile template for the cube slice at ``sel_time`` — for machine map clients.
+
+    Same endpoint/query as ``render_tilejson`` but the raw ``tiles/.../{z}/{x}/{y}.png`` template that
+    XYZ clients (QGIS/Leaflet/OpenLayers) substitute before requesting. The ``map.html`` ``viewer``
+    (below) stays the human-clickable link; both coexist, as on S2.
+    """
+    base = _cube_item_base(raster_api, cube_collection, tile_id)
+    q = _render_to_query(render, include_tilesize=True)
+    return f"{base}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{q}&{_sel_time(sel_time)}"
+
+
 def render_viewer(
     raster_api: str, cube_collection: str, tile_id: str, render: dict, sel_time: str
 ) -> str:
     """Interactive ``map.html`` viewer for the cube slice at ``sel_time`` — the human-clickable map.
 
     A raw ``{z}/{x}/{y}`` xyz tile template 422s when clicked in a STAC browser (the placeholders are
-    sent to TiTiler literally); ``map.html`` fills the tile coords in itself. ``tilejson`` (above)
-    serves the tile template to machine map clients.
+    sent to TiTiler literally); ``map.html`` fills the tile coords in itself. ``tilejson``/``xyz``
+    (above) serve the tile template to machine map clients.
     """
     base = _cube_item_base(raster_api, cube_collection, tile_id)
     q = _render_to_query(render, include_tilesize=True)
@@ -121,6 +135,12 @@ def decorate_acquisition_item(
             "type": "application/json",
             "href": render_tilejson(raster_api, cube_collection, tile_id, render, sel_time),
             "title": "tilejson",
+        },
+        {
+            "rel": "xyz",
+            "type": "image/png",
+            "href": render_xyz(raster_api, cube_collection, tile_id, render, sel_time),
+            "title": "Sentinel-1 GRD RGB composite",
         },
         {
             "rel": "viewer",

--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -228,8 +228,9 @@ def add_visualization_links(
 ) -> None:
     """Add the TiTiler visualization links.
 
-    The render path (producer ``renders`` config) emits an interactive ``map.html`` ``viewer`` + a
-    ``tilejson``; the mission fallbacks keep the legacy bare ``/viewer`` + ``xyz`` tile template.
+    The render path (producer ``renders`` config) emits an interactive ``map.html`` ``viewer``, a
+    ``tilejson`` and an ``xyz`` ``{z}/{x}/{y}`` tile template (for machine map clients); the mission
+    fallbacks keep the legacy bare ``/viewer`` + ``xyz`` tile template.
 
     ``sel_time`` (when set) pins the render to one cube slice by datetime — the cube item passes the
     best-recent acquisition so its preview isn't the default (oldest) slice.
@@ -241,10 +242,11 @@ def add_visualization_links(
     if render := _select_render(item):
         query = _with_sel_time(_render_to_query(render, include_tilesize=True), sel_time)
         title = render.get("title") or f"Visualization for {item.id}"
-        # Human-clickable interactive viewer carrying the render expression/rescale/sel. A raw
-        # {z}/{x}/{y} xyz tile template 422s when clicked in a STAC browser (the placeholders are
-        # sent to TiTiler literally); map.html fills the tile coords in itself. Machine map clients
-        # consume the tilejson link below for the tile template.
+        # Human-clickable interactive viewer carrying the render expression/rescale/sel. map.html
+        # fills the tile coords in itself, so it stays clickable in a STAC browser (unlike the raw
+        # {z}/{x}/{y} xyz template below, whose placeholders 422 if a human clicks them). The xyz
+        # link is for machine map clients (QGIS/Leaflet/OpenLayers) that substitute z/x/y before
+        # requesting — both coexist, as on S2.
         item.add_link(
             Link(
                 "viewer",
@@ -259,6 +261,14 @@ def add_visualization_links(
                 f"{base_url}/WebMercatorQuad/tilejson.json?{query}",
                 "application/json",
                 f"TileJSON for {item.id}",
+            )
+        )
+        item.add_link(
+            Link(
+                "xyz",
+                f"{base_url}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{query}",
+                "image/png",
+                title,
             )
         )
         _add_explorer_link(item, collection_id)

--- a/scripts/register_v1_s1_rtc.py
+++ b/scripts/register_v1_s1_rtc.py
@@ -34,6 +34,7 @@ from register_v1 import (
     warm_thumbnail_cache,
 )
 from run_ingest_register import check_env_consistency
+from stac_link_titles import ACQUISITIONS_FILTER_TITLE
 
 log = logging.getLogger(__name__)
 
@@ -193,7 +194,7 @@ def register(
             "related",
             acquisitions_collection_href(stac_api_url, acq_collection),
             "application/json",
-            "Per-acquisition items (filter by tile grid:code)",
+            ACQUISITIONS_FILTER_TITLE,
         )
     )
 

--- a/scripts/stac_link_titles.py
+++ b/scripts/stac_link_titles.py
@@ -1,0 +1,16 @@
+"""Shared STAC link titles for the S1 RTC cube and per-acquisition registration paths.
+
+Defined once so the cube emitter (``register_v1_s1_rtc``), the per-acquisition emitter
+(``register_per_acquisition``) and the backfill migration
+(``_migrate_catalog.migrations.add_acquisitions_filter_link`` — bound here by a drift-guard test)
+all use the identical strings. The migration *gates* on :data:`PARENT_DATACUBE_TITLE`, so a silent
+rename would otherwise make it skip every item.
+"""
+
+# The acquisition item's link up to its parent tile datacube (register_per_acquisition emits it;
+# add_acquisitions_filter_link uses it to recognise a fully-structured acquisition item).
+PARENT_DATACUBE_TITLE = "Parent tile datacube"
+
+# The link out to the sibling acquisitions collection, carried by both the cube and each acquisition
+# item so STAC Browser has a rel group with >=2 entries (its grouped-rendering condition).
+ACQUISITIONS_FILTER_TITLE = "Per-acquisition items (filter by tile grid:code)"

--- a/tests/unit/test_migrate_catalog.py
+++ b/tests/unit/test_migrate_catalog.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from _migrate_catalog.history import load_history, record_run, was_migration_run
+from _migrate_catalog.migrations.add_xyz_link import add_xyz_link
 from _migrate_catalog.migrations.fix_url_encoding import fix_url_encoding
 from _migrate_catalog.migrations.fix_zarr_media_type import fix_zarr_media_type
 from _migrate_catalog.runner import STACMigrationRunner, compose_migrations
@@ -175,6 +176,116 @@ class TestFixZarrMediaType:
         assert result2 is None
 
 
+_TJ_BASE = (
+    "https://api.example.com/raster/collections/sentinel-1-grd-rtc-staging"
+    "/items/s1-rtc-31TCG/WebMercatorQuad/tilejson.json"
+)
+_TJ_QUERY = "expression=%2Fdescending%3Avv&rescale=0.0%2C0.2&sel=time=2026-06-07T05%3A52%3A48"
+_TJ_HREF = f"{_TJ_BASE}?{_TJ_QUERY}"
+
+
+def _item_with_tilejson(*, viewer_title=None, render_title=None, extra_links=None) -> dict:
+    """A STAC item carrying a well-formed tilejson link (+ optional viewer/renders), no xyz yet."""
+    links = [
+        {"rel": "self", "href": "https://api.example.com/stac/.../s1-rtc-31TCG"},
+        {"rel": "tilejson", "type": "application/json", "href": _TJ_HREF, "title": "tilejson"},
+    ]
+    if viewer_title is not None:
+        links.append(
+            {
+                "rel": "viewer",
+                "type": "text/html",
+                "href": f"{_TJ_BASE.replace('tilejson.json', 'map.html')}?{_TJ_QUERY}",
+                "title": viewer_title,
+            }
+        )
+    links.extend(extra_links or [])
+    item: dict = {"id": "s1-rtc-31TCG", "links": links, "assets": {}}
+    if render_title is not None:
+        item["properties"] = {"renders": {"rgb": {"title": render_title}}}
+    return item
+
+
+class TestAddXyzLink:
+    def test_adds_xyz_after_tilejson(self):
+        item = _item_with_tilejson()
+        result = add_xyz_link(item)
+        assert result is not None
+        rels = [lk["rel"] for lk in result["links"]]
+        assert rels.count("xyz") == 1
+        assert rels.index("xyz") == rels.index("tilejson") + 1
+        xyz = next(lk for lk in result["links"] if lk["rel"] == "xyz")
+        assert xyz["type"] == "image/png"
+        assert "/tiles/WebMercatorQuad/{z}/{x}/{y}.png?" in xyz["href"]
+
+    def test_query_preserved_including_encoded_sel_time(self):
+        result = add_xyz_link(_item_with_tilejson())
+        assert result is not None
+        xyz = next(lk for lk in result["links"] if lk["rel"] == "xyz")
+        # query byte-identical to tilejson's (incl. percent-encoded sel=time colons)
+        assert xyz["href"].split("?", 1)[1] == _TJ_QUERY
+
+    def test_title_from_viewer_first(self):
+        # live per-acq items carry both a viewer title and a renders title — viewer wins for parity
+        result = add_xyz_link(
+            _item_with_tilejson(
+                viewer_title="Sentinel-1 GRD RGB composite", render_title="VV, VH, VV/VH composite"
+            )
+        )
+        assert result is not None
+        xyz = next(lk for lk in result["links"] if lk["rel"] == "xyz")
+        assert xyz["title"] == "Sentinel-1 GRD RGB composite"
+
+    def test_title_from_renders_when_no_viewer(self):
+        result = add_xyz_link(_item_with_tilejson(render_title="VV, VH, VV/VH composite"))
+        assert result is not None
+        xyz = next(lk for lk in result["links"] if lk["rel"] == "xyz")
+        assert xyz["title"] == "VV, VH, VV/VH composite"
+
+    def test_title_fallback_when_no_viewer_or_renders(self):
+        result = add_xyz_link(_item_with_tilejson())
+        assert result is not None
+        xyz = next(lk for lk in result["links"] if lk["rel"] == "xyz")
+        assert xyz["title"] == "XYZ tile template"
+
+    def test_skips_when_xyz_already_present(self):
+        item = _item_with_tilejson(
+            extra_links=[{"rel": "xyz", "type": "image/png", "href": "https://x/{z}/{x}/{y}.png"}]
+        )
+        assert add_xyz_link(item) is None
+
+    def test_skips_legacy_bare_tilejson(self):
+        # the 3 known-legacy items carry .../WebMercatorQuad (no /tilejson.json?) — deriving xyz
+        # would emit garbage; they're slated for wipe+re-ingest, so skip them.
+        item = {
+            "id": "s1-rtc-31TCJ",
+            "links": [
+                {
+                    "rel": "tilejson",
+                    "type": "application/json",
+                    "href": "https://api.example.com/raster/.../s1-rtc-31TCJ/WebMercatorQuad",
+                }
+            ],
+            "assets": {},
+        }
+        assert add_xyz_link(item) is None
+
+    def test_skips_when_no_tilejson(self):
+        item = {"id": "x", "links": [{"rel": "self", "href": "https://x"}], "assets": {}}
+        assert add_xyz_link(item) is None
+
+    def test_does_not_mutate_input(self):
+        item = _item_with_tilejson()
+        original_rels = [lk["rel"] for lk in item["links"]]
+        add_xyz_link(item)
+        assert [lk["rel"] for lk in item["links"]] == original_rels
+
+    def test_idempotent(self):
+        result1 = add_xyz_link(_item_with_tilejson())
+        assert result1 is not None
+        assert add_xyz_link(result1) is None
+
+
 def _make_mock_search(items_dicts: list, total: int | None = None) -> MagicMock:
     """Build a mock pystac_client search that yields one page with the given items."""
     mock_items = []
@@ -264,6 +375,35 @@ class TestSTACMigrationRunner:
         assert result.items_modified == 1
         assert result.items_skipped == 1
         runner._update_item.assert_called_once()
+
+    def test_ids_are_passed_to_search(self, item_clean):
+        # Canary path: run_migration(ids=[...]) restricts the search to those item ids so the
+        # single-tile run uses the exact same code path/recovery/history as the full run.
+        runner = self._make_runner()
+        mock_search = _make_mock_search([item_clean], total=1)
+
+        with patch("_migrate_catalog.runner.Client") as mock_client:
+            mock_client.open.return_value.search.return_value = mock_search
+            runner.run_migration(
+                "test-col", fix_zarr_media_type, "fix_zarr_media_type", ids=["item-a", "item-b"]
+            )
+
+        mock_client.open.return_value.search.assert_called_once_with(
+            collections=["test-col"], ids=["item-a", "item-b"], max_items=None, limit=100
+        )
+
+    def test_no_ids_omits_ids_filter(self, item_clean):
+        # Without ids the full-collection search must not pass an ids filter (backcompat).
+        runner = self._make_runner()
+        mock_search = _make_mock_search([item_clean], total=1)
+
+        with patch("_migrate_catalog.runner.Client") as mock_client:
+            mock_client.open.return_value.search.return_value = mock_search
+            runner.run_migration("test-col", fix_zarr_media_type, "fix_zarr_media_type")
+
+        mock_client.open.return_value.search.assert_called_once_with(
+            collections=["test-col"], max_items=None, limit=100
+        )
 
     def test_clone_collection_copies_metadata_and_items(self):
         runner = STACMigrationRunner("https://api.example.com/stac")

--- a/tests/unit/test_migrate_catalog.py
+++ b/tests/unit/test_migrate_catalog.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from _migrate_catalog.history import load_history, record_run, was_migration_run
+from _migrate_catalog.migrations.add_acquisitions_filter_link import add_acquisitions_filter_link
 from _migrate_catalog.migrations.add_xyz_link import add_xyz_link
 from _migrate_catalog.migrations.align_visualization_links import align_visualization_links
 from _migrate_catalog.migrations.fix_url_encoding import fix_url_encoding
@@ -432,6 +433,78 @@ class TestAlignVisualizationLinks:
         assert rels == ["store", "viewer", "tilejson", "xyz", "via", "related"]
         by_rel = {lk["rel"]: lk for lk in result["links"]}
         assert by_rel["xyz"]["title"] == "VV, VH, VV/VH composite"
+
+
+_FILTER_TITLE = "Per-acquisition items (filter by tile grid:code)"
+
+
+def _acq_item_no_filter() -> dict:
+    """An aligned acquisition item carrying only the single parent related link (no filter link)."""
+    stac = "https://api.example.com/stac"
+    acq_coll = "sentinel-1-grd-rtc-acquisitions-staging"
+    return {
+        "id": "s1-rtc-31TCG-20260701t175417",
+        "collection": acq_coll,
+        "properties": {"renders": {"rgb": {"title": "VV, VH, VV/VH composite"}}},
+        "links": [
+            {
+                "rel": "self",
+                "href": f"{stac}/collections/{acq_coll}/items/s1-rtc-31TCG-20260701t175417",
+            },
+            {"rel": "store", "title": "Zarr Store", "href": "https://x/z"},
+            {"rel": "viewer", "title": "VV, VH, VV/VH composite", "href": "https://x/v"},
+            {"rel": "tilejson", "title": "TileJSON for s1-rtc-...", "href": "https://x/t"},
+            {"rel": "xyz", "title": "VV, VH, VV/VH composite", "href": "https://x/xyz"},
+            {"rel": "via", "title": "EOPF Explorer", "href": "https://x/e"},
+            {
+                "rel": "related",
+                "type": "application/json",
+                "href": f"{stac}/collections/sentinel-1-grd-rtc-staging/items/s1-rtc-31TCG",
+                "title": "Parent tile datacube",
+            },
+        ],
+        "assets": {},
+    }
+
+
+class TestAddAcquisitionsFilterLink:
+    def test_adds_filter_link_after_parent(self):
+        result = add_acquisitions_filter_link(_acq_item_no_filter())
+        assert result is not None
+        related = [lk for lk in result["links"] if lk["rel"] == "related"]
+        assert [lk["title"] for lk in related] == ["Parent tile datacube", _FILTER_TITLE]
+
+    def test_filter_href_targets_the_acquisitions_collection(self):
+        result = add_acquisitions_filter_link(_acq_item_no_filter())
+        assert result is not None
+        filt = next(lk for lk in result["links"] if lk.get("title") == _FILTER_TITLE)
+        assert (
+            filt["href"]
+            == "https://api.example.com/stac/collections/sentinel-1-grd-rtc-acquisitions-staging"
+        )
+        assert filt["rel"] == "related"
+        assert filt["type"] == "application/json"
+
+    def test_now_two_related_links_triggers_grouping(self):
+        result = add_acquisitions_filter_link(_acq_item_no_filter())
+        assert result is not None
+        assert sum(1 for lk in result["links"] if lk["rel"] == "related") == 2
+
+    def test_idempotent(self):
+        result1 = add_acquisitions_filter_link(_acq_item_no_filter())
+        assert result1 is not None
+        assert add_acquisitions_filter_link(result1) is None
+
+    def test_skips_non_acquisition_item(self):
+        # No "Parent tile datacube" related link (e.g. a cube or S2 item) → not an acq item → skip.
+        item = _canonical_cube_item()
+        assert add_acquisitions_filter_link(item) is None
+
+    def test_does_not_mutate_input(self):
+        item = _acq_item_no_filter()
+        before = len(item["links"])
+        add_acquisitions_filter_link(item)
+        assert len(item["links"]) == before
 
 
 def _make_mock_search(items_dicts: list, total: int | None = None) -> MagicMock:

--- a/tests/unit/test_migrate_catalog.py
+++ b/tests/unit/test_migrate_catalog.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from _migrate_catalog.history import load_history, record_run, was_migration_run
 from _migrate_catalog.migrations.add_xyz_link import add_xyz_link
+from _migrate_catalog.migrations.align_visualization_links import align_visualization_links
 from _migrate_catalog.migrations.fix_url_encoding import fix_url_encoding
 from _migrate_catalog.migrations.fix_zarr_media_type import fix_zarr_media_type
 from _migrate_catalog.runner import STACMigrationRunner, compose_migrations
@@ -284,6 +285,153 @@ class TestAddXyzLink:
         result1 = add_xyz_link(_item_with_tilejson())
         assert result1 is not None
         assert add_xyz_link(result1) is None
+
+
+def _nav_links() -> list:
+    return [
+        {"rel": "collection", "href": "https://x/c"},
+        {"rel": "parent", "href": "https://x/p"},
+        {"rel": "root", "href": "https://x/r"},
+        {"rel": "self", "href": "https://x/s"},
+    ]
+
+
+def _old_acq_item() -> dict:
+    """An acquisition item as the OLD register_per_acquisition emitted it: order
+    store→tilejson→xyz→viewer, tilejson titled 'tilejson', viewer/xyz hardcoded."""
+    q = "expression=a&sel=time=2026-07-01T17%3A54%3A17"
+    base = (
+        "https://api.example.com/raster/collections/sentinel-1-grd-rtc-staging/items/s1-rtc-31TCG"
+    )
+    return {
+        "id": "s1-rtc-31TCG-20260701t175417",
+        "properties": {"renders": {"rgb": {"title": "VV, VH, VV/VH composite"}}},
+        "links": [
+            *_nav_links(),
+            {"rel": "store", "title": "Zarr Store", "href": "https://x/z"},
+            {
+                "rel": "tilejson",
+                "type": "application/json",
+                "title": "tilejson",
+                "href": f"{base}/WebMercatorQuad/tilejson.json?{q}",
+            },
+            {
+                "rel": "xyz",
+                "type": "image/png",
+                "title": "Sentinel-1 GRD RGB composite",
+                "href": f"{base}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?{q}",
+            },
+            {
+                "rel": "viewer",
+                "type": "text/html",
+                "title": "Sentinel-1 GRD RGB composite",
+                "href": f"{base}/WebMercatorQuad/map.html?{q}",
+            },
+            {"rel": "via", "type": "text/html", "title": "EOPF Explorer", "href": "https://x/e"},
+            {
+                "rel": "related",
+                "type": "application/json",
+                "title": "Parent tile datacube",
+                "href": "https://x/pt",
+            },
+        ],
+        "assets": {},
+    }
+
+
+def _canonical_cube_item() -> dict:
+    """A cube item already in the canonical form register_v1 emits — align must no-op on it."""
+    return {
+        "id": "s1-rtc-31TCG",
+        "properties": {"renders": {"rgb": {"title": "VV, VH, VV/VH composite"}}},
+        "links": [
+            *_nav_links(),
+            {"rel": "store", "title": "Zarr Store", "href": "https://x/z"},
+            {"rel": "viewer", "title": "VV, VH, VV/VH composite", "href": "https://x/v"},
+            {"rel": "tilejson", "title": "TileJSON for s1-rtc-31TCG", "href": "https://x/t"},
+            {"rel": "xyz", "title": "VV, VH, VV/VH composite", "href": "https://x/xyz"},
+            {"rel": "via", "title": "EOPF Explorer", "href": "https://x/e"},
+            {"rel": "related", "title": "Acquisition A", "href": "https://x/a1"},
+            {"rel": "related", "title": "Acquisition B", "href": "https://x/a2"},
+        ],
+        "assets": {},
+    }
+
+
+class TestAlignVisualizationLinks:
+    def test_retitles_viewer_tilejson_xyz(self):
+        result = align_visualization_links(_old_acq_item())
+        assert result is not None
+        by_rel = {lk["rel"]: lk for lk in result["links"]}
+        assert by_rel["viewer"]["title"] == "VV, VH, VV/VH composite"
+        assert by_rel["xyz"]["title"] == "VV, VH, VV/VH composite"
+        assert by_rel["tilejson"]["title"] == "TileJSON for s1-rtc-31TCG-20260701t175417"
+
+    def test_reorders_non_nav_to_canonical(self):
+        result = align_visualization_links(_old_acq_item())
+        assert result is not None
+        rels = [lk["rel"] for lk in result["links"]]
+        non_nav = [r for r in rels if r not in {"collection", "parent", "root", "self"}]
+        assert non_nav == ["store", "viewer", "tilejson", "xyz", "via", "related"]
+
+    def test_preserves_related_order_and_count(self):
+        item = _old_acq_item()
+        item["links"].append({"rel": "related", "title": "Second related", "href": "https://x/pt2"})
+        result = align_visualization_links(item)
+        assert result is not None
+        related = [lk for lk in result["links"] if lk["rel"] == "related"]
+        assert [lk["title"] for lk in related] == ["Parent tile datacube", "Second related"]
+
+    def test_noop_on_canonical_cube_item(self):
+        assert align_visualization_links(_canonical_cube_item()) is None
+
+    def test_skips_item_without_renders(self):
+        item = {"id": "s2", "properties": {}, "links": _nav_links(), "assets": {}}
+        assert align_visualization_links(item) is None
+
+    def test_retitles_even_when_xyz_absent(self):
+        item = _old_acq_item()
+        item["links"] = [lk for lk in item["links"] if lk["rel"] != "xyz"]
+        result = align_visualization_links(item)
+        assert result is not None
+        by_rel = {lk["rel"]: lk for lk in result["links"]}
+        assert by_rel["tilejson"]["title"] == "TileJSON for s1-rtc-31TCG-20260701t175417"
+        assert by_rel["viewer"]["title"] == "VV, VH, VV/VH composite"
+
+    def test_render_title_fallback_when_untitled(self):
+        item = _old_acq_item()
+        del item["properties"]["renders"]["rgb"]["title"]
+        result = align_visualization_links(item)
+        assert result is not None
+        by_rel = {lk["rel"]: lk for lk in result["links"]}
+        assert by_rel["viewer"]["title"] == "Visualization for s1-rtc-31TCG-20260701t175417"
+
+    def test_does_not_mutate_input(self):
+        item = _old_acq_item()
+        before = [lk["rel"] for lk in item["links"]]
+        align_visualization_links(item)
+        assert [lk["rel"] for lk in item["links"]] == before
+
+    def test_idempotent(self):
+        result1 = align_visualization_links(_old_acq_item())
+        assert result1 is not None
+        assert align_visualization_links(result1) is None
+
+    def test_composes_with_add_xyz_link(self):
+        # Full backfill path: add xyz (item without one) then align → canonical form.
+        item = _old_acq_item()
+        item["links"] = [lk for lk in item["links"] if lk["rel"] != "xyz"]
+        composed = compose_migrations([add_xyz_link, align_visualization_links])
+        result = composed(item)
+        assert result is not None
+        rels = [
+            lk["rel"]
+            for lk in result["links"]
+            if lk["rel"] not in {"collection", "parent", "root", "self"}
+        ]
+        assert rels == ["store", "viewer", "tilejson", "xyz", "via", "related"]
+        by_rel = {lk["rel"]: lk for lk in result["links"]}
+        assert by_rel["xyz"]["title"] == "VV, VH, VV/VH composite"
 
 
 def _make_mock_search(items_dicts: list, total: int | None = None) -> MagicMock:

--- a/tests/unit/test_migrate_catalog.py
+++ b/tests/unit/test_migrate_catalog.py
@@ -596,11 +596,12 @@ class TestSTACMigrationRunner:
         rels = [lk["rel"] for lk in body["links"]]
         assert rels.index("xyz") == rels.index("tilejson") + 1
 
-    def test_reads_raw_dicts_so_unmodelable_items_dont_abort(self):
+    def test_unmodelable_item_failed_without_delete(self):
         # A live item can carry an asset with no href (e.g. s1-rtc-30TWQ) that pystac's
-        # Item.from_dict rejects. run_migration must iterate raw dicts (items_as_dicts), not
-        # pystac Item objects, so one malformed item can't abort the whole run.
-        runner = self._make_runner()
+        # Item.from_dict rejects. It is READ fine (raw dicts, so it can't abort the run) but it
+        # cannot be turned into a transaction-valid POST body — so it must be reported failed and
+        # NEVER deleted. A delete-then-failed-POST would lose the item entirely.
+        runner = self._make_runner()  # _update_item (delete + post) is a MagicMock
         hrefless = {
             "id": "s1-rtc-30TWQ",
             "assets": {"vv": {"roles": ["data"]}},  # no href — pystac would raise KeyError
@@ -623,8 +624,9 @@ class TestSTACMigrationRunner:
             result = runner.run_migration("test-col", add_xyz_link, "add_xyz_link")
 
         assert result.items_processed == 1
-        assert result.items_modified == 1
-        assert result.items_failed == 0
+        assert result.items_modified == 0
+        assert result.items_failed == 1
+        runner._update_item.assert_not_called()  # never delete an item we can't re-POST
 
     def test_clone_collection_copies_metadata_and_items(self):
         runner = STACMigrationRunner("https://api.example.com/stac")

--- a/tests/unit/test_migrate_catalog.py
+++ b/tests/unit/test_migrate_catalog.py
@@ -506,6 +506,15 @@ class TestAddAcquisitionsFilterLink:
         add_acquisitions_filter_link(item)
         assert len(item["links"]) == before
 
+    def test_gate_titles_match_registration_source_of_truth(self):
+        # The migration gates on these titles; if register_* renames them the migration would
+        # silently skip every item. Bind them to the shared constants (drift guard).
+        from _migrate_catalog.migrations import add_acquisitions_filter_link as mod
+        from stac_link_titles import ACQUISITIONS_FILTER_TITLE, PARENT_DATACUBE_TITLE
+
+        assert mod._PARENT_TITLE == PARENT_DATACUBE_TITLE
+        assert mod._FILTER_TITLE == ACQUISITIONS_FILTER_TITLE
+
 
 def _make_mock_search(items_dicts: list, total: int | None = None) -> MagicMock:
     """Build a mock pystac_client search that yields one page with the given items."""

--- a/tests/unit/test_migrate_catalog.py
+++ b/tests/unit/test_migrate_catalog.py
@@ -298,6 +298,9 @@ def _make_mock_search(items_dicts: list, total: int | None = None) -> MagicMock:
     mock_search = MagicMock()
     mock_search.matched.return_value = total
     mock_search.pages.return_value = [mock_page] if mock_items else []
+    # run_migration consumes raw dicts (robust to items pystac can't model); clone/fetch still
+    # use .pages()/.items.
+    mock_search.items_as_dicts.return_value = list(items_dicts)
     return mock_search
 
 
@@ -404,6 +407,76 @@ class TestSTACMigrationRunner:
         mock_client.open.return_value.search.assert_called_once_with(
             collections=["test-col"], max_items=None, limit=100
         )
+
+    def test_post_body_normalized_so_datacube_items_dont_400(self):
+        # Datacube items have null datetime, which the STAC GET/search view omits from
+        # properties — but the transaction POST requires the key. run_migration must normalize
+        # the POST body (via pystac) so it re-materializes properties.datetime.
+        runner = self._make_runner()  # _update_item is a MagicMock
+        item = {
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "id": "s1-rtc-31TCG",
+            "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]},
+            "bbox": [0, 0, 1, 1],
+            "properties": {  # note: NO "datetime" key (null-datetime datacube), only start/end
+                "start_datetime": "2026-06-01T00:00:00Z",
+                "end_datetime": "2026-07-01T00:00:00Z",
+            },
+            "links": [
+                {
+                    "rel": "tilejson",
+                    "type": "application/json",
+                    "href": "https://x/WebMercatorQuad/tilejson.json?expression=a",
+                }
+            ],
+            "assets": {},
+            "collection": "sentinel-1-grd-rtc-staging",
+        }
+        mock_search = MagicMock()
+        mock_search.matched.return_value = 1
+        mock_search.items_as_dicts.return_value = [item]
+
+        with patch("_migrate_catalog.runner.Client") as mock_client:
+            mock_client.open.return_value.search.return_value = mock_search
+            runner.run_migration("test-col", add_xyz_link, "add_xyz_link")
+
+        runner._update_item.assert_called_once()
+        _, _, body = runner._update_item.call_args[0]
+        assert "datetime" in body["properties"]  # key present (None) for the transaction API
+        # xyz stays immediately after tilejson through normalization
+        rels = [lk["rel"] for lk in body["links"]]
+        assert rels.index("xyz") == rels.index("tilejson") + 1
+
+    def test_reads_raw_dicts_so_unmodelable_items_dont_abort(self):
+        # A live item can carry an asset with no href (e.g. s1-rtc-30TWQ) that pystac's
+        # Item.from_dict rejects. run_migration must iterate raw dicts (items_as_dicts), not
+        # pystac Item objects, so one malformed item can't abort the whole run.
+        runner = self._make_runner()
+        hrefless = {
+            "id": "s1-rtc-30TWQ",
+            "assets": {"vv": {"roles": ["data"]}},  # no href — pystac would raise KeyError
+            "links": [
+                {
+                    "rel": "tilejson",
+                    "type": "application/json",
+                    "href": "https://x/WebMercatorQuad/tilejson.json?expression=a",
+                }
+            ],
+        }
+        mock_search = MagicMock()
+        mock_search.matched.return_value = 1
+        mock_search.items_as_dicts.return_value = [hrefless]
+        # Prove the runner does NOT touch the pystac-parsing path.
+        mock_search.pages.side_effect = KeyError("href")
+
+        with patch("_migrate_catalog.runner.Client") as mock_client:
+            mock_client.open.return_value.search.return_value = mock_search
+            result = runner.run_migration("test-col", add_xyz_link, "add_xyz_link")
+
+        assert result.items_processed == 1
+        assert result.items_modified == 1
+        assert result.items_failed == 0
 
     def test_clone_collection_copies_metadata_and_items(self):
         runner = STACMigrationRunner("https://api.example.com/stac")

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -87,7 +87,7 @@ def test_render_links_point_at_cube_endpoint_with_sel_datetime() -> None:
         _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER, stac_api_url=STAC
     )
     links = _links(d)
-    for rel in ("tilejson", "viewer"):
+    for rel in ("tilejson", "viewer", "xyz"):
         href = links[rel]
         assert f"/collections/{CUBE}/items/s1-rtc-31TCH" in href  # cube endpoint, not the acq item
         assert ACQ not in href
@@ -102,7 +102,27 @@ def test_render_links_point_at_cube_endpoint_with_sel_datetime() -> None:
     assert (
         "/WebMercatorQuad/map.html" in links["viewer"]
     )  # interactive viewer, not a raw tile template
-    assert "{z}/{x}/{y}" not in str(d["links"])  # the broken xyz template is gone
+    # the sole {z}/{x}/{y} template is the machine-facing rel=xyz link
+    xyz_hrefs = [lk["href"] for lk in d["links"] if "{z}/{x}/{y}" in lk["href"]]
+    assert xyz_hrefs == [links["xyz"]]
+
+
+def test_xyz_link_shape() -> None:
+    """The xyz link carries the literal {z}/{x}/{y} template (catches f-string escaping bugs),
+    is image/png, ordered right after tilejson, and shares tilejson's exact query."""
+    d = decorate_acquisition_item(
+        _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER, stac_api_url=STAC
+    )
+    xyz = next(lk for lk in d["links"] if lk["rel"] == "xyz")
+    assert "/tiles/WebMercatorQuad/{z}/{x}/{y}.png?" in xyz["href"]
+    assert xyz["type"] == "image/png"
+    assert xyz["title"] == "Sentinel-1 GRD RGB composite"  # matches the sibling viewer title
+    # ordered immediately after tilejson
+    rels = [lk["rel"] for lk in d["links"]]
+    assert rels.index("xyz") == rels.index("tilejson") + 1
+    # query byte-identical to the tilejson link's
+    tj = next(lk for lk in d["links"] if lk["rel"] == "tilejson")
+    assert xyz["href"].split("?", 1)[1] == tj["href"].split("?", 1)[1]
 
 
 def test_thumbnail_via_and_store_link_kept() -> None:

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -133,11 +133,27 @@ def test_link_titles_and_order_match_cube_convention() -> None:
         _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER, stac_api_url=STAC
     )
     rels = [lk["rel"] for lk in d["links"]]
-    assert rels == ["store", "viewer", "tilejson", "xyz", "via", "related"]
+    # two related links (parent + sibling-collection filter) so STAC Browser groups the section
+    assert rels == ["store", "viewer", "tilejson", "xyz", "via", "related", "related"]
     by_rel = {lk["rel"]: lk for lk in d["links"]}
     assert by_rel["viewer"]["title"] == "VV, VH, VV/VH composite"
     assert by_rel["xyz"]["title"] == "VV, VH, VV/VH composite"
     assert by_rel["tilejson"]["title"] == "TileJSON for s1-rtc-31TCH-20260605t060907"
+
+
+def test_two_related_links_for_stac_browser_grouping() -> None:
+    """Acq items carry two related links — parent cube + sibling acquisitions collection — so a rel
+    group has >=2 entries and STAC Browser renders grouped 'Additional Resources' category headers."""
+    d = decorate_acquisition_item(
+        _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER, stac_api_url=STAC
+    )
+    related = [lk for lk in d["links"] if lk["rel"] == "related"]
+    assert len(related) == 2
+    titles = [lk["title"] for lk in related]
+    assert titles == ["Parent tile datacube", "Per-acquisition items (filter by tile grid:code)"]
+    filt = related[1]
+    assert filt["href"] == f"{STAC}/collections/{ACQ}"  # the sibling acquisitions collection
+    assert filt["type"] == "application/json"
 
 
 def test_thumbnail_via_and_store_link_kept() -> None:
@@ -154,8 +170,11 @@ def test_thumbnail_via_and_store_link_kept() -> None:
     assert links["via"].endswith(f"/collections/{ACQ}/items/s1-rtc-31TCH-20260605t060907")
     assert "store" in links  # the caller's cube store link is preserved
     assert "/WebMercatorQuad/map.html" in links["viewer"]  # map.html deep-link into this slice
-    # related link → the parent tile datacube STAC item (cube collection)
-    assert links["related"] == f"{STAC}/collections/{CUBE}/items/s1-rtc-31TCH"
+    # the parent related link → the parent tile datacube STAC item (cube collection)
+    parent = next(
+        lk for lk in d["links"] if lk["rel"] == "related" and lk["title"] == "Parent tile datacube"
+    )
+    assert parent["href"] == f"{STAC}/collections/{CUBE}/items/s1-rtc-31TCH"
 
 
 def test_no_orbit_leak() -> None:

--- a/tests/unit/test_register_per_acquisition.py
+++ b/tests/unit/test_register_per_acquisition.py
@@ -48,6 +48,7 @@ def _acq_item() -> pystac.Item:
             "sat:orbit_state": "descending",
             "renders": {
                 "rgb": {
+                    "title": "VV, VH, VV/VH composite",
                     "expression": "/descending:vv;/descending:vh;(/descending:vv)/(/descending:vh)",
                     "rescale": [[0.0, 0.4], [0.0, 0.1], [1.0, 15.0]],
                     "bidx": [1],
@@ -116,13 +117,27 @@ def test_xyz_link_shape() -> None:
     xyz = next(lk for lk in d["links"] if lk["rel"] == "xyz")
     assert "/tiles/WebMercatorQuad/{z}/{x}/{y}.png?" in xyz["href"]
     assert xyz["type"] == "image/png"
-    assert xyz["title"] == "Sentinel-1 GRD RGB composite"  # matches the sibling viewer title
+    assert xyz["title"] == "VV, VH, VV/VH composite"  # the render composite title (as on the cube)
     # ordered immediately after tilejson
     rels = [lk["rel"] for lk in d["links"]]
     assert rels.index("xyz") == rels.index("tilejson") + 1
     # query byte-identical to the tilejson link's
     tj = next(lk for lk in d["links"] if lk["rel"] == "tilejson")
     assert xyz["href"].split("?", 1)[1] == tj["href"].split("?", 1)[1]
+
+
+def test_link_titles_and_order_match_cube_convention() -> None:
+    """Acq visualization links mirror the cube (register_v1): order store→viewer→tilejson→xyz,
+    viewer/xyz titled by the render composite, tilejson 'TileJSON for {id}'."""
+    d = decorate_acquisition_item(
+        _acq_item(), tile_id="31TCH", cube_collection=CUBE, raster_api=RASTER, stac_api_url=STAC
+    )
+    rels = [lk["rel"] for lk in d["links"]]
+    assert rels == ["store", "viewer", "tilejson", "xyz", "via", "related"]
+    by_rel = {lk["rel"]: lk for lk in d["links"]}
+    assert by_rel["viewer"]["title"] == "VV, VH, VV/VH composite"
+    assert by_rel["xyz"]["title"] == "VV, VH, VV/VH composite"
+    assert by_rel["tilejson"]["title"] == "TileJSON for s1-rtc-31TCH-20260605t060907"
 
 
 def test_thumbnail_via_and_store_link_kept() -> None:

--- a/tests/unit/test_register_v1.py
+++ b/tests/unit/test_register_v1.py
@@ -215,8 +215,28 @@ class TestVisualizationFromRenders:
             assert "0.1" in link.href
         # the human viewer is the interactive map.html, not a raw {z}/{x}/{y} tile template
         assert "/WebMercatorQuad/map.html" in viewer.href
-        assert not any("{z}/{x}/{y}" in link.href for link in item.links)
+        # the sole raw {z}/{x}/{y} tile template is the machine-facing rel=xyz link
+        xyz_links = [link for link in item.links if "{z}/{x}/{y}" in link.href]
+        assert [link.rel for link in xyz_links] == ["xyz"]
         assert "tilejson.json" in tilejson.href
+
+    def test_xyz_tile_template_from_render(self):
+        item = _real_item(_s1_rgb_renders())
+        add_visualization_links(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
+
+        xyz = [link for link in item.links if link.rel == "xyz"]
+        assert len(xyz) == 1
+        xyz = xyz[0]
+        # raw XYZ tile template for machine map clients (QGIS/Leaflet/OpenLayers)
+        assert "/tiles/WebMercatorQuad/{z}/{x}/{y}.png?" in xyz.href
+        assert xyz.media_type == "image/png"
+        assert xyz.title == "VV, VH, VV/VH composite"
+        # query is byte-identical to the tilejson link's query
+        tilejson = next(link for link in item.links if link.rel == "tilejson")
+        assert xyz.href.split("?", 1)[1] == tilejson.href.split("?", 1)[1]
+        # ordered immediately after tilejson
+        rels = [link.rel for link in item.links]
+        assert rels.index("xyz") == rels.index("tilejson") + 1
 
     def test_thumbnail_uses_render_expression(self):
         item = _real_item(_s1_rgb_renders())
@@ -233,6 +253,17 @@ class TestVisualizationFromRenders:
         add_thumbnail_asset(item, RASTER_BASE, "sentinel-1-grd-rtc-staging")
         # legacy VH grayscale path still applies when no render config present
         assert "thumbnail" in item.assets
+
+    def test_s2_fallback_xyz_unchanged(self):
+        # No-renders S2 item must keep the legacy hardcoded true-color xyz template
+        # untouched (no-regression guarantee for the deliberate reversal on S1).
+        item = _real_item()  # no renders property
+        add_visualization_links(item, RASTER_BASE, "sentinel-2-l2a")
+        xyz = next(link for link in item.links if link.rel == "xyz")
+        assert "/tiles/WebMercatorQuad/{z}/{x}/{y}.png?" in xyz.href
+        assert xyz.media_type == "image/png"
+        assert xyz.title == "Sentinel-2 L2A True Color"
+        assert "color_formula=" in xyz.href
 
 
 _SEL = "2026-06-07T05:52:48"
@@ -253,6 +284,12 @@ class TestSelTimePinsSlice:
         for rel in ("viewer", "tilejson"):
             link = next(link for link in item.links if link.rel == rel)
             assert _SEL_Q in link.href
+
+    def test_xyz_carries_sel_time(self):
+        item = _real_item(_s1_rgb_renders())
+        add_visualization_links(item, RASTER_BASE, "sentinel-1-grd-rtc-staging", sel_time=_SEL)
+        xyz = next(link for link in item.links if link.rel == "xyz")
+        assert _SEL_Q in xyz.href
 
     def test_no_sel_time_by_default_backcompat(self):
         # sel_time omitted (S2 + any other caller) => links/thumbnail unchanged, no sel.


### PR DESCRIPTION
## Summary

Adds a `rel="xyz"` `{z}/{x}/{y}.png` tile-template link to S1 RTC STAC items (for XYZ map clients, as S2 already has), aligns the per-acquisition items' links with the cube, and adds a second `related` link so STAC Browser renders the grouped "Additional Resources" section (its `LinkList` only groups when a `rel` has ≥2 links). Three idempotent `_migrate_catalog` plugins backfill the items already in staging.

Base is `feat--s1_grd_phase5` (the S1 integration tip, tag `v0.8.0-s1rtc-rc10`), not `main`.

## For reviewers

- S2 unchanged (no `renders` → never enters the render path; migrations no-op).
- Backfill already run on staging: cube 170/170, acquisitions 1352/1368 (16 legacy-tile stragglers pending wipe+re-ingest). xyz templates render real tiles.
- Follow-up (not this PR): deploy the image before the cron re-upserts cube items on the old code.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted (Claude Code) test-first; every migration result reconciled against `numberMatched` + an independent pystac sweep, and xyz templates validated by rendering real tiles.
