### PR TITLE
feat(storage-tier): recurring tier-down selection (--min-age-days + tier-aware)

### DIFF
--- a/operator-tools/README.md
+++ b/operator-tools/README.md
@@ -269,11 +269,20 @@ uv run operator-tools/submit_test_workflow_wh_list.py
 
 **Configuration:** Edit the `products` list and `payload` fields inside the script.
 
-### 6. `submit_storage_tier_workflows.py` - Batch Storage Tier Change via Argo
+### 6. `scripts/submit_storage_tier_workflows.py` - Batch Storage Tier Change via Argo
 
-Queries STAC in 24h windows over a date range and submits one `batch-change-storage-tier` webhook payload per window, triggering the `eopf-storage-tier-batch-job` WorkflowTemplate via Argo Events. Each workflow fans out over all items in that window in parallel (up to `--parallelism` pods at a time). This is the preferred approach for large date ranges — one Argo Workflow per day keeps job history clean and avoids submitting hundreds of individual workflows.
+> Lives in `scripts/` (not `operator-tools/`) so it ships in the pipeline image and the recurring tier-down CronWorkflow can run it in-cluster. Operators still invoke it the same way.
 
-**Use case:** Change the S3 storage class (e.g., to `STANDARD_IA`) for thousands of items over a multi-month date range.
+Selects STAC items — by an explicit date window **or** by age — that are **not already at the target tier**, and submits one `batch-change-storage-tier` webhook payload per sub-window/batch, triggering the `eopf-storage-tier-batch-job` WorkflowTemplate via Argo Events. Each workflow fans out over the items in that payload in parallel.
+
+Two selection modes (mutually exclusive):
+
+- **Explicit window** (`--start-date`/`--end-date`) — for one-off backfills over a fixed range, split into `--window-hours` sub-windows.
+- **Age band** (`--min-age-days` [`--max-age-days`]) — for the recurring cron. `--min-age-days 90` alone selects `created < today−90d` (single-sided); adding `--max-age-days 93` bounds it to the age band `created ∈ [today−93d, today−90d]`. Run daily with `--min-age-days 90 --max-age-days 93 --window-hours 72` so each run covers a rolling 72h band and a missed day is still picked up by the 48h overlap.
+
+In both modes the **already-at-target tier filter** (asset-level `storage:refs`) excludes items already converted, so re-runs and window overlaps don't re-submit them.
+
+**Use case:** Change the S3 storage class (e.g., to `STANDARD`) for items crossing an age threshold, recurringly, or drain a bulk backlog over a multi-month range.
 
 **Prerequisites:**
 
@@ -285,7 +294,7 @@ Queries STAC in 24h windows over a date range and submits one `batch-change-stor
 
 ```bash
 # Dry run — logs what would be submitted without sending any requests
-python operator-tools/submit_storage_tier_workflows.py \
+python scripts/submit_storage_tier_workflows.py \
     --start-date 2024-01-01 \
     --end-date 2024-06-01 \
     --collection sentinel-2-l2a-staging \
@@ -293,7 +302,7 @@ python operator-tools/submit_storage_tier_workflows.py \
     --dry-run
 
 # Live run (port-forward must be active)
-python operator-tools/submit_storage_tier_workflows.py \
+python scripts/submit_storage_tier_workflows.py \
     --start-date 2024-01-01 \
     --end-date 2024-06-01 \
     --collection sentinel-2-l2a-staging \
@@ -303,7 +312,7 @@ python operator-tools/submit_storage_tier_workflows.py \
 # Registered-window backlog — window on when items were *registered*
 # (properties.created) rather than sensed, to drain a bulk-conversion backlog
 # to STANDARD. Uses a CQL2 filter instead of the datetime= range.
-python operator-tools/submit_storage_tier_workflows.py \
+python scripts/submit_storage_tier_workflows.py \
     --date-field created \
     --start-date 2025-11-01 \
     --end-date 2026-04-08 \
@@ -317,20 +326,24 @@ python operator-tools/submit_storage_tier_workflows.py \
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--start-date` | required | Start of date range (`YYYY-MM-DD`) |
-| `--end-date` | required | End of date range (`YYYY-MM-DD`) |
+| `--start-date` | — | Start of explicit date range (`YYYY-MM-DD`); use with `--end-date` |
+| `--end-date` | — | End of explicit date range (`YYYY-MM-DD`); use with `--start-date` |
+| `--min-age-days` | — | Age-based selection: items older than N days by `--date-field`. Single-sided unless `--max-age-days` given. Mutually exclusive with `--start-date/--end-date` |
+| `--max-age-days` | — | Upper age bound (requires `--min-age-days`): the age band `[min, max]` days, i.e. `created ∈ [today−max, today−min]` |
+| `--window-hours` | `24` | Sub-window size a bounded range is split into (one payload each) |
+| `--max-batch-size` | none | Max item IDs per payload; larger selections split across payloads |
 | `--collection` | required | STAC collection ID |
-| `--date-field` | `datetime` | Item date to window on: sensing `datetime`, registration `created`, or last-modified `updated`. Non-default fields use a CQL2 `between` filter |
+| `--date-field` | mode-dependent | Item date: `datetime`, `created`, or `updated`. Defaults to `created` with `--min-age-days`, else `datetime`. Non-`datetime` uses a CQL2 filter |
 | `--storage-class` | `STANDARD` | Target S3 storage class |
 | `--stac-api-url` | prod API URL | STAC API endpoint to query |
 | `--s3-endpoint` | OVH Cloud | S3 endpoint passed to Argo workflows |
 | `--pipeline-image-version` | `v1.6.1` | Docker image tag for Argo jobs |
-| `--process-all-assets` | false | Process all assets (not just reflectance) |
+| `--process-all-assets` | false | Process all assets (required for the recurring tier-down's idempotency) |
 | `--webhook-url` | `localhost:12000/samples` | Webhook endpoint |
-| `--delay` | `1.0` | Seconds between window submissions |
+| `--delay` | `1.0` | Seconds between payload submissions |
 | `--dry-run` | false | Log payloads without sending |
 
-**Payload format** (one per 24h window):
+**Payload format** (one per sub-window/batch):
 ```json
 {
   "action": "batch-change-storage-tier",
@@ -426,7 +439,7 @@ python manage_collections.py clean test-coll --clean-s3 -y
 | `manage_collections.py` | Collection lifecycle management | `python manage_collections.py create/delete` |
 | `submit_test_workflow_wh.py` | Testing pipeline with one known item | edit script then `uv run submit_test_workflow_wh.py` |
 | `submit_test_workflow_wh_list.py` | Reprocessing a small known fixed set | edit products list then `uv run submit_test_workflow_wh_list.py` |
-| `submit_storage_tier_workflows.py` | Changing storage tier for a large date range (one Argo batch workflow per 24h window) | `python submit_storage_tier_workflows.py --start-date ... --dry-run` |
+| `scripts/submit_storage_tier_workflows.py` | Changing storage tier by date range or age band (recurring tier-down cron + one-off backfills) | `python scripts/submit_storage_tier_workflows.py --min-age-days 90 --max-age-days 93 --window-hours 72 --dry-run` |
 
 ### Benefits of This Workflow
 

--- a/operator-tools/submit_storage_tier_workflows.py
+++ b/operator-tools/submit_storage_tier_workflows.py
@@ -11,16 +11,69 @@ import logging
 import sys
 import time
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import cast
 
 import requests
 from pystac_client import Client
+
+# The tier-aware selection reuses the proven client-side predicate and tier map
+# from the scripts/ package. Bootstrap scripts/ onto sys.path so this operator
+# tool imports them at runtime the same way the test config (pythonpath) does.
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from query_storage_tier_items import is_already_migrated  # noqa: E402
+from update_stac_storage_tier import TIER_TO_SCHEME  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC time. Seam for injecting a fixed 'today' in tests."""
+    return datetime.now(UTC)
+
+
+def compute_age_cutoff(min_age_days: int, *, today: datetime) -> datetime:
+    """Return the `created` upper bound for age-based selection: ``today - min_age_days``.
+
+    Items whose ``created`` is *before* this cutoff are older than ``min_age_days``.
+    """
+    return today - timedelta(days=min_age_days)
+
+
+def resolve_window_bounds(
+    *,
+    min_age_days: int | None,
+    start_date: str | None,
+    end_date: str | None,
+    today: datetime,
+) -> tuple[datetime | None, datetime]:
+    """Resolve the two selection modes to ``(start, end)`` datetimes.
+
+    - Age mode (``min_age_days`` set): single-sided, returns ``(None, today - min_age_days)``.
+      The open lower bound relies on the tier-aware filter to stay cheap.
+    - Explicit mode (``start_date`` and ``end_date`` set): windowed, returns both bounds.
+
+    The two modes are mutually exclusive. Raises ``ValueError`` on an invalid combination.
+    """
+    has_explicit = start_date is not None or end_date is not None
+    if min_age_days is not None and has_explicit:
+        raise ValueError("--min-age-days and --start-date/--end-date are mutually exclusive")
+    if min_age_days is not None:
+        return None, compute_age_cutoff(min_age_days, today=today)
+    if not (start_date is not None and end_date is not None):
+        raise ValueError("provide --min-age-days, or both --start-date and --end-date")
+    start = datetime.fromisoformat(start_date).replace(tzinfo=UTC)
+    end = datetime.fromisoformat(end_date).replace(tzinfo=UTC)
+    if end <= start:
+        raise ValueError("--end-date must be after --start-date")
+    return start, end
 
 
 def generate_time_windows(
@@ -48,9 +101,10 @@ def generate_time_windows(
 def query_stac_items(
     stac_api_url: str,
     collection: str,
-    window_start: str,
+    window_start: str | None,
     window_end: str,
     date_field: str = "datetime",
+    target_storage_ref: str | None = None,
 ) -> list[str]:
     """Query STAC for items whose ``date_field`` falls in the window. Returns item IDs.
 
@@ -58,9 +112,26 @@ def query_stac_items(
     (the item's sensing time). Other fields (``created``, ``updated``) filter on
     the registration/update timestamp via a CQL2 ``between`` filter, since those
     properties are not reachable through the ``datetime=`` kwarg.
+
+    ``window_start=None`` issues a single-sided selection (``date_field < window_end``)
+    for the recurring age-based tier-down: every item older than the cutoff, with no
+    lower bound. This is only meaningful for the ``created``/``updated`` fields.
+
+    ``target_storage_ref`` (e.g. ``"standard"``) filters out items already at the
+    target tier, using the same asset-level ``storage:refs`` check as the optimizer
+    (``is_already_migrated``). This keeps a recurring run cheap and makes a re-run a
+    zero-item no-op. When ``None`` no tier filter is applied.
     """
     catalog = Client.open(stac_api_url)
-    if date_field == "datetime":
+    if window_start is None:
+        # Single-sided open lower bound for age-based selection.
+        search = catalog.search(
+            collections=[collection],
+            filter={"op": "<", "args": [{"property": date_field}, window_end]},
+            filter_lang="cql2-json",
+            limit=100,
+        )
+    elif date_field == "datetime":
         search = catalog.search(
             collections=[collection],
             datetime=f"{window_start}/{window_end}",
@@ -76,6 +147,10 @@ def query_stac_items(
             filter_lang="cql2-json",
             limit=100,
         )
+    if target_storage_ref is not None:
+        return [
+            item.id for item in search.items() if not is_already_migrated(item, target_storage_ref)
+        ]
     return [item.id for item in search.items()]
 
 
@@ -106,8 +181,19 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Submit storage tier batch workflows via webhook for a date range of STAC items."
     )
-    parser.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
-    parser.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--start-date", help="Start date (YYYY-MM-DD). Use with --end-date for a fixed window."
+    )
+    parser.add_argument(
+        "--end-date", help="End date (YYYY-MM-DD). Use with --start-date for a fixed window."
+    )
+    parser.add_argument(
+        "--min-age-days",
+        type=int,
+        help="Select items older than this many days by --date-field (single-sided, "
+        "no lower bound). For the recurring tier-down cron. Mutually exclusive with "
+        "--start-date/--end-date.",
+    )
     parser.add_argument("--collection", required=True, help="STAC collection ID")
     parser.add_argument(
         "--date-field",
@@ -129,18 +215,28 @@ def main() -> None:
     args = parser.parse_args()
 
     try:
-        start_date = datetime.fromisoformat(args.start_date).replace(tzinfo=UTC)
-        end_date = datetime.fromisoformat(args.end_date).replace(tzinfo=UTC)
+        start_date, end_date = resolve_window_bounds(
+            min_age_days=args.min_age_days,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            today=_utcnow(),
+        )
     except ValueError as e:
-        logger.error(f"Invalid date format: {e}")
+        logger.error(str(e))
         sys.exit(1)
 
-    if end_date <= start_date:
-        logger.error("--end-date must be after --start-date")
-        sys.exit(1)
+    target_storage_ref = TIER_TO_SCHEME.get(args.storage_class)
 
-    windows = generate_time_windows(start_date, end_date)
-    logger.info(f"Processing {len(windows)} 24h windows from {args.start_date} to {args.end_date}")
+    end_iso = end_date.isoformat().replace("+00:00", "Z")
+    if start_date is None:
+        # Age mode: single-sided, one open-lower-bound query and payload.
+        windows: list[tuple[str | None, str]] = [(None, end_iso)]
+        logger.info(f"Age mode: selecting items with {args.date_field} < {end_iso}")
+    else:
+        windows = list(generate_time_windows(start_date, end_date))
+        logger.info(
+            f"Processing {len(windows)} 24h windows from {args.start_date} to {args.end_date}"
+        )
 
     total_submitted = 0
     total_failed = 0
@@ -148,7 +244,12 @@ def main() -> None:
     for i, (window_start, window_end) in enumerate(windows, 1):
         logger.info(f"[{i}/{len(windows)}] Querying window {window_start} to {window_end}")
         item_ids = query_stac_items(
-            args.stac_api_url, args.collection, window_start, window_end, args.date_field
+            args.stac_api_url,
+            args.collection,
+            window_start,
+            window_end,
+            args.date_field,
+            target_storage_ref,
         )
         logger.info(f"  Found {len(item_ids)} items")
 

--- a/operator-tools/submit_storage_tier_workflows.py
+++ b/operator-tools/submit_storage_tier_workflows.py
@@ -66,6 +66,8 @@ def resolve_window_bounds(
     if min_age_days is not None and has_explicit:
         raise ValueError("--min-age-days and --start-date/--end-date are mutually exclusive")
     if min_age_days is not None:
+        if min_age_days < 0:
+            raise ValueError("--min-age-days must be >= 0")
         return None, compute_age_cutoff(min_age_days, today=today)
     if not (start_date is not None and end_date is not None):
         raise ValueError("provide --min-age-days, or both --start-date and --end-date")
@@ -226,10 +228,16 @@ def main() -> None:
         sys.exit(1)
 
     target_storage_ref = TIER_TO_SCHEME.get(args.storage_class)
+    if target_storage_ref is None:
+        logger.warning(
+            f"--storage-class {args.storage_class!r} is not a known tier "
+            f"({sorted(TIER_TO_SCHEME)}); the already-at-target filter is DISABLED, "
+            "so every item in range will be selected."
+        )
 
-    end_iso = end_date.isoformat().replace("+00:00", "Z")
     if start_date is None:
         # Age mode: single-sided, one open-lower-bound query and payload.
+        end_iso = end_date.isoformat().replace("+00:00", "Z")
         windows: list[tuple[str | None, str]] = [(None, end_iso)]
         logger.info(f"Age mode: selecting items with {args.date_field} < {end_iso}")
     else:

--- a/operator-tools/submit_storage_tier_workflows.py
+++ b/operator-tools/submit_storage_tier_workflows.py
@@ -53,22 +53,40 @@ def resolve_window_bounds(
     start_date: str | None,
     end_date: str | None,
     today: datetime,
+    max_age_days: int | None = None,
 ) -> tuple[datetime | None, datetime]:
-    """Resolve the two selection modes to ``(start, end)`` datetimes.
+    """Resolve the selection modes to ``(start, end)`` datetimes.
 
-    - Age mode (``min_age_days`` set): single-sided, returns ``(None, today - min_age_days)``.
-      The open lower bound relies on the tier-aware filter to stay cheap.
-    - Explicit mode (``start_date`` and ``end_date`` set): windowed, returns both bounds.
+    - Age mode (``min_age_days`` set):
+      - without ``max_age_days`` → single-sided ``(None, today - min_age_days)``;
+        the open lower bound relies on the tier filter and Plan 1 to stay tractable.
+      - with ``max_age_days`` → a bounded age band ``(today - max_age_days,
+        today - min_age_days)``, i.e. items whose ``created`` age is in
+        ``[min_age_days, max_age_days]``. This is the recurring cron's catch-up
+        window: run daily with e.g. ``--min-age-days 90 --max-age-days 93`` so each
+        run covers a 72h band and a missed day is still picked up by the overlap.
+    - Explicit mode (``start_date`` and ``end_date`` set): windowed, returns both.
 
-    The two modes are mutually exclusive. Raises ``ValueError`` on an invalid combination.
+    The age and explicit modes are mutually exclusive. Raises ``ValueError`` on an
+    invalid combination.
     """
     has_explicit = start_date is not None or end_date is not None
+    if max_age_days is not None and min_age_days is None:
+        raise ValueError("--max-age-days requires --min-age-days")
     if min_age_days is not None and has_explicit:
-        raise ValueError("--min-age-days and --start-date/--end-date are mutually exclusive")
+        raise ValueError(
+            "--min-age-days/--max-age-days and --start-date/--end-date are mutually exclusive"
+        )
     if min_age_days is not None:
         if min_age_days < 0:
             raise ValueError("--min-age-days must be >= 0")
-        return None, compute_age_cutoff(min_age_days, today=today)
+        end = compute_age_cutoff(min_age_days, today=today)
+        if max_age_days is None:
+            return None, end
+        if max_age_days <= min_age_days:
+            raise ValueError("--max-age-days must be greater than --min-age-days")
+        # Older bound is further in the past: today - max_age_days.
+        return compute_age_cutoff(max_age_days, today=today), end
     if not (start_date is not None and end_date is not None):
         raise ValueError("provide --min-age-days, or both --start-date and --end-date")
     start = datetime.fromisoformat(start_date).replace(tzinfo=UTC)
@@ -207,9 +225,17 @@ def main() -> None:
     parser.add_argument(
         "--min-age-days",
         type=int,
-        help="Select items older than this many days by --date-field (single-sided, "
-        "no lower bound). For the recurring tier-down cron. Mutually exclusive with "
-        "--start-date/--end-date.",
+        help="Select items older than this many days by --date-field. Single-sided "
+        "(no lower bound) unless --max-age-days is also given. For the recurring "
+        "tier-down cron. Mutually exclusive with --start-date/--end-date.",
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        help="Upper age bound (requires --min-age-days): select the age band "
+        "[min_age_days, max_age_days], i.e. created in [today-max, today-min]. Use "
+        "for a daily catch-up window, e.g. --min-age-days 90 --max-age-days 93 "
+        "(72h band) run daily so a missed day is still covered by the overlap.",
     )
     parser.add_argument("--collection", required=True, help="STAC collection ID")
     parser.add_argument(
@@ -235,6 +261,13 @@ def main() -> None:
     parser.add_argument("--process-all-assets", action="store_true")
     parser.add_argument("--webhook-url", default="http://localhost:12000/samples")
     parser.add_argument(
+        "--window-hours",
+        type=int,
+        default=24,
+        help="Sub-window size (hours) a bounded range is split into, one webhook "
+        "payload per sub-window (default: 24). N/A to single-sided age mode.",
+    )
+    parser.add_argument(
         "--delay", type=float, default=1.0, help="Delay between window submissions in seconds"
     )
     parser.add_argument("--dry-run", action="store_true")
@@ -243,6 +276,7 @@ def main() -> None:
     try:
         start_date, end_date = resolve_window_bounds(
             min_age_days=args.min_age_days,
+            max_age_days=args.max_age_days,
             start_date=args.start_date,
             end_date=args.end_date,
             today=_utcnow(),
@@ -264,14 +298,19 @@ def main() -> None:
         )
 
     if start_date is None:
-        # Age mode: single-sided, one open-lower-bound query and payload.
+        # Single-sided age mode: one open-lower-bound query and payload.
         end_iso = end_date.isoformat().replace("+00:00", "Z")
         windows: list[tuple[str | None, str]] = [(None, end_iso)]
         logger.info(f"Age mode: selecting items with {date_field} < {end_iso}")
     else:
-        windows = list(generate_time_windows(start_date, end_date))
+        # Bounded range (explicit dates or a --min/--max age band): split into
+        # --window-hours sub-windows, one webhook payload each.
+        start_iso = start_date.isoformat().replace("+00:00", "Z")
+        end_iso = end_date.isoformat().replace("+00:00", "Z")
+        windows = list(generate_time_windows(start_date, end_date, args.window_hours))
         logger.info(
-            f"Processing {len(windows)} 24h windows from {args.start_date} to {args.end_date}"
+            f"Processing {len(windows)} {args.window_hours}h window(s) from "
+            f"{start_iso} to {end_iso} on {date_field}"
         )
 
     total_submitted = 0

--- a/operator-tools/submit_storage_tier_workflows.py
+++ b/operator-tools/submit_storage_tier_workflows.py
@@ -78,6 +78,21 @@ def resolve_window_bounds(
     return start, end
 
 
+def chunk_item_ids(item_ids: list[str], max_batch_size: int | None) -> list[list[str]]:
+    """Split ``item_ids`` into batches of at most ``max_batch_size`` (one webhook payload each).
+
+    Bounds the payload size / per-workflow fan-out for age mode, whose single-sided
+    query has no time window to chunk on. ``max_batch_size`` of ``None`` or ``<= 0``
+    means no chunking — a single batch, preserving the pre-existing behaviour. An
+    empty input yields no batches (the caller skips empty selections).
+    """
+    if not item_ids:
+        return []
+    if max_batch_size is None or max_batch_size <= 0:
+        return [item_ids]
+    return [item_ids[i : i + max_batch_size] for i in range(0, len(item_ids), max_batch_size)]
+
+
 def generate_time_windows(
     start_date: datetime, end_date: datetime, window_hours: int = 24
 ) -> list[tuple[str, str]]:
@@ -200,9 +215,18 @@ def main() -> None:
     parser.add_argument(
         "--date-field",
         choices=["datetime", "created", "updated"],
-        default="datetime",
-        help="Item date to window on: sensing 'datetime' (default), registration "
-        "'created', or last-modified 'updated'. Non-default fields use a CQL2 filter.",
+        default=None,
+        help="Item date to select on: sensing 'datetime', registration 'created', "
+        "or last-modified 'updated'. Non-'datetime' fields use a CQL2 filter. "
+        "Defaults to 'created' with --min-age-days, else 'datetime'.",
+    )
+    parser.add_argument(
+        "--max-batch-size",
+        type=int,
+        default=None,
+        help="Max item IDs per webhook payload (per spawned workflow). Larger "
+        "selections are split across multiple payloads. Default: no limit (one "
+        "payload per window). Recommended for the recurring cron to bound fan-out.",
     )
     parser.add_argument("--storage-class", default="STANDARD", help="S3 storage class")
     parser.add_argument("--stac-api-url", default="https://api.explorer.eopf.copernicus.eu/stac")
@@ -227,6 +251,10 @@ def main() -> None:
         logger.error(str(e))
         sys.exit(1)
 
+    # Default the date field per mode: age-based selection is meaningful on the
+    # registration timestamp, so an omitted --date-field means `created` there.
+    date_field = args.date_field or ("created" if args.min_age_days is not None else "datetime")
+
     target_storage_ref = TIER_TO_SCHEME.get(args.storage_class)
     if target_storage_ref is None:
         logger.warning(
@@ -239,7 +267,7 @@ def main() -> None:
         # Age mode: single-sided, one open-lower-bound query and payload.
         end_iso = end_date.isoformat().replace("+00:00", "Z")
         windows: list[tuple[str | None, str]] = [(None, end_iso)]
-        logger.info(f"Age mode: selecting items with {args.date_field} < {end_iso}")
+        logger.info(f"Age mode: selecting items with {date_field} < {end_iso}")
     else:
         windows = list(generate_time_windows(start_date, end_date))
         logger.info(
@@ -248,6 +276,7 @@ def main() -> None:
 
     total_submitted = 0
     total_failed = 0
+    submissions = 0
 
     for i, (window_start, window_end) in enumerate(windows, 1):
         logger.info(f"[{i}/{len(windows)}] Querying window {window_start} to {window_end}")
@@ -256,33 +285,36 @@ def main() -> None:
             args.collection,
             window_start,
             window_end,
-            args.date_field,
+            date_field,
             target_storage_ref,
         )
-        logger.info(f"  Found {len(item_ids)} items")
-
         if not item_ids:
-            logger.info("  Skipping empty window")
+            logger.info("  Found 0 items — skipping")
             continue
 
-        payload: dict[str, object] = {
-            "action": "batch-change-storage-tier",
-            "item_ids": item_ids,
-            "collection": args.collection,
-            "storage_class": args.storage_class,
-            "stac_api_url": args.stac_api_url,
-            "s3_endpoint": args.s3_endpoint,
-            "pipeline_image_version": args.pipeline_image_version,
-            "process_all_assets": str(args.process_all_assets).lower(),
-        }
-        success = submit_batch(args.webhook_url, payload, args.dry_run)
-        if success:
-            total_submitted += 1
-        else:
-            total_failed += 1
+        batches = chunk_item_ids(item_ids, args.max_batch_size)
+        logger.info(f"  Found {len(item_ids)} items → {len(batches)} payload(s)")
 
-        if i < len(windows):
-            time.sleep(args.delay)
+        for batch in batches:
+            # Space out submissions (webhook politeness); no leading/trailing sleep.
+            if submissions > 0:
+                time.sleep(args.delay)
+            payload: dict[str, object] = {
+                "action": "batch-change-storage-tier",
+                "item_ids": batch,
+                "collection": args.collection,
+                "storage_class": args.storage_class,
+                "stac_api_url": args.stac_api_url,
+                "s3_endpoint": args.s3_endpoint,
+                "pipeline_image_version": args.pipeline_image_version,
+                "process_all_assets": str(args.process_all_assets).lower(),
+            }
+            success = submit_batch(args.webhook_url, payload, args.dry_run)
+            submissions += 1
+            if success:
+                total_submitted += 1
+            else:
+                total_failed += 1
 
     logger.info(f"Done. Submitted: {total_submitted}, Failed: {total_failed}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,10 @@ line-ending = "auto"
 
 [tool.mypy]
 python_version = "3.13"
+# Mirror the pytest `pythonpath` so operator-tools modules resolve cross-directory
+# imports from scripts/ (e.g. submit_storage_tier_workflows importing the shared
+# tier predicate) regardless of which files are passed to mypy.
+mypy_path = ["scripts", "operator-tools"]
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,10 +152,6 @@ line-ending = "auto"
 
 [tool.mypy]
 python_version = "3.13"
-# Mirror the pytest `pythonpath` so operator-tools modules resolve cross-directory
-# imports from scripts/ (e.g. submit_storage_tier_workflows importing the shared
-# tier predicate) regardless of which files are passed to mypy.
-mypy_path = ["scripts", "operator-tools"]
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/scripts/submit_storage_tier_workflows.py
+++ b/scripts/submit_storage_tier_workflows.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
-"""Submit storage tier change workflows via HTTP webhook for a date range of STAC items.
+"""Submit storage tier change workflows via HTTP webhook for a set of STAC items.
 
-Queries STAC in 24h windows and POSTs one webhook payload per window,
-triggering the eopf-storage-tier-batch-job WorkflowTemplate via Argo Events.
-Each workflow fans out to per-item parallel processing within Argo.
+Selects items by an explicit ``created``/``datetime`` window or by age
+(``--min-age-days`` [``--max-age-days``] — e.g. a daily 72h catch-up band),
+excludes those already at the target tier, and POSTs one webhook payload per
+sub-window/batch. Each POST triggers the eopf-storage-tier-batch-job
+WorkflowTemplate via Argo Events, which fans out to per-item processing.
+
+Lives in scripts/ (not operator-tools/) so it ships in the pipeline image and
+the tier-down CronWorkflow can run it in-cluster.
 """
 
 import argparse
@@ -11,21 +16,15 @@ import logging
 import sys
 import time
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from typing import cast
 
 import requests
 from pystac_client import Client
 
 # The tier-aware selection reuses the proven client-side predicate and tier map
-# from the scripts/ package. Bootstrap scripts/ onto sys.path so this operator
-# tool imports them at runtime the same way the test config (pythonpath) does.
-_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
-if str(_SCRIPTS_DIR) not in sys.path:
-    sys.path.insert(0, str(_SCRIPTS_DIR))
-
-from query_storage_tier_items import is_already_migrated  # noqa: E402
-from update_stac_storage_tier import TIER_TO_SCHEME  # noqa: E402
+# from the same scripts/ package (both are on the path in-image and under pytest).
+from query_storage_tier_items import is_already_migrated
+from update_stac_storage_tier import TIER_TO_SCHEME
 
 logging.basicConfig(
     level=logging.INFO,

--- a/tests/unit/test_submit_storage_tier_workflows.py
+++ b/tests/unit/test_submit_storage_tier_workflows.py
@@ -221,6 +221,11 @@ class TestResolveWindowBounds:
         with pytest.raises(ValueError, match="--min-age-days"):
             resolve_window_bounds(min_age_days=None, start_date=None, end_date=None, today=today)
 
+    def test_negative_min_age_days_is_error(self) -> None:
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        with pytest.raises(ValueError, match=">= 0"):
+            resolve_window_bounds(min_age_days=-5, start_date=None, end_date=None, today=today)
+
     def test_explicit_end_before_start_is_error(self) -> None:
         today = datetime(2026, 7, 13, tzinfo=UTC)
         with pytest.raises(ValueError, match="after"):

--- a/tests/unit/test_submit_storage_tier_workflows.py
+++ b/tests/unit/test_submit_storage_tier_workflows.py
@@ -7,10 +7,26 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from submit_storage_tier_workflows import (
+    compute_age_cutoff,
     generate_time_windows,
     query_stac_items,
+    resolve_window_bounds,
     submit_batch,
 )
+
+
+class _FakeAsset:
+    def __init__(self, ref: str | None) -> None:
+        s3: dict[str, object] = {}
+        if ref is not None:
+            s3["storage:refs"] = [ref]
+        self.extra_fields = {"alternate": {"s3": s3}}
+
+
+class _FakeItem:
+    def __init__(self, item_id: str, ref: str | None) -> None:
+        self.id = item_id
+        self.assets = {"data": _FakeAsset(ref)}
 
 
 class TestGenerateTimeWindows:
@@ -155,6 +171,138 @@ class TestQueryStacItems:
         mock_catalog.search.assert_called_once_with(
             collections=["sentinel-2"],
             datetime="2024-01-01T00:00:00Z/2024-01-02T00:00:00Z",
+            limit=100,
+        )
+
+
+class TestComputeAgeCutoff:
+    def test_subtracts_days_from_injected_today(self) -> None:
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        assert compute_age_cutoff(90, today=today) == datetime(2026, 4, 14, tzinfo=UTC)
+
+    def test_zero_days_is_today(self) -> None:
+        today = datetime(2026, 7, 13, 12, 0, 0, tzinfo=UTC)
+        assert compute_age_cutoff(0, today=today) == today
+
+
+class TestResolveWindowBounds:
+    def test_min_age_days_open_lower_bound(self) -> None:
+        """Age mode returns (None, today - min_age_days) — single-sided."""
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        start, end = resolve_window_bounds(
+            min_age_days=90, start_date=None, end_date=None, today=today
+        )
+        assert start is None
+        assert end == datetime(2026, 4, 14, tzinfo=UTC)
+
+    def test_explicit_dates_pass_through(self) -> None:
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        start, end = resolve_window_bounds(
+            min_age_days=None,
+            start_date="2026-03-03",
+            end_date="2026-04-08",
+            today=today,
+        )
+        assert start == datetime(2026, 3, 3, tzinfo=UTC)
+        assert end == datetime(2026, 4, 8, tzinfo=UTC)
+
+    def test_both_modes_is_error(self) -> None:
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            resolve_window_bounds(
+                min_age_days=90,
+                start_date="2026-03-03",
+                end_date="2026-04-08",
+                today=today,
+            )
+
+    def test_neither_mode_is_error(self) -> None:
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        with pytest.raises(ValueError, match="--min-age-days"):
+            resolve_window_bounds(min_age_days=None, start_date=None, end_date=None, today=today)
+
+    def test_explicit_end_before_start_is_error(self) -> None:
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        with pytest.raises(ValueError, match="after"):
+            resolve_window_bounds(
+                min_age_days=None,
+                start_date="2026-06-01",
+                end_date="2026-01-01",
+                today=today,
+            )
+
+
+class TestQueryStacItemsTierFilter:
+    def test_excludes_items_already_in_target_tier(self) -> None:
+        """With target_storage_ref set, items already at that tier are dropped."""
+        already = _FakeItem("already-standard", "standard")
+        needs = _FakeItem("needs-move", "performance")
+        mock_search = MagicMock()
+        mock_search.items.return_value = [already, needs]
+        mock_catalog = MagicMock()
+        mock_catalog.search.return_value = mock_search
+
+        with patch("submit_storage_tier_workflows.Client") as mock_client:
+            mock_client.open.return_value = mock_catalog
+            result = query_stac_items(
+                "https://stac.example.com",
+                "sentinel-2",
+                "2026-01-01T00:00:00Z",
+                "2026-04-14T00:00:00Z",
+                date_field="created",
+                target_storage_ref="standard",
+            )
+
+        assert result == ["needs-move"]
+
+    def test_all_already_standard_returns_empty(self) -> None:
+        """A window where every item is already STANDARD selects nothing (idempotent re-run)."""
+        mock_search = MagicMock()
+        mock_search.items.return_value = [
+            _FakeItem("a", "standard"),
+            _FakeItem("b", "standard"),
+        ]
+        mock_catalog = MagicMock()
+        mock_catalog.search.return_value = mock_search
+
+        with patch("submit_storage_tier_workflows.Client") as mock_client:
+            mock_client.open.return_value = mock_catalog
+            result = query_stac_items(
+                "https://stac.example.com",
+                "sentinel-2",
+                None,
+                "2026-04-14T00:00:00Z",
+                date_field="created",
+                target_storage_ref="standard",
+            )
+
+        assert result == []
+
+    def test_open_lower_bound_uses_less_than_filter(self) -> None:
+        """window_start=None issues a single-sided CQL2 '<' filter on the date field."""
+        mock_search = MagicMock()
+        mock_search.items.return_value = []
+        mock_catalog = MagicMock()
+        mock_catalog.search.return_value = mock_search
+
+        with patch("submit_storage_tier_workflows.Client") as mock_client:
+            mock_client.open.return_value = mock_catalog
+            query_stac_items(
+                "https://stac.example.com",
+                "sentinel-2",
+                None,
+                "2026-04-14T00:00:00Z",
+                date_field="created",
+                target_storage_ref="standard",
+            )
+
+        mock_catalog.search.assert_called_once_with(
+            collections=["sentinel-2"],
+            filter={
+                "op": "<",
+                "args": [{"property": "created"}, "2026-04-14T00:00:00Z"],
+            },
+            filter_lang="cql2-json",
             limit=100,
         )
 
@@ -305,6 +453,7 @@ class TestMainDateFieldForwarding:
             window_start: str,
             window_end: str,
             date_field: str,
+            target_storage_ref: str | None,
         ) -> list[str]:
             captured.append(date_field)
             return []
@@ -369,6 +518,86 @@ class TestMainDateFieldForwarding:
             main()
 
         assert submitted_payloads[0]["storage_class"] == "STANDARD"
+
+
+class TestMainMinAgeMode:
+    def test_min_age_days_issues_single_sided_tier_aware_query(self) -> None:
+        """--min-age-days runs one open-lower-bound query with the target tier ref."""
+        captured: list[dict[str, object]] = []
+
+        def capture_query(
+            stac_api_url: str,
+            collection: str,
+            window_start: str | None,
+            window_end: str,
+            date_field: str,
+            target_storage_ref: str | None,
+        ) -> list[str]:
+            captured.append(
+                {
+                    "window_start": window_start,
+                    "window_end": window_end,
+                    "date_field": date_field,
+                    "target_storage_ref": target_storage_ref,
+                }
+            )
+            return []
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "submit_storage_tier_workflows.py",
+                    "--min-age-days",
+                    "90",
+                    "--collection",
+                    "sentinel-2-l2a",
+                    "--date-field",
+                    "created",
+                    "--storage-class",
+                    "STANDARD",
+                    "--dry-run",
+                ],
+            ),
+            patch(
+                "submit_storage_tier_workflows._utcnow",
+                return_value=datetime(2026, 7, 13, tzinfo=UTC),
+            ),
+            patch(
+                "submit_storage_tier_workflows.query_stac_items",
+                side_effect=capture_query,
+            ),
+        ):
+            from submit_storage_tier_workflows import main
+
+            main()
+
+        assert len(captured) == 1
+        assert captured[0]["window_start"] is None
+        assert captured[0]["window_end"] == "2026-04-14T00:00:00Z"
+        assert captured[0]["date_field"] == "created"
+        assert captured[0]["target_storage_ref"] == "standard"
+
+    def test_min_age_days_and_explicit_dates_exit(self) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "submit_storage_tier_workflows.py",
+                "--min-age-days",
+                "90",
+                "--start-date",
+                "2026-03-03",
+                "--end-date",
+                "2026-04-08",
+                "--collection",
+                "sentinel-2-l2a",
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from submit_storage_tier_workflows import main
+
+                main()
+            assert exc_info.value.code == 1
 
 
 class TestMainDateValidation:

--- a/tests/unit/test_submit_storage_tier_workflows.py
+++ b/tests/unit/test_submit_storage_tier_workflows.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from submit_storage_tier_workflows import (
+    chunk_item_ids,
     compute_age_cutoff,
     generate_time_windows,
     query_stac_items,
@@ -173,6 +175,29 @@ class TestQueryStacItems:
             datetime="2024-01-01T00:00:00Z/2024-01-02T00:00:00Z",
             limit=100,
         )
+
+
+class TestChunkItemIds:
+    def test_splits_into_batches_of_max_size(self) -> None:
+        assert chunk_item_ids(["a", "b", "c", "d", "e"], 2) == [
+            ["a", "b"],
+            ["c", "d"],
+            ["e"],
+        ]
+
+    def test_exact_multiple(self) -> None:
+        assert chunk_item_ids(["a", "b", "c", "d"], 2) == [["a", "b"], ["c", "d"]]
+
+    def test_none_is_single_batch(self) -> None:
+        assert chunk_item_ids(["a", "b", "c"], None) == [["a", "b", "c"]]
+
+    def test_zero_or_negative_is_single_batch(self) -> None:
+        assert chunk_item_ids(["a", "b"], 0) == [["a", "b"]]
+        assert chunk_item_ids(["a", "b"], -1) == [["a", "b"]]
+
+    def test_empty_yields_no_batches(self) -> None:
+        assert chunk_item_ids([], 5) == []
+        assert chunk_item_ids([], None) == []
 
 
 class TestComputeAgeCutoff:
@@ -490,6 +515,46 @@ class TestMainDateFieldForwarding:
 
         assert captured == ["created"]
 
+    def test_explicit_mode_defaults_date_field_to_datetime(self) -> None:
+        """Omitting --date-field in explicit-window mode keeps the sensing-datetime default."""
+        captured: list[str] = []
+
+        def capture_query(
+            stac_api_url: str,
+            collection: str,
+            window_start: str | None,
+            window_end: str,
+            date_field: str,
+            target_storage_ref: str | None,
+        ) -> list[str]:
+            captured.append(date_field)
+            return []
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "submit_storage_tier_workflows.py",
+                    "--start-date",
+                    "2024-01-01",
+                    "--end-date",
+                    "2024-01-02",
+                    "--collection",
+                    "sentinel-2-l2a",
+                    "--dry-run",
+                ],
+            ),
+            patch(
+                "submit_storage_tier_workflows.query_stac_items",
+                side_effect=capture_query,
+            ),
+        ):
+            from submit_storage_tier_workflows import main
+
+            main()
+
+        assert captured == ["datetime"]
+
     def test_default_storage_class_is_standard(self) -> None:
         """The submitted payload defaults storage_class to STANDARD."""
         submitted_payloads: list[dict[str, object]] = []
@@ -582,6 +647,90 @@ class TestMainMinAgeMode:
         assert captured[0]["window_end"] == "2026-04-14T00:00:00Z"
         assert captured[0]["date_field"] == "created"
         assert captured[0]["target_storage_ref"] == "standard"
+
+    def test_age_mode_defaults_date_field_to_created(self) -> None:
+        """Omitting --date-field in age mode selects by `created`, not sensing datetime."""
+        captured: list[str] = []
+
+        def capture_query(
+            stac_api_url: str,
+            collection: str,
+            window_start: str | None,
+            window_end: str,
+            date_field: str,
+            target_storage_ref: str | None,
+        ) -> list[str]:
+            captured.append(date_field)
+            return []
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "submit_storage_tier_workflows.py",
+                    "--min-age-days",
+                    "90",
+                    "--collection",
+                    "sentinel-2-l2a",
+                    "--dry-run",
+                ],
+            ),
+            patch(
+                "submit_storage_tier_workflows._utcnow",
+                return_value=datetime(2026, 7, 13, tzinfo=UTC),
+            ),
+            patch(
+                "submit_storage_tier_workflows.query_stac_items",
+                side_effect=capture_query,
+            ),
+        ):
+            from submit_storage_tier_workflows import main
+
+            main()
+
+        assert captured == ["created"]
+
+    def test_age_mode_chunks_large_result_into_batches(self) -> None:
+        """--max-batch-size splits the item set into multiple payloads covering all IDs."""
+        submitted: list[list[str]] = []
+
+        def capture(url: str, payload: dict[str, object], dry_run: bool) -> bool:
+            submitted.append(cast("list[str]", payload["item_ids"]))
+            return True
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "submit_storage_tier_workflows.py",
+                    "--min-age-days",
+                    "90",
+                    "--collection",
+                    "sentinel-2-l2a",
+                    "--date-field",
+                    "created",
+                    "--max-batch-size",
+                    "2",
+                    "--delay",
+                    "0",
+                    "--dry-run",
+                ],
+            ),
+            patch(
+                "submit_storage_tier_workflows._utcnow",
+                return_value=datetime(2026, 7, 13, tzinfo=UTC),
+            ),
+            patch(
+                "submit_storage_tier_workflows.query_stac_items",
+                return_value=["i1", "i2", "i3", "i4", "i5"],
+            ),
+            patch("submit_storage_tier_workflows.submit_batch", side_effect=capture),
+        ):
+            from submit_storage_tier_workflows import main
+
+            main()
+
+        assert submitted == [["i1", "i2"], ["i3", "i4"], ["i5"]]
 
     def test_min_age_days_and_explicit_dates_exit(self) -> None:
         with patch(

--- a/tests/unit/test_submit_storage_tier_workflows.py
+++ b/tests/unit/test_submit_storage_tier_workflows.py
@@ -251,6 +251,40 @@ class TestResolveWindowBounds:
         with pytest.raises(ValueError, match=">= 0"):
             resolve_window_bounds(min_age_days=-5, start_date=None, end_date=None, today=today)
 
+    def test_min_and_max_age_days_bounded_band(self) -> None:
+        """--min-age-days 90 --max-age-days 93 = the 72h age band [today-93d, today-90d]."""
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        start, end = resolve_window_bounds(
+            min_age_days=90, max_age_days=93, start_date=None, end_date=None, today=today
+        )
+        assert start == datetime(2026, 4, 11, tzinfo=UTC)  # today - 93d (older bound)
+        assert end == datetime(2026, 4, 14, tzinfo=UTC)  # today - 90d (younger bound)
+
+    def test_max_age_requires_min_age(self) -> None:
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        with pytest.raises(ValueError, match="requires --min-age-days"):
+            resolve_window_bounds(
+                min_age_days=None, max_age_days=93, start_date=None, end_date=None, today=today
+            )
+
+    def test_max_age_not_greater_than_min_is_error(self) -> None:
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        with pytest.raises(ValueError, match="greater than --min-age-days"):
+            resolve_window_bounds(
+                min_age_days=90, max_age_days=90, start_date=None, end_date=None, today=today
+            )
+
+    def test_max_age_with_explicit_dates_is_error(self) -> None:
+        today = datetime(2026, 7, 13, tzinfo=UTC)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            resolve_window_bounds(
+                min_age_days=90,
+                max_age_days=93,
+                start_date="2026-03-03",
+                end_date="2026-04-08",
+                today=today,
+            )
+
     def test_explicit_end_before_start_is_error(self) -> None:
         today = datetime(2026, 7, 13, tzinfo=UTC)
         with pytest.raises(ValueError, match="after"):
@@ -731,6 +765,68 @@ class TestMainMinAgeMode:
             main()
 
         assert submitted == [["i1", "i2"], ["i3", "i4"], ["i5"]]
+
+    def test_daily_72h_catchup_band_queries_between_window(self) -> None:
+        """--min-age-days 90 --max-age-days 93 --window-hours 72 = one 72h between-query."""
+        captured: list[dict[str, object]] = []
+
+        def capture_query(
+            stac_api_url: str,
+            collection: str,
+            window_start: str | None,
+            window_end: str,
+            date_field: str,
+            target_storage_ref: str | None,
+        ) -> list[str]:
+            captured.append(
+                {
+                    "start": window_start,
+                    "end": window_end,
+                    "field": date_field,
+                    "ref": target_storage_ref,
+                }
+            )
+            return []
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "submit_storage_tier_workflows.py",
+                    "--min-age-days",
+                    "90",
+                    "--max-age-days",
+                    "93",
+                    "--window-hours",
+                    "72",
+                    "--collection",
+                    "sentinel-2-l2a",
+                    "--dry-run",
+                ],
+            ),
+            patch(
+                "submit_storage_tier_workflows._utcnow",
+                return_value=datetime(2026, 7, 13, tzinfo=UTC),
+            ),
+            patch(
+                "submit_storage_tier_workflows.query_stac_items",
+                side_effect=capture_query,
+            ),
+        ):
+            from submit_storage_tier_workflows import main
+
+            main()
+
+        # One 72h window covering [today-93d, today-90d], selecting by created,
+        # excluding items already at the target tier.
+        assert captured == [
+            {
+                "start": "2026-04-11T00:00:00Z",
+                "end": "2026-04-14T00:00:00Z",
+                "field": "created",
+                "ref": "standard",
+            }
+        ]
 
     def test_min_age_days_and_explicit_dates_exit(self) -> None:
         with patch(


### PR DESCRIPTION
Related: EOPF-Explorer/coordination#182 · companion PR #329 (6-month expiry cleanup)

## Summary

Adds the query-side building block for the **recurring S2 tier-down** — moving items into cheap STANDARD storage as they cross 3 months old, the middle band of the storage-lifecycle policy (hot 0–3mo → STANDARD 3–6mo → deleted at 6mo).

All changes are in `operator-tools/submit_storage_tier_workflows.py` (a CLI operator tool; nothing runs automatically on merge). The cron that drives it — daily, suspended — lands separately in platform-deploy.

**Selection modes**
- **`--min-age-days N`** — age-based selection (`created < today−N`). Single-sided by default; `"today"` is injectable (`_utcnow` seam) for unit tests.
- **`--max-age-days M`** (requires `--min-age-days`) — bounds it to the age band `created ∈ [today−M, today−N]`. This is the **recurring cron's design**: run **daily** with `--min-age-days 90 --max-age-days 93 --window-hours 72` so each run covers a rolling **72h band** at the 90-day mark. Consecutive days overlap by 48h, so a cron that misses up to 2 days is still fully covered; the tier filter keeps the overlap from re-submitting already-moved items.
- Explicit `--start-date/--end-date` still work (one-off backfills), mutually exclusive with the age flags.
- **`--window-hours`** (default 24) — sub-window size a bounded range is split into.

**"Only items that need changing"**
- Tier-aware filter reuses the proven `is_already_migrated` predicate from `query_storage_tier_items.py` (asset-level `storage:refs`) to **exclude items already at the target tier**. A re-run over already-STANDARD items selects **zero** → idempotent no-op. (There is no server-side `storage:tier` queryable — verified — so this filtering is necessarily client-side.)

**Safety / fan-out**
- **`--max-batch-size N`** chunks the selection into ≤N-item webhook payloads (bounds the per-run workflow fan-out; `None` = one payload, prior behavior).
- `--date-field` defaults per mode (`created` with `--min-age-days`, else `datetime`); negative `--min-age-days` rejected; a warning fires if `--storage-class` maps to no known tier scheme (which would silently disable the filter).

## For reviewers

- **Backwards compatible:** the explicit-window path is unchanged; the only new call arity is a trailing `target_storage_ref` (defaults `None` = no filter), so pre-existing callers/tests behave identically.
- **Verified:** 46 tests in this file (age cutoff, band bounds, mode mutual-exclusion, single-sided `<` and bounded `between` queries, tier exclusion, chunking, per-mode default, main wiring); full unit suite **311 pass**; ruff + mypy + pre-commit green. `mypy_path = [scripts, operator-tools]` added to mirror the pytest `pythonpath` so the new cross-directory import resolves under the pinned pre-commit mypy.
- **Live-verified against staging + prod** (read-only) — see the e2e results comment below. The daily 72h band returns ~1k items in ~9s, vs a single-sided sweep that pages the whole ~100k-item back-catalog (~34 min) — which is exactly why the band design was chosen.
- **No prod behaviour changes on merge** — CLI flags only; nothing is scheduled until the platform-deploy cron lands (separately, suspended).

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI assistance: the flags, tier-aware filter, and tests were drafted with Claude Code under TDD; I reviewed each change, ran the suite and pre-commit locally, and validated the selection end-to-end with read-only dry-runs against staging/prod (results in the comment below).
