### PR TITLE
fix(deps): re-sync uv.lock version stamp with pyproject (1.10.0 -> 1.12.0)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -828,7 +828,7 @@ distributed = [
 
 [[package]]
 name = "data-pipeline"
-version = "1.10.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

The 1.11.0 and 1.12.0 releases bumped `pyproject.toml` but left `uv.lock`'s `data-pipeline` entry stamped `1.10.0`. The pre-commit pytest hook runs `uv run --group test pytest`, and every `uv run` re-syncs that stamp and writes the file — so the hook modified a tracked file on every invocation and failed with `files were modified by this hook`. In practice that made `--no-verify` the only way to commit anything to this repo, on any branch off `main`.


## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood
  every change and can explain why each is correct.

AI assistance: Claude diagnosed the root cause (tracing the failing hook to `uv run` rewriting the stale stamp), produced the one-line lock re-sync, and verified it by committing with hooks enabled and confirming `uv run` no longer dirties the file. I reviewed the change and the verification.
