### PR TITLE
fix(migrate): make search-pagination client resilient (timeout + retry)

### DIFF
--- a/operator-tools/_migrate_catalog/runner.py
+++ b/operator-tools/_migrate_catalog/runner.py
@@ -9,17 +9,37 @@ from typing import Any
 import click
 import requests
 from pystac_client import Client
+from pystac_client.stac_api_io import StacApiIO
+from urllib3.util.retry import Retry
 
 from _migrate_catalog.types import MigrationFn, MigrationResult
 
 logger = logging.getLogger(__name__)
 
-# Per-request timeout (seconds) for the search-pagination client. Without it,
-# pystac_client's session has no timeout and a stalled socket hangs the whole run
-# indefinitely (observed: 4.5h wall / 26s CPU against the prod STAC API). With a
-# timeout, a stuck read raises and StacApiIO's default max_retries=5 reconnects.
-# Override via STAC_HTTP_TIMEOUT.
+# Resilience for the search-pagination client on long backfills. Two failures
+# seen live against the prod STAC API:
+#   - no timeout -> a stalled socket hangs the whole run forever (4.5h wall /
+#     26s CPU, never past "Found N items").
+#   - weak default retries -> a transient ConnectionReset mid-pagination aborts
+#     the entire run (crashed at ~20% of a 23k-item staging backfill).
+# _resilient_stac_io gives the pagination client a per-request timeout plus
+# urllib3 retries with exponential backoff on connection errors and 5xx, for GET
+# and the POST /search pagination. urllib3 cannot always retry a reset mid-body,
+# so this is best-effort; the migration is idempotent (skips already-stamped),
+# so anything that still slips through is recovered by simply re-running.
+# Override the timeout via STAC_HTTP_TIMEOUT.
 _SEARCH_TIMEOUT = float(os.getenv("STAC_HTTP_TIMEOUT", "60"))
+
+
+def _resilient_stac_io() -> StacApiIO:
+    retry = Retry(
+        total=8,
+        backoff_factor=1.0,
+        status_forcelist=(429, 502, 503, 504),
+        allowed_methods=frozenset({"GET", "POST"}),
+        raise_on_status=False,
+    )
+    return StacApiIO(timeout=_SEARCH_TIMEOUT, max_retries=retry)
 
 
 def compose_migrations(fns: list[MigrationFn]) -> MigrationFn:
@@ -85,7 +105,7 @@ class STACMigrationRunner:
             errors=[],
         )
 
-        catalog = Client.open(self.api_url, timeout=_SEARCH_TIMEOUT)
+        catalog = Client.open(self.api_url, stac_io=_resilient_stac_io())
         search = catalog.search(collections=[collection_id], max_items=None, limit=page_size)
 
         total = search.matched()
@@ -123,7 +143,7 @@ class STACMigrationRunner:
 
     def _fetch_existing_ids(self, collection_id: str, page_size: int) -> set[str]:
         """Return the set of item IDs already present in collection_id."""
-        catalog = Client.open(self.api_url, timeout=_SEARCH_TIMEOUT)
+        catalog = Client.open(self.api_url, stac_io=_resilient_stac_io())
         search = catalog.search(
             collections=[collection_id],
             max_items=None,
@@ -158,7 +178,7 @@ class STACMigrationRunner:
             existing_ids = self._fetch_existing_ids(target_id, page_size)
             click.echo(f"Found {len(existing_ids)} items already in '{target_id}', skipping them.")
 
-        catalog = Client.open(self.api_url, timeout=_SEARCH_TIMEOUT)
+        catalog = Client.open(self.api_url, stac_io=_resilient_stac_io())
         search = catalog.search(collections=[source_id], max_items=None, limit=page_size)
 
         total = search.matched()

--- a/operator-tools/_migrate_catalog/runner.py
+++ b/operator-tools/_migrate_catalog/runner.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import logging
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,13 @@ from pystac_client import Client
 from _migrate_catalog.types import MigrationFn, MigrationResult
 
 logger = logging.getLogger(__name__)
+
+# Per-request timeout (seconds) for the search-pagination client. Without it,
+# pystac_client's session has no timeout and a stalled socket hangs the whole run
+# indefinitely (observed: 4.5h wall / 26s CPU against the prod STAC API). With a
+# timeout, a stuck read raises and StacApiIO's default max_retries=5 reconnects.
+# Override via STAC_HTTP_TIMEOUT.
+_SEARCH_TIMEOUT = float(os.getenv("STAC_HTTP_TIMEOUT", "60"))
 
 
 def compose_migrations(fns: list[MigrationFn]) -> MigrationFn:
@@ -77,7 +85,7 @@ class STACMigrationRunner:
             errors=[],
         )
 
-        catalog = Client.open(self.api_url)
+        catalog = Client.open(self.api_url, timeout=_SEARCH_TIMEOUT)
         search = catalog.search(collections=[collection_id], max_items=None, limit=page_size)
 
         total = search.matched()
@@ -115,7 +123,7 @@ class STACMigrationRunner:
 
     def _fetch_existing_ids(self, collection_id: str, page_size: int) -> set[str]:
         """Return the set of item IDs already present in collection_id."""
-        catalog = Client.open(self.api_url)
+        catalog = Client.open(self.api_url, timeout=_SEARCH_TIMEOUT)
         search = catalog.search(
             collections=[collection_id],
             max_items=None,
@@ -150,7 +158,7 @@ class STACMigrationRunner:
             existing_ids = self._fetch_existing_ids(target_id, page_size)
             click.echo(f"Found {len(existing_ids)} items already in '{target_id}', skipping them.")
 
-        catalog = Client.open(self.api_url)
+        catalog = Client.open(self.api_url, timeout=_SEARCH_TIMEOUT)
         search = catalog.search(collections=[source_id], max_items=None, limit=page_size)
 
         total = search.matched()

--- a/tests/unit/test_migrate_catalog.py
+++ b/tests/unit/test_migrate_catalog.py
@@ -919,3 +919,18 @@ class TestRunCommandSurfacesHistogram:
         assert seen_at_start["total"] == 0  # histogram was reset before processing
         assert "stamped" in res.output
         assert "already_stamped" in res.output
+
+
+def test_search_client_is_resilient() -> None:
+    """The pagination client must carry a timeout AND retry-with-backoff so a
+    stalled socket or a transient reset can't kill a long backfill (runner
+    defects seen live: a 4.5h hang, then a ConnectionReset abort at ~20%). The
+    migration's idempotent re-run is the final backstop."""
+    from _migrate_catalog.runner import _SEARCH_TIMEOUT, _resilient_stac_io
+
+    io = _resilient_stac_io()
+    assert io.timeout == _SEARCH_TIMEOUT
+    retry = io.session.get_adapter("https://example.com").max_retries
+    assert retry.total and retry.total >= 5
+    assert retry.backoff_factor and retry.backoff_factor > 0
+    assert "POST" in retry.allowed_methods  # /search pagination uses POST


### PR DESCRIPTION
## Summary

Make the `migrate_catalog` search-pagination client survive transient network faults on long backfills. Two failure modes hit live against the prod STAC API, both fatal to the coordination#183 Task-9 backfill:

1. **No timeout** — `STACMigrationRunner` opened its client with a bare `Client.open(url)`, whose `requests` session has no timeout. A page fetch stalled on a half-open socket blocked `search.pages()` forever: observed **4.5h wall / 26s CPU**, never past the initial `Found N items` line, with an idle-but-ESTABLISHED connection.
2. **Weak retries** — even with a timeout, a transient `ConnectionReset` mid-pagination aborts the whole run: it propagates out of `for page in search.pages()`, which sits **outside** the per-item try/except. Seen live: a 23k-item staging backfill crashed at ~20%.

Fix: a shared `_resilient_stac_io()` gives the pagination client, at all three `Client.open` sites, a per-request **timeout** (default 60s, `STAC_HTTP_TIMEOUT`) **plus** a urllib3 `Retry` (total=8, exponential backoff, connection-errors + 429/5xx, for GET and the POST `/search` pagination).

## For reviewers

- 3 call sites (`run_migration`, `_fetch_existing_ids`, `clone_collection`) + one helper + one constant. No behaviour change beyond bounding waits and retrying transient failures.
- **Honest limit:** urllib3 cannot always retry a reset that lands mid-response-body, so this is best-effort. The migration is **idempotent** (skips `already_stamped`), so anything that still slips through is recovered by simply re-running — that remains the final backstop, by design.
- **Live-verified:** with the timeout, a real `stamp_expires` backfill on `sentinel-2-l2a-staging` progressed steadily past the exact point it previously hung (0 → thousands of items).
- Structural test asserts the client carries the timeout + a retry-with-backoff that allows POST. Migrate suite green (68 passed); ruff/format clean. (Pre-existing standalone-mypy `bar` annotations at the `click.progressbar` lines are unrelated and present on `main`.)
- Unblocks the Task-9 historical-cleanup backfill; does **not** touch the cleanup crons or any deletion behaviour.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted (Claude Code): both failure modes were root-caused from live runs (idle ESTABLISHED socket with no timeout; then a ConnectionReset aborting pagination); the timeout + retry were verified against pystac_client 0.9.0's `Client.open(stac_io=StacApiIO(timeout=…, max_retries=Retry(…)))` and a real staging backfill.
