### PR TITLE
fix(cleanup): datetime-based expiry + exclude-list-first demo protection

### DIFF
--- a/operator-tools/README_MIGRATIONS.md
+++ b/operator-tools/README_MIGRATIONS.md
@@ -41,25 +41,35 @@ backlog (bounded by the cron's `--max-items`).
 | `EXPIRES_MIN_DATETIME` | (unset) | Floor: skip items acquired before this (`before_floor`). RFC3339 timestamp or bare `YYYY-MM-DD` (→ midnight UTC). Inclusive of its own instant. |
 | `EXPIRES_EXCLUDE_FILE` | (unset) | Newline-delimited item-ID denylist, never stamped (`#` comments ok) |
 
-**Demo-data protection is layered:**
+**Demo-data protection is layered — the exclude file is the real protection:**
 
-- **Primary — the acquisition floor (`EXPIRES_MIN_DATETIME`).** The curated demo
-  scenes are all older than the pipeline era, so a single date floor (e.g.
-  `2025-11-01`) skips every pre-pipeline item. Skipped items are never stamped,
-  carry no `expires`, and are therefore structurally undeletable — no ID
-  enumeration required. Run a dry-run first and read the outcome histogram
-  (`stamped` vs `before_floor`, logged + tallied) to confirm the split.
-- **Secondary — the exclude file (`EXPIRES_EXCLUDE_FILE`).** For any individual
-  item to protect regardless of its acquisition date — e.g. a demo scene that
-  falls *inside* the retained window. Enumerated IDs are never stamped.
+- **Primary — the exclude file (`EXPIRES_EXCLUDE_FILE`).** Point it at
+  `scripts/demo_exclude_ids.txt` (the same canonical list `register_v1` and the
+  cleanup honor). Demo scenes are **scattered across 2021→2026 and interleaved
+  with pipeline data** — several are acquired *after* any pipeline-era floor — so
+  enumerating their IDs is the only complete protection. Excluded IDs are never
+  stamped, carry no `expires`, and are structurally undeletable; the check runs
+  *before* the floor, so an excluded ID is safe regardless of its acquisition
+  date. **A floor-only run (exclude file unset) will stamp — and later delete —
+  any demo acquired after the floor.** After a run, check the report for the
+  `exclude-file id(s) matched no item` warning: it means a listed ID is a typo or
+  a stale/reconverted id and is protecting nothing.
+- **Secondary — the acquisition floor (`EXPIRES_MIN_DATETIME`).** A single date
+  floor (e.g. `2025-11-01`) skips every item acquired before it (`before_floor`),
+  never stamping them. Its job is to **bound the first cleanup's blast radius**
+  and coarsely cover the pre-pipeline tail — not to protect demos. Run a dry-run
+  first and read the outcome histogram (`stamped` vs `before_floor`, logged +
+  tallied) to confirm the split.
 
-Note: because the rule now keys off `properties.datetime` (a mandatory core STAC
+Note: because the rule keys off `properties.datetime` (a mandatory core STAC
 field, not a server-managed audit timestamp), it does not depend on `created`
 surviving the framework's DELETE-then-POST round-trip.
 
 ```bash
 # Dry-run: review the skip-reason / stamped histogram in the logs first.
-# EXPIRES_MIN_DATETIME floors out the pre-pipeline (demo) scenes.
+# EXPIRES_EXCLUDE_FILE protects the demo scenes (mandatory — several are acquired
+# after the floor); EXPIRES_MIN_DATETIME bounds the backlog / blast radius.
+EXPIRES_EXCLUDE_FILE=scripts/demo_exclude_ids.txt \
 EXPIRES_MIN_DATETIME=2025-11-01 \
 uv run operator-tools/migrate_catalog.py run --migration stamp_expires \
   sentinel-2-l2a-staging --dry-run

--- a/operator-tools/README_MIGRATIONS.md
+++ b/operator-tools/README_MIGRATIONS.md
@@ -13,7 +13,7 @@ is shown when the API supports `numberMatched`.
 |---|---|
 | `fix_url_encoding` | Replace `+` with `%20` in asset/link href query strings (RFC 3986 compliance) |
 | `fix_zarr_media_type` | Fix zarr media types (`vnd+zarr` → `vnd.zarr`, `version=2` → `version=3`, add missing `version=3`) and remove `zipped_product` asset |
-| `stamp_expires` | Backfill `properties.expires = created + retention` (timestamps ext); skips already-stamped, excluded, and (optionally) large `created − datetime` gaps. See [stamp_expires](#stamp_expires-backfill-retention-expiry) below |
+| `stamp_expires` | Backfill `properties.expires = datetime (acquisition) + retention` (timestamps ext); skips already-stamped, excluded, and items acquired before the floor. See [stamp_expires](#stamp_expires-backfill-retention-expiry) below |
 
 ## `stamp_expires` (backfill retention expiry)
 
@@ -22,40 +22,45 @@ them ([coordination#183](https://github.com/EOPF-Explorer/coordination/issues/18
 New items are stamped at registration; this migration covers the pre-existing
 catalogue. Companion doc: [scripts/README_cleanup_expired_items.md](../scripts/README_cleanup_expired_items.md).
 
-**Rule**: `expires = created + retention` (default 183 days, from
+**Rule**: `expires = datetime + retention` (default 183 days, from
 `s3_item_cleanup.DEFAULT_RETENTION_DAYS`), plus the timestamps extension URL.
-Strict by design — items older than the window become immediately past-expiry,
-so the first cleanup runs drain a backlog (bounded by the cron's `--max-items`).
+Retention is measured from **acquisition** (`properties.datetime`), not
+`created`. `created` records when an item was *converted/registered*, and the
+catalogue holds multiple bulk-conversion cohorts — items acquired the same week
+can carry `created` dates months apart, and a re-conversion resets `created`, so
+a `created`-based expiry is unstable and disconnected from data age. Acquisition
+`datetime` is stable across re-conversions. Strict by design — items older than
+the window become immediately past-expiry, so the first cleanup runs drain a
+backlog (bounded by the cron's `--max-items`).
 
 **Configuration (environment):**
 
 | Env | Default | Effect |
 |---|---|---|
-| `EXPIRES_RETENTION_DAYS` | `183` | Retention window added to `created` |
+| `EXPIRES_RETENTION_DAYS` | `183` | Retention window added to `datetime` |
+| `EXPIRES_MIN_DATETIME` | (unset) | Floor: skip items acquired before this (`before_floor`). RFC3339 timestamp or bare `YYYY-MM-DD` (→ midnight UTC). Inclusive of its own instant. |
 | `EXPIRES_EXCLUDE_FILE` | (unset) | Newline-delimited item-ID denylist, never stamped (`#` comments ok) |
-| `EXPIRES_DEMO_GAP_DAYS` | (unset) | If set, skip items whose `created − datetime` gap exceeds this many days (`demo_gap`) |
 
 **Demo-data protection is layered:**
 
-- **Primary — the exclude file.** Enumerate demo item IDs (e.g. the 2021 scenes)
-  in `EXPIRES_EXCLUDE_FILE`. They are never stamped, so they carry no `expires`
-  and are structurally undeletable.
-- **Secondary — the gap heuristic (disabled by default).** A large
-  `created − datetime` gap *can* indicate manually-ingested demo data — but
-  bulk catalogue-conversion campaigns also produce large gaps, so a naive
-  threshold would leave exactly the oldest, most-bloating data unstamped
-  forever. **Do not assume a threshold.** Run a dry-run first, read the outcome
-  histogram (logged per item + tallied), then either enumerate demo items in the
-  exclude file (preferred) or set `EXPIRES_DEMO_GAP_DAYS` from the data.
+- **Primary — the acquisition floor (`EXPIRES_MIN_DATETIME`).** The curated demo
+  scenes are all older than the pipeline era, so a single date floor (e.g.
+  `2025-11-01`) skips every pre-pipeline item. Skipped items are never stamped,
+  carry no `expires`, and are therefore structurally undeletable — no ID
+  enumeration required. Run a dry-run first and read the outcome histogram
+  (`stamped` vs `before_floor`, logged + tallied) to confirm the split.
+- **Secondary — the exclude file (`EXPIRES_EXCLUDE_FILE`).** For any individual
+  item to protect regardless of its acquisition date — e.g. a demo scene that
+  falls *inside* the retained window. Enumerated IDs are never stamped.
 
-**⚠️ Pre-run check (open question): does `properties.created` survive the
-DELETE-then-POST round-trip?** The framework deletes and re-POSTs each item;
-pgstac may re-stamp `created` server-side. Before a real backfill, migrate one
-staging item and confirm `created` is unchanged — the whole rule depends on it.
-If it is re-stamped, preserve the original `created` in the POST body.
+Note: because the rule now keys off `properties.datetime` (a mandatory core STAC
+field, not a server-managed audit timestamp), it does not depend on `created`
+surviving the framework's DELETE-then-POST round-trip.
 
 ```bash
 # Dry-run: review the skip-reason / stamped histogram in the logs first.
+# EXPIRES_MIN_DATETIME floors out the pre-pipeline (demo) scenes.
+EXPIRES_MIN_DATETIME=2025-11-01 \
 uv run operator-tools/migrate_catalog.py run --migration stamp_expires \
   sentinel-2-l2a-staging --dry-run
 

--- a/operator-tools/_migrate_catalog/migrations/stamp_expires.py
+++ b/operator-tools/_migrate_catalog/migrations/stamp_expires.py
@@ -14,15 +14,24 @@ carry ``created`` dates months apart, and a re-conversion resets it), so a
 retention window are then immediately past-expiry, the first cleanup runs drain
 a backlog (bounded by the cron's ``--max-items``).
 
-Demo-data protection is layered:
-- **Primary (floor)**: env ``EXPIRES_MIN_DATETIME`` (an RFC3339 timestamp, or a
-  bare ``YYYY-MM-DD`` date). Items acquired **before** the floor are skipped
-  (``before_floor``) and never stamped — and an item with no ``expires`` is
-  structurally undeletable. The curated demo scenes are all older than the
-  pipeline era, so a single date floor protects them without enumerating IDs.
-- **Secondary (exclude list)**: env ``EXPIRES_EXCLUDE_FILE``, a newline-delimited
-  item-ID denylist, for any individual item to protect regardless of its
-  acquisition date (e.g. a demo scene inside the retained window).
+Demo-data protection is layered — **the exclude list is the real protection**:
+
+- **Primary — the exclude list** (env ``EXPIRES_EXCLUDE_FILE``, the same
+  ``scripts/demo_exclude_ids.txt`` that ``register_v1`` and the cleanup honor).
+  Demo scenes are scattered across 2021→2026 and interleaved with pipeline data
+  — several are acquired *after* any pipeline-era floor — so enumerating their
+  ids is the only complete protection. Excluded ids are never stamped, carry no
+  ``expires``, and are structurally undeletable. This check runs *before* the
+  floor, so an excluded id is protected regardless of its acquisition date.
+- **Secondary — the acquisition floor** (env ``EXPIRES_MIN_DATETIME``, an RFC3339
+  timestamp or a bare ``YYYY-MM-DD`` date). Items acquired **before** the floor
+  are skipped (``before_floor``) and never stamped. Its job is to bound the first
+  cleanup's blast radius and coarsely cover the pre-pipeline tail — it does
+  **not** protect a demo acquired on or after it; those must be in the exclude
+  list.
+
+A stale or mistyped exclude id would silently protect nothing, so ``report()``
+warns when a configured exclude id matched zero items during a run.
 
 Every outcome is tallied in ``SKIP_HISTOGRAM`` and logged, so a dry-run doubles
 as the histogram the team reviews (``stamped`` vs ``before_floor`` etc.) before
@@ -68,9 +77,18 @@ logger = logging.getLogger(__name__)
 # are the histogram the team reviews. Reset with reset_histogram().
 SKIP_HISTOGRAM: Counter[str] = Counter()
 
+# The configured exclude ids and the subset actually seen in the catalogue this
+# run. The exclude list is the crown-jewel demo protection, so an id that matches
+# nothing (typo, or a scene renamed/reconverted to a new id) would silently
+# protect nothing. report() warns on the difference. Reset with the histogram.
+_EXCLUDE_IDS: set[str] = set()
+_MATCHED_EXCLUDE_IDS: set[str] = set()
+
 
 def reset_histogram() -> None:
     SKIP_HISTOGRAM.clear()
+    _EXCLUDE_IDS.clear()
+    _MATCHED_EXCLUDE_IDS.clear()
 
 
 def report(result: MigrationResult) -> str:
@@ -97,6 +115,14 @@ def report(result: MigrationResult) -> str:
             f"(processed={result.items_processed}, modified={result.items_modified}, "
             f"skipped={result.items_skipped}, failed={result.items_failed})"
         )
+
+    unmatched = _EXCLUDE_IDS - _MATCHED_EXCLUDE_IDS
+    if unmatched:
+        lines.append(
+            f"  WARNING: {len(unmatched)} exclude-file id(s) matched no item "
+            f"(typo, or stale/reconverted id?) — verify demo protection: "
+            f"{', '.join(sorted(unmatched))}"
+        )
     return "\n".join(lines)
 
 
@@ -119,6 +145,9 @@ def classify_and_stamp(
     if item.get("id") in exclude_ids:
         return None, "excluded"
 
+    # ``datetime`` is a mandatory STAC core field and S2 L2A always populates it.
+    # A range-only item (``datetime=null`` with start/end_datetime) would skip
+    # here and never expire — a cost leak, not a safety risk. None exist in S2.
     acquired = props.get("datetime")
     if not acquired:
         return None, "no_datetime"
@@ -140,8 +169,11 @@ def _parse_floor(value: str) -> datetime:
     """Parse ``EXPIRES_MIN_DATETIME``. Accepts a full RFC3339 timestamp or a
     bare ``YYYY-MM-DD`` date (normalised to midnight UTC so a naive local-time
     interpretation can't shift the floor by the machine's offset)."""
-    if "T" not in value:
+    # A bare date has no time separator; RFC3339 allows lower- or upper-case "T".
+    if "T" not in value.upper():
         value = f"{value}T00:00:00Z"
+    # Annotate to launder the Any from the runtime-only s3_item_cleanup import
+    # (mypy can't resolve it statically) into a concrete datetime.
     floor: datetime = parse_stac_timestamp(value)
     return floor
 
@@ -165,6 +197,13 @@ def stamp_expires(item: dict[str, Any]) -> dict[str, Any] | None:
     """Stamp ``expires`` on one item. Config from the environment
     (EXPIRES_RETENTION_DAYS, EXPIRES_EXCLUDE_FILE, EXPIRES_MIN_DATETIME)."""
     retention_days, exclude_ids, min_datetime = _resolve_config()
+    # Track which exclude ids are actually present so report() can flag any that
+    # matched nothing. Record on id-presence (not on the "excluded" outcome) so an
+    # excluded item that is already stamped still counts as matched.
+    _EXCLUDE_IDS.update(exclude_ids)
+    item_id = item.get("id")
+    if item_id in exclude_ids:
+        _MATCHED_EXCLUDE_IDS.add(item_id)
     result, reason = classify_and_stamp(
         item,
         retention_days=retention_days,
@@ -173,5 +212,5 @@ def stamp_expires(item: dict[str, Any]) -> dict[str, Any] | None:
     )
     SKIP_HISTOGRAM[reason] += 1
     if reason != "stamped":
-        logger.info("stamp_expires skip: id=%s reason=%s", item.get("id"), reason)
+        logger.info("stamp_expires skip: id=%s reason=%s", item_id, reason)
     return result

--- a/operator-tools/_migrate_catalog/migrations/stamp_expires.py
+++ b/operator-tools/_migrate_catalog/migrations/stamp_expires.py
@@ -4,22 +4,29 @@ Part of the expiry-driven retention design (coordination#183). New items get
 ``expires`` at registration; this migration backfills the ones already in the
 catalogue so the cleanup cron can act on them.
 
-Strict rule: ``expires = created + DEFAULT_RETENTION_DAYS``. Because pipeline
-items older than the retention window are then immediately past-expiry, the
-first cleanup runs drain a backlog (bounded by the cron's ``--max-items``).
+Strict rule: ``expires = properties.datetime + DEFAULT_RETENTION_DAYS`` — i.e.
+retention is measured from **acquisition** (data age), not from ``created``.
+``created`` records when an item was *converted/registered*, and the catalogue
+holds multiple bulk-conversion cohorts (e.g. items acquired the same week can
+carry ``created`` dates months apart, and a re-conversion resets it), so a
+``created``-based expiry is unstable and disconnected from data age. Acquisition
+``datetime`` is stable across re-conversions. Because items older than the
+retention window are then immediately past-expiry, the first cleanup runs drain
+a backlog (bounded by the cron's ``--max-items``).
 
 Demo-data protection is layered:
-- **Primary**: an explicit exclude list of item IDs (env ``EXPIRES_EXCLUDE_FILE``)
-  that are never stamped — items with no ``expires`` are structurally
-  undeletable.
-- **Secondary**: an optional ``created − datetime`` gap check
-  (env ``EXPIRES_DEMO_GAP_DAYS``). It is **disabled by default** because a naive
-  threshold would wrongly skip bulk-converted historical data (which also has a
-  large gap). Run a dry-run first, review the outcome histogram, and only then
-  decide a threshold or (preferably) enumerate demo items in the exclude file.
+- **Primary (floor)**: env ``EXPIRES_MIN_DATETIME`` (an RFC3339 timestamp, or a
+  bare ``YYYY-MM-DD`` date). Items acquired **before** the floor are skipped
+  (``before_floor``) and never stamped — and an item with no ``expires`` is
+  structurally undeletable. The curated demo scenes are all older than the
+  pipeline era, so a single date floor protects them without enumerating IDs.
+- **Secondary (exclude list)**: env ``EXPIRES_EXCLUDE_FILE``, a newline-delimited
+  item-ID denylist, for any individual item to protect regardless of its
+  acquisition date (e.g. a demo scene inside the retained window).
 
 Every outcome is tallied in ``SKIP_HISTOGRAM`` and logged, so a dry-run doubles
-as the histogram the team reviews before committing to a threshold.
+as the histogram the team reviews (``stamped`` vs ``before_floor`` etc.) before
+committing to a floor.
 """
 
 from __future__ import annotations
@@ -29,7 +36,7 @@ import logging
 import os
 import sys
 from collections import Counter
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -98,7 +105,7 @@ def classify_and_stamp(
     *,
     retention_days: int,
     exclude_ids: set[str],
-    gap_threshold_days: int | None,
+    min_datetime: datetime | None,
 ) -> tuple[dict[str, Any] | None, str]:
     """Decide an item's fate and, if stamping, return a modified copy.
 
@@ -112,18 +119,15 @@ def classify_and_stamp(
     if item.get("id") in exclude_ids:
         return None, "excluded"
 
-    created = props.get("created")
-    if not created:
-        return None, "no_created"
+    acquired = props.get("datetime")
+    if not acquired:
+        return None, "no_datetime"
 
-    if gap_threshold_days is not None:
-        acquired = props.get("datetime")
-        if acquired:
-            gap_days = (parse_stac_timestamp(created) - parse_stac_timestamp(acquired)).days
-            if gap_days > gap_threshold_days:
-                return None, "demo_gap"
+    acquired_dt = parse_stac_timestamp(acquired)
+    if min_datetime is not None and acquired_dt < min_datetime:
+        return None, "before_floor"
 
-    expires = parse_stac_timestamp(created) + timedelta(days=retention_days)
+    expires = acquired_dt + timedelta(days=retention_days)
     result = copy.deepcopy(item)
     result.setdefault("properties", {})["expires"] = format_expires(expires)
     extensions = result.setdefault("stac_extensions", [])
@@ -132,30 +136,40 @@ def classify_and_stamp(
     return result, "stamped"
 
 
-def _resolve_config() -> tuple[int, set[str], int | None]:
+def _parse_floor(value: str) -> datetime:
+    """Parse ``EXPIRES_MIN_DATETIME``. Accepts a full RFC3339 timestamp or a
+    bare ``YYYY-MM-DD`` date (normalised to midnight UTC so a naive local-time
+    interpretation can't shift the floor by the machine's offset)."""
+    if "T" not in value:
+        value = f"{value}T00:00:00Z"
+    floor: datetime = parse_stac_timestamp(value)
+    return floor
+
+
+def _resolve_config() -> tuple[int, set[str], datetime | None]:
     retention_days = env_int("EXPIRES_RETENTION_DAYS", DEFAULT_RETENTION_DAYS)
     exclude_ids = load_exclude_ids(os.getenv("EXPIRES_EXCLUDE_FILE"))
-    gap_env = os.getenv("EXPIRES_DEMO_GAP_DAYS")
-    gap_threshold_days = int(gap_env) if gap_env else None
-    return retention_days, exclude_ids, gap_threshold_days
+    floor_env = os.getenv("EXPIRES_MIN_DATETIME")
+    min_datetime = _parse_floor(floor_env) if floor_env else None
+    return retention_days, exclude_ids, min_datetime
 
 
 @migration(
     "stamp_expires",
-    "Backfill properties.expires = created + retention (timestamps ext); "
-    "skips already-stamped, excluded, and (optionally) large created-datetime gaps",
+    "Backfill properties.expires = datetime (acquisition) + retention (timestamps "
+    "ext); skips already-stamped, excluded, and items acquired before the floor",
     reporter=report,
     reset=reset_histogram,
 )
 def stamp_expires(item: dict[str, Any]) -> dict[str, Any] | None:
     """Stamp ``expires`` on one item. Config from the environment
-    (EXPIRES_RETENTION_DAYS, EXPIRES_EXCLUDE_FILE, EXPIRES_DEMO_GAP_DAYS)."""
-    retention_days, exclude_ids, gap_threshold_days = _resolve_config()
+    (EXPIRES_RETENTION_DAYS, EXPIRES_EXCLUDE_FILE, EXPIRES_MIN_DATETIME)."""
+    retention_days, exclude_ids, min_datetime = _resolve_config()
     result, reason = classify_and_stamp(
         item,
         retention_days=retention_days,
         exclude_ids=exclude_ids,
-        gap_threshold_days=gap_threshold_days,
+        min_datetime=min_datetime,
     )
     SKIP_HISTOGRAM[reason] += 1
     if reason != "stamped":

--- a/scripts/README_cleanup_expired_items.md
+++ b/scripts/README_cleanup_expired_items.md
@@ -14,13 +14,13 @@ There are two ways it lands on an item:
 1. **At registration** — `register_v1.py` stamps `expires = now + EXPIRES_RETENTION_DAYS`.
    - `EXPIRES_RETENTION_DAYS` defaults to **183** (6 months), shared from
      `s3_item_cleanup.DEFAULT_RETENTION_DAYS`.
-   - **`EXPIRES_RETENTION_DAYS=0` disables stamping.** Run manual/demo
-     registrations (e.g. the 2021 showcase scenes) with `=0` so they get **no**
-     `expires` and are therefore structurally undeletable by this script.
-   - ⚠️ Stamping is unconditional on upsert — re-registering an item resets its
-     clock, and re-registering a protected demo item *with* a non-zero retention
-     would give it an expiry. The runtime `--exclude-file` denylist is the
-     backstop.
+   - **`EXPIRES_RETENTION_DAYS=0` disables stamping** for a whole run.
+   - **`EXPIRES_EXCLUDE_FILE` protects specific ids.** `register_v1` reads the
+     **same demo denylist** the cleanup honors, and never stamps `expires` on an
+     id in it. So re-registering or **reconverting** a demo scene keeps it with
+     **no `expires`** (structurally undeletable) — the one list is the single
+     source of truth for demo protection at both register-time and cleanup-time,
+     and there's no window where an upsert re-arms a demo scene.
 2. **Backfill** — the `stamp_expires` migration stamps existing items
    (`expires = datetime + retention`, keyed off acquisition age; items acquired
    before its `EXPIRES_MIN_DATETIME` floor are left unstamped). See

--- a/scripts/README_cleanup_expired_items.md
+++ b/scripts/README_cleanup_expired_items.md
@@ -22,7 +22,8 @@ There are two ways it lands on an item:
      would give it an expiry. The runtime `--exclude-file` denylist is the
      backstop.
 2. **Backfill** — the `stamp_expires` migration stamps existing items
-   (`expires = created + retention`). See
+   (`expires = datetime + retention`, keyed off acquisition age; items acquired
+   before its `EXPIRES_MIN_DATETIME` floor are left unstamped). See
    [operator-tools/README_MIGRATIONS.md](../operator-tools/README_MIGRATIONS.md).
 
 ## Safety model

--- a/scripts/demo_exclude_ids.txt
+++ b/scripts/demo_exclude_ids.txt
@@ -1,0 +1,32 @@
+# Demo-scene protection list — the single source of truth for demo protection.
+# Point EXPIRES_EXCLUDE_FILE at this file (baked into the image at
+# /app/scripts/demo_exclude_ids.txt). It is honored in BOTH places:
+#   - register_v1.py  -> never stamps `expires` on these ids (no expires = undeletable)
+#   - cleanup_expired_items.py -> never deletes these ids (skipped even if expired)
+# so reconverting/re-registering a demo scene can never re-arm it for deletion.
+#
+# Source of truth for "what is a demo": EOPF-Explorer/narratives + the OpenLayers
+# geozarr.html example. Ids are ESA product ids => stable across reconversion.
+# Verified against the live catalog 2026-07-14. Blank lines / '#' comments ignored.
+
+# --- Lava Flow (La Palma), tile T28RBS, prod ---
+S2B_MSIL2A_20210925T120319_N0500_R023_T28RBS_20230109T005655
+S2A_MSIL2A_20210930T120331_N0500_R023_T28RBS_20230109T180123
+S2A_MSIL2A_20211010T120331_N0500_R023_T28RBS_20230106T001906
+S2B_MSIL2A_20211015T120329_N0500_R023_T28RBS_20230104T221431
+S2A_MSIL2A_20211030T120331_N0500_R023_T28RBS_20230105T031900
+S2B_MSIL2A_20220103T120319_N0510_R023_T28RBS_20240423T015628
+
+# --- NDCI, tile T32TQR, prod ---
+S2C_MSIL2A_20250512T100611_N0511_R022_T32TQR_20250512T173114
+
+# --- NDVI, tile T31TDH, prod — ABSENT today (referenced in ndvi.md; convert-fresh TBD) ---
+S2B_MSIL2A_20250804T103629_N0511_R008_T31TDH_20250804T130722
+S2A_MSIL2A_20250831T103701_N0511_R008_T31TDH_20250831T145420
+
+# --- NDVI hero, tile T33TVF, prod + staging ---
+S2B_MSIL2A_20260225T095029_N0512_R079_T33TVF_20260225T141422
+
+# --- OpenLayers geozarr.html example (read as raw .zarr), prod ---
+S2C_MSIL2A_20260120T084301_N0511_R064_T36UXA_20260120T122910
+S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151

--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -21,6 +21,7 @@ from s3_item_cleanup import (
     TIMESTAMPS_EXTENSION,
     env_int,
     format_expires,
+    load_exclude_ids,
 )
 from storage_tier_utils import extract_region_from_endpoint, get_s3_storage_class
 
@@ -357,13 +358,29 @@ def resolve_retention_days() -> int:
     return env_int("EXPIRES_RETENTION_DAYS", DEFAULT_RETENTION_DAYS)
 
 
-def add_expires(item: Item, retention_days: int) -> None:
+def resolve_exclude_ids() -> set[str]:
+    """Demo denylist from ``EXPIRES_EXCLUDE_FILE`` (coordination#183).
+
+    This is the *same* list the cleanup honors, so demo protection is defined
+    once and can't drift between register-time and cleanup-time. An id in this
+    list is never stamped with ``expires`` here, and never deleted by the
+    cleanup — so re-registering or reconverting a demo scene keeps it
+    structurally undeletable. Unset ⇒ empty set.
+    """
+    return load_exclude_ids(os.getenv("EXPIRES_EXCLUDE_FILE"))
+
+
+def add_expires(item: Item, retention_days: int, exclude_ids: set[str] | None = None) -> None:
     """Stamp ``properties.expires`` = now + retention_days and the timestamps
     extension so the cleanup cron can select expired items (coordination#183).
 
-    ``retention_days <= 0`` is a no-op — items with no ``expires`` are
-    structurally undeletable, which is how manual/demo data is protected.
+    No ``expires`` is stamped (leaving the item structurally undeletable) when
+    either the item is in ``exclude_ids`` (the demo denylist) or
+    ``retention_days <= 0``. The exclude check is what makes reconverting a demo
+    scene safe — otherwise every re-register would re-arm it for deletion.
     """
+    if exclude_ids and item.id in exclude_ids:
+        return
     if retention_days <= 0:
         return
 
@@ -782,11 +799,16 @@ def run_registration(
     # 12. Add derived_from link to source item
     add_derived_from_link(item, source_url)
 
-    # 12.5 Stamp expiry for retention-driven cleanup (coordination#183)
+    # 12.5 Stamp expiry for retention-driven cleanup (coordination#183).
+    # Demo/exclude-listed items are left without expires (structurally
+    # undeletable), using the same denylist the cleanup honors.
     retention_days = resolve_retention_days()
-    add_expires(item, retention_days)
-    if retention_days > 0:
+    exclude_ids = resolve_exclude_ids()
+    add_expires(item, retention_days, exclude_ids)
+    if retention_days > 0 and item.id not in exclude_ids:
         logger.info(f"   ⏳ Stamped expires = now + {retention_days}d")
+    else:
+        logger.info("   🛡️  No expires (demo/exclude-listed or retention=0) — undeletable")
 
     # 13. Register to STAC API
     client = Client.open(stac_api_url)

--- a/tests/unit/test_migrate_catalog.py
+++ b/tests/unit/test_migrate_catalog.py
@@ -720,6 +720,33 @@ class TestClassifyAndStamp:
         assert reason == "stamped"
         assert result is not None
 
+    def test_excluded_wins_over_floor_eligible(self) -> None:
+        # The crown-jewel contract: a demo acquired AFTER the floor (so it would
+        # otherwise be stamped) is protected by the exclude list, not the floor.
+        # This is the real T33TVF / T36UXA / T27VWL (2026) demo case.
+        item = _stampable_item(item_id="demo_after_floor", datetime_str="2026-02-25T00:00:00Z")
+        result, reason = classify_and_stamp(
+            item,
+            retention_days=183,
+            exclude_ids={"demo_after_floor"},
+            min_datetime=_parse("2025-11-01T00:00:00Z"),
+        )
+        assert result is None
+        assert reason == "excluded"
+
+    def test_same_after_floor_item_is_stamped_without_exclusion(self) -> None:
+        # Documents the danger the exclude list guards against: the identical
+        # after-floor demo, if NOT excluded, is stamped and becomes deletable.
+        item = _stampable_item(item_id="demo_after_floor", datetime_str="2026-02-25T00:00:00Z")
+        result, reason = classify_and_stamp(
+            item,
+            retention_days=183,
+            exclude_ids=set(),
+            min_datetime=_parse("2025-11-01T00:00:00Z"),
+        )
+        assert reason == "stamped"
+        assert result is not None
+
     def test_does_not_mutate_input_item(self) -> None:
         item = _stampable_item()
         classify_and_stamp(item, retention_days=183, exclude_ids=set(), min_datetime=None)
@@ -822,6 +849,39 @@ class TestHistogramReporting:
         SKIP_HISTOGRAM["stamped"] = 9
         reset_histogram()
         assert sum(SKIP_HISTOGRAM.values()) == 0
+
+    def test_report_warns_when_exclude_id_matched_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # The exclude list is the crown-jewel demo protection, so a listed id that
+        # matches no item (typo / stale reconverted id) must fail loud.
+        from _migrate_catalog.migrations.stamp_expires import report
+
+        exclude_file = tmp_path / "exclude.txt"
+        exclude_file.write_text("real_demo\nTYPO_demo_xyz\n")
+        monkeypatch.setenv("EXPIRES_EXCLUDE_FILE", str(exclude_file))
+        monkeypatch.delenv("EXPIRES_MIN_DATETIME", raising=False)
+        reset_histogram()
+        stamp_expires(_stampable_item(item_id="real_demo"))  # matches one listed id
+        stamp_expires(_stampable_item(item_id="pipeline"))  # a normal item
+        text = report(_result(processed=2, modified=1, skipped=1))
+        assert "matched no item" in text
+        assert "TYPO_demo_xyz" in text
+        assert "real_demo" not in text  # the matched id is not flagged
+
+    def test_report_quiet_when_all_exclude_ids_match(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from _migrate_catalog.migrations.stamp_expires import report
+
+        exclude_file = tmp_path / "exclude.txt"
+        exclude_file.write_text("real_demo\n")
+        monkeypatch.setenv("EXPIRES_EXCLUDE_FILE", str(exclude_file))
+        monkeypatch.delenv("EXPIRES_MIN_DATETIME", raising=False)
+        reset_histogram()
+        stamp_expires(_stampable_item(item_id="real_demo"))
+        text = report(_result(processed=1, modified=0, skipped=1))
+        assert "matched no item" not in text
 
 
 class TestRunCommandSurfacesHistogram:

--- a/tests/unit/test_migrate_catalog.py
+++ b/tests/unit/test_migrate_catalog.py
@@ -639,20 +639,21 @@ def _parse(value: str) -> datetime:
 
 
 class TestClassifyAndStamp:
-    def test_stamps_expires_at_created_plus_retention(self) -> None:
-        item = _stampable_item()
+    def test_stamps_expires_at_datetime_plus_retention(self) -> None:
+        # Retention is measured from acquisition (datetime), not created.
+        item = _stampable_item(created="2026-05-05T00:00:00Z", datetime_str="2025-12-31T00:00:00Z")
         result, reason = classify_and_stamp(
-            item, retention_days=183, exclude_ids=set(), gap_threshold_days=None
+            item, retention_days=183, exclude_ids=set(), min_datetime=None
         )
         assert reason == "stamped"
         assert result is not None
-        delta = _parse(result["properties"]["expires"]) - _parse("2025-01-01T00:00:00Z")
+        delta = _parse(result["properties"]["expires"]) - _parse("2025-12-31T00:00:00Z")
         assert delta == timedelta(days=183)
 
     def test_stamped_item_gets_timestamps_extension_once(self) -> None:
         item = _stampable_item()
         result, _ = classify_and_stamp(
-            item, retention_days=183, exclude_ids=set(), gap_threshold_days=None
+            item, retention_days=183, exclude_ids=set(), min_datetime=None
         )
         assert result is not None
         assert result["stac_extensions"].count(TIMESTAMPS_EXTENSION) == 1
@@ -660,7 +661,7 @@ class TestClassifyAndStamp:
     def test_expires_is_utc_z_formatted(self) -> None:
         item = _stampable_item()
         result, _ = classify_and_stamp(
-            item, retention_days=183, exclude_ids=set(), gap_threshold_days=None
+            item, retention_days=183, exclude_ids=set(), min_datetime=None
         )
         assert result is not None
         assert result["properties"]["expires"].endswith("Z")
@@ -668,7 +669,7 @@ class TestClassifyAndStamp:
     def test_already_stamped_item_is_skipped(self) -> None:
         item = _stampable_item(expires="2025-07-01T00:00:00Z")
         result, reason = classify_and_stamp(
-            item, retention_days=183, exclude_ids=set(), gap_threshold_days=None
+            item, retention_days=183, exclude_ids=set(), min_datetime=None
         )
         assert result is None
         assert reason == "already_stamped"
@@ -679,41 +680,49 @@ class TestClassifyAndStamp:
             item,
             retention_days=183,
             exclude_ids={"S2_demo"},
-            gap_threshold_days=None,
+            min_datetime=None,
         )
         assert result is None
         assert reason == "excluded"
 
-    def test_item_without_created_is_skipped(self) -> None:
+    def test_item_without_datetime_is_skipped(self) -> None:
         item = _stampable_item()
-        del item["properties"]["created"]
+        del item["properties"]["datetime"]
         result, reason = classify_and_stamp(
-            item, retention_days=183, exclude_ids=set(), gap_threshold_days=None
+            item, retention_days=183, exclude_ids=set(), min_datetime=None
         )
         assert result is None
-        assert reason == "no_created"
+        assert reason == "no_datetime"
 
-    def test_large_created_datetime_gap_flags_demo_when_threshold_set(self) -> None:
-        # A 2021 scene converted in 2025 has a multi-year created-datetime gap.
-        item = _stampable_item(created="2025-01-01T00:00:00Z", datetime_str="2021-05-01T00:00:00Z")
+    def test_item_acquired_before_floor_is_skipped(self) -> None:
+        # A 2021 demo scene is skipped (never stamped => never deleted) when the
+        # floor is in the pipeline era.
+        item = _stampable_item(datetime_str="2021-05-01T00:00:00Z")
         result, reason = classify_and_stamp(
-            item, retention_days=183, exclude_ids=set(), gap_threshold_days=30
+            item,
+            retention_days=183,
+            exclude_ids=set(),
+            min_datetime=_parse("2025-11-01T00:00:00Z"),
         )
         assert result is None
-        assert reason == "demo_gap"
+        assert reason == "before_floor"
 
-    def test_large_gap_is_stamped_when_threshold_disabled(self) -> None:
-        # Default (threshold=None) is strict: big gaps are stamped, not skipped.
-        item = _stampable_item(created="2025-01-01T00:00:00Z", datetime_str="2021-05-01T00:00:00Z")
+    def test_item_acquired_on_or_after_floor_is_stamped(self) -> None:
+        # The floor is inclusive of its own instant: an item exactly at the floor
+        # is stamped, not skipped.
+        item = _stampable_item(datetime_str="2025-11-01T00:00:00Z")
         result, reason = classify_and_stamp(
-            item, retention_days=183, exclude_ids=set(), gap_threshold_days=None
+            item,
+            retention_days=183,
+            exclude_ids=set(),
+            min_datetime=_parse("2025-11-01T00:00:00Z"),
         )
         assert reason == "stamped"
         assert result is not None
 
     def test_does_not_mutate_input_item(self) -> None:
         item = _stampable_item()
-        classify_and_stamp(item, retention_days=183, exclude_ids=set(), gap_threshold_days=None)
+        classify_and_stamp(item, retention_days=183, exclude_ids=set(), min_datetime=None)
         assert "expires" not in item["properties"]
 
 
@@ -725,16 +734,27 @@ class TestStampExpiresMigration:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
-        monkeypatch.delenv("EXPIRES_DEMO_GAP_DAYS", raising=False)
-        item = _stampable_item()
+        monkeypatch.delenv("EXPIRES_MIN_DATETIME", raising=False)
+        item = _stampable_item()  # datetime default 2024-12-31
         result = stamp_expires(item)
         assert result is not None
-        delta = _parse(result["properties"]["expires"]) - _parse("2025-01-01T00:00:00Z")
+        delta = _parse(result["properties"]["expires"]) - _parse("2024-12-31T00:00:00Z")
         assert delta == timedelta(days=DEFAULT_RETENTION_DAYS)
+
+    def test_min_datetime_floor_skips_old_acquisitions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
+        monkeypatch.setenv("EXPIRES_MIN_DATETIME", "2025-11-01")  # bare date form
+        reset_histogram()
+        stamp_expires(_stampable_item(item_id="old", datetime_str="2021-09-17T00:00:00Z"))
+        stamp_expires(_stampable_item(item_id="new", datetime_str="2026-02-01T00:00:00Z"))
+        assert SKIP_HISTOGRAM["before_floor"] == 1
+        assert SKIP_HISTOGRAM["stamped"] == 1
 
     def test_histogram_counts_outcomes(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
-        monkeypatch.delenv("EXPIRES_DEMO_GAP_DAYS", raising=False)
+        monkeypatch.delenv("EXPIRES_MIN_DATETIME", raising=False)
         reset_histogram()
         stamp_expires(_stampable_item(item_id="a"))
         stamp_expires(_stampable_item(item_id="b", expires="2025-07-01T00:00:00Z"))
@@ -815,7 +835,7 @@ class TestRunCommandSurfacesHistogram:
         climod = importlib.import_module("_migrate_catalog.cli")
 
         monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
-        monkeypatch.delenv("EXPIRES_DEMO_GAP_DAYS", raising=False)
+        monkeypatch.delenv("EXPIRES_MIN_DATETIME", raising=False)
         SKIP_HISTOGRAM.clear()
         SKIP_HISTOGRAM["stamped"] = 99  # stale — must be cleared before the run
 

--- a/tests/unit/test_register_v1.py
+++ b/tests/unit/test_register_v1.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(scripts_dir))
 from register_v1 import (  # noqa: E402
     TIMESTAMPS_EXTENSION,
     add_expires,
+    resolve_exclude_ids,
     resolve_retention_days,
     upsert_item,
 )
@@ -181,6 +182,33 @@ class TestAddExpires:
         add_expires(item, -5)
         assert "expires" not in item.properties
         assert TIMESTAMPS_EXTENSION not in item.stac_extensions
+
+    def test_excluded_item_is_not_stamped(self) -> None:
+        # A demo scene in the denylist stays structurally undeletable even when
+        # re-registered with a positive retention (the reconversion case).
+        item = _real_item(item_id="S2_demo")
+        add_expires(item, 183, exclude_ids={"S2_demo"})
+        assert "expires" not in item.properties
+        assert TIMESTAMPS_EXTENSION not in item.stac_extensions
+
+    def test_non_excluded_item_is_still_stamped(self) -> None:
+        item = _real_item(item_id="S2_pipeline")
+        add_expires(item, 183, exclude_ids={"S2_demo"})
+        assert "expires" in item.properties
+
+
+class TestResolveExcludeIds:
+    """resolve_exclude_ids reads the demo denylist from EXPIRES_EXCLUDE_FILE."""
+
+    def test_unset_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
+        assert resolve_exclude_ids() == set()
+
+    def test_reads_ids_from_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        f = tmp_path / "demo.txt"
+        f.write_text("# demo\nS2_demo_a\nS2_demo_b\n")
+        monkeypatch.setenv("EXPIRES_EXCLUDE_FILE", str(f))
+        assert resolve_exclude_ids() == {"S2_demo_a", "S2_demo_b"}
 
 
 class TestResolveRetentionDays:


### PR DESCRIPTION
Part of EOPF-Explorer/coordination#183

## Summary

Refines the v1.11.0 expiry-retention design in three linked changes so the
expiry-driven cleanup can safely drain the historical `sentinel-2-l2a` backlog
without ever endangering the curated demo scenes.

**1. Retention is measured from acquisition (`properties.datetime`), not `created`.**
`created` records when an item was converted/registered. The prod catalogue holds
multiple bulk-conversion cohorts, so `created` is unstable and disconnected from
data age — verified live: a Dec-2025 acquisition cohort carries `created=2026-05-05`
(a ~127-day gap), and a re-conversion resets `created`. Acquisition `datetime` is a
stable, mandatory core field, so `expires = datetime + 183d` holds across
re-conversions. As a bonus this removes the prior open question of whether `created`
survives the framework's DELETE-then-POST round-trip.

**2. Demo protection is the exclude list (primary), with an acquisition floor as a
blast-radius bound (secondary).** The curated demos are **not** all pre-pipeline —
three are 2026 acquisitions (`…T33TVF_20260225…`, `…T36UXA_20260120…`,
`…T27VWL_20260120…`), i.e. *after* any sane floor. So the enumerated exclude list
(`scripts/demo_exclude_ids.txt`, 12 verified ids) is the only complete protection;
excluded ids are never stamped and are structurally undeletable, checked *before*
the floor. `EXPIRES_MIN_DATETIME` is retained as a coarse secondary control — its
job is to bound how far back the first cleanup reaches and cover the pre-pipeline
tail, **not** to protect demos. This replaces the fragile, disabled-by-default
`created − datetime` gap heuristic (`EXPIRES_DEMO_GAP_DAYS`, removed).

**3. Demo protection is unified across register and cleanup, and fails loud.**
`register_v1.add_expires` now honors the *same* `EXPIRES_EXCLUDE_FILE` denylist, so
re-registering or reconverting a demo scene never re-arms it for deletion (register
otherwise stamps `now + retention` unconditionally). And `stamp_expires`'s report
now warns when a configured exclude-file id matched **zero** items in a run (typo,
or a stale/reconverted id) — because the exclude list is the crown-jewel
protection, a silent no-match must not pass unnoticed.

## For reviewers

- Behavior change is confined to the `stamp_expires` migration and `register_v1`'s
  expiry stamping, plus tests and docs. The cleanup script and the crons are
  unchanged.
- **Verified against live staging:** a dry-run with `EXPIRES_MIN_DATETIME=2025-11-01`
  on `sentinel-2-l2a-staging` produced **23,295 stamped / 90 before_floor**,
  reconciling exactly with an independent STAC datetime-range count (90 items
  acquired before the floor; all 2022 scenes).
- **Deployment precondition (safety-critical):** `EXPIRES_EXCLUDE_FILE` must be
  wired to `scripts/demo_exclude_ids.txt` in **both** cleanup crons *and* the
  register step (platform-deploy) before any real stamp/backfill or un-suspend. A
  floor-only run stamps — and later deletes — the three after-floor demos. The
  crons are suspended + in dry-run and the exclude file is currently unset, so
  nothing is at risk today.
- Tests cover: datetime-based expiry, inclusive floor boundary, `before_floor`,
  `no_datetime`, bare-`YYYY-MM-DD` and lowercase-`t` floor parsing; the
  crown-jewel contract (an after-floor demo in the exclude list is skipped as
  `excluded`, with a companion proving the same item is stamped when *not*
  excluded); the exclude-id-matched-nothing warning (fires on a stale id, quiet
  when all match); and register_v1 skipping excluded ids. mypy + ruff hooks pass;
  full unit suite green.
- This is a design change to retention semantics shipped in v1.11.0. It is **inert**
  until an operator runs the backfill; the cleanup crons remain suspended and in
  dry-run. Per coordination#183, documented team approval is still required before
  the real prod backfill and before un-suspending the crons.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every
  change and can explain why each is correct.

AI assistance (Claude Code) was used for the created-vs-datetime analysis, the
exclude-list-first protection design, the fail-loud hardening, and the
implementation. I verified the `created`-instability defect and the floor split
directly against the live staging catalogue (the 23,295 / 90 dry-run reconciled
against an independent STAC count), confirmed the three after-floor demo ids
against the live catalogue, and reviewed the full diff and tests.
