### PR TITLE
feat(query-stac): add --max-cloud-cover filter to discover

### DIFF
--- a/scripts/query_stac.py
+++ b/scripts/query_stac.py
@@ -312,7 +312,7 @@ def main() -> None:
         type=_optional_float,
         default=None,
         help="Optical filter: keep only items with eo:cloud_cover strictly below this "
-        "percentage (0-100]. Omit or pass blank for no cloud-cover filter (default).",
+        "percentage, in (0, 100]. Omit or pass blank for no cloud-cover filter (default).",
     )
     d.set_defaults(func=discover)
 

--- a/scripts/query_stac.py
+++ b/scripts/query_stac.py
@@ -45,6 +45,19 @@ def _require_https(url: str, name: str) -> None:
         sys.exit(f"Error: {name} must be an HTTPS URL, got: {url!r}")
 
 
+def _optional_float(value: str) -> float | None:
+    """argparse type for a float flag that may arrive blank.
+
+    The recent-data-processor uses a single shared WorkflowTemplate, so a cron that wants
+    no cloud-cover filter (e.g. a SAR/non-optical collection) cannot omit the arg — it can
+    only pass an empty value. Treat empty/whitespace as ``None`` (filter disabled) so that
+    reuse path works cleanly; otherwise parse as a float.
+    """
+    if value.strip() == "":
+        return None
+    return float(value)
+
+
 def _validate_bbox(bbox: object) -> None:
     """Raise SystemExit if bbox is not a list of exactly 4 floats."""
     if not isinstance(bbox, list) or len(bbox) != 4:
@@ -86,12 +99,15 @@ def discover(args: argparse.Namespace) -> None:
     WINDOW_HOURS = args.window_hours
     AOI_BBOX = args.aoi_bbox
     MAX_ACQUISITION_AGE_DAYS = args.max_acquisition_age_days
+    MAX_CLOUD_COVER = args.max_cloud_cover
 
     _require_https(SOURCE_STAC_API_URL, "SOURCE_STAC_API_URL")
     _require_https(TARGET_STAC_API_URL, "TARGET_STAC_API_URL")
     _validate_bbox(AOI_BBOX)
     if MAX_ACQUISITION_AGE_DAYS is not None and MAX_ACQUISITION_AGE_DAYS <= 0:
         sys.exit(f"Error: --max-acquisition-age-days must be > 0, got: {MAX_ACQUISITION_AGE_DAYS}")
+    if MAX_CLOUD_COVER is not None and not 0 < MAX_CLOUD_COVER <= 100:
+        sys.exit(f"Error: --max-cloud-cover must be in (0, 100], got: {MAX_CLOUD_COVER}")
 
     # Parse scheduled end time and calculate start time
     end_time = datetime.fromisoformat(SCHEDULED_END_TIME.replace("Z", "+00:00"))
@@ -124,6 +140,8 @@ def discover(args: argparse.Namespace) -> None:
             f"Acquisition floor: {min_acquisition_dt.isoformat().replace('+00:00', 'Z')} "
             f"(max age {MAX_ACQUISITION_AGE_DAYS} days)"
         )
+    if MAX_CLOUD_COVER is not None:
+        logger.info(f"Cloud-cover filter: eo:cloud_cover < {MAX_CLOUD_COVER}")
 
     # Connect to source STAC catalog
     source_catalog = Client.open(SOURCE_STAC_API_URL)
@@ -133,12 +151,26 @@ def discover(args: argparse.Namespace) -> None:
 
     # Search for items by updated time (for harvesting use case)
     # Query items that were updated within the time window, not by acquisition date
+    updated_filter: dict[str, object] = {
+        "op": "between",
+        "args": [{"property": "updated"}, start_time_str, end_time_str],
+    }
+    # Optionally narrow to low-cloud optical scenes server-side, so clouded items are trimmed
+    # before pagination and never cost a per-item dedup call. CQL2 three-valued logic drops
+    # items whose eo:cloud_cover is absent/null (harmless for S2 L2A, which always has it);
+    # unset ⇒ predicate omitted ⇒ nothing dropped (the SAR/non-optical reuse path).
+    filter_expr: dict[str, object] = updated_filter
+    if MAX_CLOUD_COVER is not None:
+        filter_expr = {
+            "op": "and",
+            "args": [
+                updated_filter,
+                {"op": "<", "args": [{"property": "eo:cloud_cover"}, MAX_CLOUD_COVER]},
+            ],
+        }
     search_kwargs: dict[str, object] = {
         "collections": [SOURCE_COLLECTION],
-        "filter": {
-            "op": "between",
-            "args": [{"property": "updated"}, start_time_str, end_time_str],
-        },
+        "filter": filter_expr,
         "filter_lang": "cql2-json",
         "bbox": AOI_BBOX,
         "limit": 100,  # Items per page for efficient pagination
@@ -274,6 +306,13 @@ def main() -> None:
         default=None,
         help="Real-time filter: keep only items whose acquisition datetime is within the last "
         "N days of the scheduled window end. Omit for no acquisition filter (default).",
+    )
+    d.add_argument(
+        "--max-cloud-cover",
+        type=_optional_float,
+        default=None,
+        help="Optical filter: keep only items with eo:cloud_cover strictly below this "
+        "percentage (0-100]. Omit or pass blank for no cloud-cover filter (default).",
     )
     d.set_defaults(func=discover)
 

--- a/tests/unit/test_query_stac.py
+++ b/tests/unit/test_query_stac.py
@@ -14,6 +14,9 @@ from pystac import Item, Link
 SOURCE_COLLECTION = "test"
 TARGET_COLLECTION = "test-staging"
 
+# Sentinel so run_script can distinguish "don't pass --max-cloud-cover" from "pass it blank".
+_UNSET = object()
+
 
 def create_stac_item(
     item_id: str,
@@ -132,6 +135,7 @@ def run_script(
     raise_error_on_target: bool = False,
     batch_size: int = 200,
     max_acquisition_age_days: int | None = None,
+    max_cloud_cover: object = _UNSET,
 ) -> dict:
     """Helper to run `discover` mode with test data and read back the manifest files.
 
@@ -174,6 +178,10 @@ def run_script(
     ]
     if max_acquisition_age_days is not None:
         argv += ["--max-acquisition-age-days", str(max_acquisition_age_days)]
+    # _UNSET ⇒ omit the flag entirely; any other value (including "") is passed through so
+    # the blank-disables-filter path is exercisable.
+    if max_cloud_cover is not _UNSET:
+        argv += ["--max-cloud-cover", str(max_cloud_cover)]
     with (
         patch("scripts.query_stac.Client.open", side_effect=mock_client_open),
         patch("sys.argv", argv),
@@ -621,3 +629,49 @@ class TestAcquisitionFilter:
         for bad in (0, -5):
             with pytest.raises(SystemExit):
                 run_script(source, [], max_acquisition_age_days=bad)
+
+
+class TestCloudCoverFilter:
+    """`--max-cloud-cover` adds a server-side CQL2 `eo:cloud_cover < N` predicate."""
+
+    def test_filter_unset_stays_bare_between(self):
+        """Without the flag the filter is the original bare `between` on `updated`."""
+        result = run_script([], [])
+
+        filter_param = result["source_client"].searches[0]["filter"]
+        assert filter_param["op"] == "between"
+        assert filter_param["args"][0] == {"property": "updated"}
+
+    def test_filter_set_wraps_updated_and_cloud_cover_in_and(self):
+        """With the flag the filter is `and(updated between …, eo:cloud_cover < N)`."""
+        result = run_script([], [], max_cloud_cover=90)
+
+        filter_param = result["source_client"].searches[0]["filter"]
+        assert filter_param["op"] == "and"
+        assert len(filter_param["args"]) == 2
+
+        between_clause, cloud_clause = filter_param["args"]
+        # Original updated-window predicate is preserved unchanged as the first arg.
+        assert between_clause["op"] == "between"
+        assert between_clause["args"][0] == {"property": "updated"}
+        # Second arg is the strict-below cloud-cover predicate.
+        assert cloud_clause == {"op": "<", "args": [{"property": "eo:cloud_cover"}, 90.0]}
+
+    def test_filter_lang_still_cql2_json_when_set(self):
+        """Adding the predicate must not change the declared filter language."""
+        result = run_script([], [], max_cloud_cover=50)
+
+        assert result["source_client"].searches[0]["filter_lang"] == "cql2-json"
+
+    def test_blank_value_disables_filter(self):
+        """A blank param (SAR/non-optical reuse path) parses to no cloud-cover predicate."""
+        result = run_script([], [], max_cloud_cover="")
+
+        filter_param = result["source_client"].searches[0]["filter"]
+        assert filter_param["op"] == "between"  # bare between, no `and` wrapper
+
+    def test_out_of_range_values_are_rejected(self):
+        """Values outside (0, 100] exit rather than building a filter that keeps nothing/all."""
+        for bad in (0, -5, 150):
+            with pytest.raises(SystemExit):
+                run_script([], [], max_cloud_cover=bad)

--- a/tests/unit/test_query_stac.py
+++ b/tests/unit/test_query_stac.py
@@ -675,3 +675,22 @@ class TestCloudCoverFilter:
         for bad in (0, -5, 150):
             with pytest.raises(SystemExit):
                 run_script([], [], max_cloud_cover=bad)
+
+    def test_upper_boundary_is_inclusive(self):
+        """100 is accepted (<= 100) and builds a strict `< 100` predicate."""
+        result = run_script([], [], max_cloud_cover=100)
+
+        filter_param = result["source_client"].searches[0]["filter"]
+        assert filter_param["op"] == "and"
+        assert filter_param["args"][1] == {
+            "op": "<",
+            "args": [{"property": "eo:cloud_cover"}, 100.0],
+        }
+
+    def test_cloud_and_acquisition_filters_coexist(self):
+        """Prod runs both: `filter` gets the AND(cloud) and the `datetime` floor still applies."""
+        result = run_script([], [], max_cloud_cover=90, max_acquisition_age_days=7)
+
+        search = result["source_client"].searches[0]
+        assert search["filter"]["op"] == "and"  # cloud predicate present
+        assert "datetime" in search["kwargs"]  # acquisition narrowing not clobbered


### PR DESCRIPTION
## Summary

The `eopf-recent-data-processor` CronWorkflow converts **every** newly-updated
`sentinel-2-l2a` item regardless of cloud cover, so heavily-clouded (often useless)
scenes consume conversion compute and storage.

This adds an optional `--max-cloud-cover` flag to `query_stac.py discover` that appends a
server-side CQL2 predicate `eo:cloud_cover < N`, AND-ed with the existing
`updated between` window. Being server-side, clouded items are trimmed before pagination
and never cost a per-item dedup call against the target collection.

- **Optional & blank-tolerant.** Default `None` → predicate omitted (unchanged behavior).
  A new `_optional_float` argparse type maps empty/whitespace → `None`, so the single
  shared `WorkflowTemplate` can disable the filter for a SAR/non-optical cron by passing an
  empty value (the arg can't be conditionally omitted from a shared template).
- **Validated** to `(0, 100]`, mirroring the existing `--max-acquisition-age-days` plumbing
  (arg → local → filter). No change to the per-item loop.
- **No client-side guard**, by design — see verification below.

Manifest wiring (`max_cloud_cover` param → `--max-cloud-cover` arg, default `90`) ships
separately in `EOPF-Explorer/platform-deploy`, gated on a new image tag carrying this flag.

## For reviewers

- Behavior with the flag **unset** is unchanged: the filter stays the bare `updated between`
  (guarded by the existing `test_cql2_filter_format` / `test_queries_updated_property_not_datetime`).
- **Why no client-side guard?** We chose server-side-only, which means the filter is only as
  good as the API honoring the predicate. I verified this against the real source STAC
  (`stac.core.eopf.eodc.eu`): over a 14-day western-Europe window the unfiltered sample
  spanned `eo:cloud_cover` 0.0–100.0, while the `< 90` search returned only items with
  max `eo:cloud_cover = 89.50` — the predicate is honored and drops `≥ 90` scenes. (HTTP 200
  alone would not prove this; the items' properties were inspected.)
- **CQL2 three-valued logic:** items with absent/null `eo:cloud_cover` are dropped by the
  `<` predicate. Harmless for S2 L2A (always present); the safety mechanism for non-optical
  reuse is leaving the param unset, not "keep-if-absent".
- New unit tests: `TestCloudCoverFilter` (unset → bare `between`; set → `and(between, <)`;
  blank → disabled; out-of-range → `SystemExit`). Full suite: 468 passed, 1 skipped;
  `scripts/query_stac.py` at 100% line coverage. `ruff` + `mypy` (pre-commit) green.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood
  every change and can explain why each is correct.

AI assistance: Claude Code drafted the `query_stac.py` changes, the unit tests, and the
live API verification probe; I reviewed the diff, ran the tests and the pre-commit hooks,
and confirmed the live STAC filtering behavior myself.
