### PR TITLE
fix(expires): default demo exclude-list to baked file (protection on by default)

### DIFF
--- a/operator-tools/_migrate_catalog/migrations/stamp_expires.py
+++ b/operator-tools/_migrate_catalog/migrations/stamp_expires.py
@@ -67,8 +67,8 @@ from s3_item_cleanup import (  # noqa: E402
     TIMESTAMPS_EXTENSION,
     env_int,
     format_expires,
-    load_exclude_ids,
     parse_stac_timestamp,
+    resolve_exclude_ids,
 )
 
 logger = logging.getLogger(__name__)
@@ -180,7 +180,7 @@ def _parse_floor(value: str) -> datetime:
 
 def _resolve_config() -> tuple[int, set[str], datetime | None]:
     retention_days = env_int("EXPIRES_RETENTION_DAYS", DEFAULT_RETENTION_DAYS)
-    exclude_ids = load_exclude_ids(os.getenv("EXPIRES_EXCLUDE_FILE"))
+    exclude_ids = resolve_exclude_ids()
     floor_env = os.getenv("EXPIRES_MIN_DATETIME")
     min_datetime = _parse_floor(floor_env) if floor_env else None
     return retention_days, exclude_ids, min_datetime

--- a/scripts/cleanup_expired_items.py
+++ b/scripts/cleanup_expired_items.py
@@ -39,8 +39,8 @@ from s3_item_cleanup import (
     delete_s3_objects_for_item,
     extract_s3_urls_from_item,
     format_expires,
-    load_exclude_ids,
     parse_stac_timestamp,
+    resolve_exclude_ids,
 )
 
 logging.basicConfig(
@@ -249,7 +249,7 @@ def _s3_client(s3_endpoint: str | None) -> Any:
 def run_cleanup(args: argparse.Namespace) -> int:
     """Discover and process expired items; emit JSONL; return exit code."""
     now = _now()
-    exclude_ids = load_exclude_ids(args.exclude_file)
+    exclude_ids = resolve_exclude_ids(args.exclude_file)
     dry_run = not args.execute
 
     client = Client.open(args.stac_api_url)
@@ -364,8 +364,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--exclude-file",
-        default=os.getenv("EXPIRES_EXCLUDE_FILE"),
-        help="Newline-delimited item-ID denylist (always skipped)",
+        default=None,
+        help=(
+            "Newline-delimited item-ID denylist (always skipped). Overrides "
+            "$EXPIRES_EXCLUDE_FILE; if neither is set, the baked demo denylist "
+            "is used by default."
+        ),
     )
     parser.add_argument(
         "--execute",

--- a/scripts/register_v1.py
+++ b/scripts/register_v1.py
@@ -21,7 +21,7 @@ from s3_item_cleanup import (
     TIMESTAMPS_EXTENSION,
     env_int,
     format_expires,
-    load_exclude_ids,
+    resolve_exclude_ids,
 )
 from storage_tier_utils import extract_region_from_endpoint, get_s3_storage_class
 
@@ -356,18 +356,6 @@ def resolve_retention_days() -> int:
     empty value falls back to the default. See coordination#183.
     """
     return env_int("EXPIRES_RETENTION_DAYS", DEFAULT_RETENTION_DAYS)
-
-
-def resolve_exclude_ids() -> set[str]:
-    """Demo denylist from ``EXPIRES_EXCLUDE_FILE`` (coordination#183).
-
-    This is the *same* list the cleanup honors, so demo protection is defined
-    once and can't drift between register-time and cleanup-time. An id in this
-    list is never stamped with ``expires`` here, and never deleted by the
-    cleanup — so re-registering or reconverting a demo scene keeps it
-    structurally undeletable. Unset ⇒ empty set.
-    """
-    return load_exclude_ids(os.getenv("EXPIRES_EXCLUDE_FILE"))
 
 
 def add_expires(item: Item, retention_days: int, exclude_ids: set[str] | None = None) -> None:

--- a/scripts/s3_item_cleanup.py
+++ b/scripts/s3_item_cleanup.py
@@ -18,6 +18,7 @@ import logging
 import os
 from collections import defaultdict
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
@@ -76,6 +77,29 @@ def load_exclude_ids(path: str | None) -> set[str]:
             if stripped and not stripped.startswith("#"):
                 ids.add(stripped)
     return ids
+
+
+# The demo denylist baked into the pipeline image next to this module
+# (``docker/Dockerfile`` copies ``scripts/`` to ``/app/scripts/``). Used as the
+# default so demo protection is ON even when ``EXPIRES_EXCLUDE_FILE`` is unset.
+BAKED_EXCLUDE_FILE = Path(__file__).resolve().parent / "demo_exclude_ids.txt"
+
+
+def resolve_exclude_ids(explicit_path: str | None = None) -> set[str]:
+    """Resolve the demo denylist, in order of precedence:
+    ``explicit_path`` → ``$EXPIRES_EXCLUDE_FILE`` → the baked
+    ``demo_exclude_ids.txt``.
+
+    The baked fallback makes demo protection *unconditional*: register, cleanup
+    and the backfill all skip demo ids by default, not only when a workflow
+    remembers to set the env var. A registration/reconversion that forgets
+    ``EXPIRES_EXCLUDE_FILE`` can no longer stamp ``expires`` on a demo scene
+    (coordination#183). Set ``EXPIRES_EXCLUDE_FILE`` to override/extend the list.
+    """
+    path = explicit_path or os.getenv("EXPIRES_EXCLUDE_FILE")
+    if not path and BAKED_EXCLUDE_FILE.exists():
+        path = str(BAKED_EXCLUDE_FILE)
+    return load_exclude_ids(path)
 
 
 def extract_s3_urls_from_item(item_dict: dict) -> set[str]:

--- a/scripts/s3_item_cleanup.py
+++ b/scripts/s3_item_cleanup.py
@@ -97,8 +97,19 @@ def resolve_exclude_ids(explicit_path: str | None = None) -> set[str]:
     (coordination#183). Set ``EXPIRES_EXCLUDE_FILE`` to override/extend the list.
     """
     path = explicit_path or os.getenv("EXPIRES_EXCLUDE_FILE")
-    if not path and BAKED_EXCLUDE_FILE.exists():
-        path = str(BAKED_EXCLUDE_FILE)
+    if not path:
+        if BAKED_EXCLUDE_FILE.exists():
+            path = str(BAKED_EXCLUDE_FILE)
+        else:
+            # Never fail open *silently*: with nothing configured and no baked list
+            # we are back to the opt-in behaviour this function exists to remove,
+            # so say so loudly rather than quietly returning "no demos protected".
+            logger.warning(
+                "Demo protection is OFF: no explicit path, no $EXPIRES_EXCLUDE_FILE, "
+                "and the baked denylist is missing at %s. Demo scenes may be stamped "
+                "with `expires` and later deleted (coordination#183).",
+                BAKED_EXCLUDE_FILE,
+            )
     return load_exclude_ids(path)
 
 

--- a/tests/unit/test_migrate_catalog.py
+++ b/tests/unit/test_migrate_catalog.py
@@ -610,8 +610,8 @@ from s3_item_cleanup import (  # noqa: E402
     DEFAULT_RETENTION_DAYS,
     TIMESTAMPS_EXTENSION,
     format_expires,
-    load_exclude_ids,
     parse_stac_timestamp,
+    resolve_exclude_ids,
 )
 
 
@@ -796,7 +796,7 @@ def test_stamp_expires_uses_shared_format_helper() -> None:
 
     assert se.format_expires is format_expires
     assert se.parse_stac_timestamp is parse_stac_timestamp
-    assert se.load_exclude_ids is load_exclude_ids
+    assert se.resolve_exclude_ids is resolve_exclude_ids
 
 
 # === Histogram surfacing + reconciliation (review finding: histogram invisible) ===

--- a/tests/unit/test_register_v1.py
+++ b/tests/unit/test_register_v1.py
@@ -201,9 +201,7 @@ class TestResolveExcludeIds:
     """resolve_exclude_ids reads the demo denylist; when the env is unset it
     falls back to the baked file so demo protection is never accidentally off."""
 
-    def test_unset_falls_back_to_baked_demo_file(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_unset_falls_back_to_baked_demo_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # A forgotten EXPIRES_EXCLUDE_FILE must NOT unprotect demo scenes — the
         # baked /app/scripts/demo_exclude_ids.txt is used by default (coordination#183).
         from s3_item_cleanup import BAKED_EXCLUDE_FILE, load_exclude_ids

--- a/tests/unit/test_register_v1.py
+++ b/tests/unit/test_register_v1.py
@@ -198,13 +198,22 @@ class TestAddExpires:
 
 
 class TestResolveExcludeIds:
-    """resolve_exclude_ids reads the demo denylist from EXPIRES_EXCLUDE_FILE."""
+    """resolve_exclude_ids reads the demo denylist; when the env is unset it
+    falls back to the baked file so demo protection is never accidentally off."""
 
-    def test_unset_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_unset_falls_back_to_baked_demo_file(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A forgotten EXPIRES_EXCLUDE_FILE must NOT unprotect demo scenes — the
+        # baked /app/scripts/demo_exclude_ids.txt is used by default (coordination#183).
+        from s3_item_cleanup import BAKED_EXCLUDE_FILE, load_exclude_ids
+
         monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
-        assert resolve_exclude_ids() == set()
+        ids = resolve_exclude_ids()
+        assert ids  # the baked file ships real demo ids
+        assert ids == load_exclude_ids(str(BAKED_EXCLUDE_FILE))
 
-    def test_reads_ids_from_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def test_env_overrides_baked(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         f = tmp_path / "demo.txt"
         f.write_text("# demo\nS2_demo_a\nS2_demo_b\n")
         monkeypatch.setenv("EXPIRES_EXCLUDE_FILE", str(f))

--- a/tests/unit/test_s3_item_cleanup.py
+++ b/tests/unit/test_s3_item_cleanup.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-import s3_item_cleanup as sic
 from s3_item_cleanup import (
     BAKED_EXCLUDE_FILE,
     DEFAULT_RETENTION_DAYS,

--- a/tests/unit/test_s3_item_cleanup.py
+++ b/tests/unit/test_s3_item_cleanup.py
@@ -11,10 +11,13 @@ boto3 is fully mocked — no network, no AWS.
 """
 
 import importlib.util
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+import s3_item_cleanup as sic
 from s3_item_cleanup import (
     BAKED_EXCLUDE_FILE,
     DEFAULT_RETENTION_DAYS,
@@ -244,30 +247,45 @@ class TestResolveExcludeIds:
     forgets EXPIRES_EXCLUDE_FILE cannot leave demo scenes unprotected
     (coordination#183). Precedence: explicit path > env > baked file."""
 
-    def test_baked_file_ships_with_the_image(self) -> None:
-        # The fallback is only real protection if the file is actually present.
+    def test_baked_file_is_present_and_non_empty(self) -> None:
+        # The fallback is only real protection if the file is actually there. This
+        # guards the source tree; `docker/Dockerfile`'s `COPY scripts/ /app/scripts/`
+        # is what carries it into the image (.dockerignore excludes *.md, not *.txt).
         assert BAKED_EXCLUDE_FILE.exists()
         assert load_exclude_ids(str(BAKED_EXCLUDE_FILE))  # non-empty
 
-    def test_unset_falls_back_to_baked(self, monkeypatch: object) -> None:
-        monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)  # type: ignore[attr-defined]
+    def test_unset_falls_back_to_baked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
         assert resolve_exclude_ids() == load_exclude_ids(str(BAKED_EXCLUDE_FILE))
 
-    def test_env_overrides_baked(self, monkeypatch: object, tmp_path: Path) -> None:
+    def test_env_overrides_baked(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         f = tmp_path / "env.txt"
         f.write_text("env-a\nenv-b\n")
-        monkeypatch.setenv("EXPIRES_EXCLUDE_FILE", str(f))  # type: ignore[attr-defined]
+        monkeypatch.setenv("EXPIRES_EXCLUDE_FILE", str(f))
         assert resolve_exclude_ids() == {"env-a", "env-b"}
 
     def test_explicit_path_overrides_env_and_baked(
-        self, monkeypatch: object, tmp_path: Path
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         env_f = tmp_path / "env.txt"
         env_f.write_text("env-a\n")
-        monkeypatch.setenv("EXPIRES_EXCLUDE_FILE", str(env_f))  # type: ignore[attr-defined]
+        monkeypatch.setenv("EXPIRES_EXCLUDE_FILE", str(env_f))
         explicit = tmp_path / "explicit.txt"
         explicit.write_text("explicit-a\nexplicit-b\n")
         assert resolve_exclude_ids(str(explicit)) == {"explicit-a", "explicit-b"}
+
+    def test_missing_baked_file_warns_instead_of_silently_unprotecting(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Losing the baked list reverts to the opt-in behaviour this function removes.
+        # That must never happen quietly — an operator has to be able to see it.
+        monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
+        monkeypatch.setattr(sic, "BAKED_EXCLUDE_FILE", tmp_path / "absent.txt")
+
+        with caplog.at_level(logging.WARNING, logger=sic.__name__):
+            assert resolve_exclude_ids() == set()
+
+        assert "Demo protection is OFF" in caplog.text
 
 
 def test_consumers_share_one_format_helper() -> None:

--- a/tests/unit/test_s3_item_cleanup.py
+++ b/tests/unit/test_s3_item_cleanup.py
@@ -279,9 +279,9 @@ class TestResolveExcludeIds:
         # Losing the baked list reverts to the opt-in behaviour this function removes.
         # That must never happen quietly — an operator has to be able to see it.
         monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
-        monkeypatch.setattr(sic, "BAKED_EXCLUDE_FILE", tmp_path / "absent.txt")
+        monkeypatch.setattr("s3_item_cleanup.BAKED_EXCLUDE_FILE", tmp_path / "absent.txt")
 
-        with caplog.at_level(logging.WARNING, logger=sic.__name__):
+        with caplog.at_level(logging.WARNING, logger="s3_item_cleanup"):
             assert resolve_exclude_ids() == set()
 
         assert "Demo protection is OFF" in caplog.text

--- a/tests/unit/test_s3_item_cleanup.py
+++ b/tests/unit/test_s3_item_cleanup.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from s3_item_cleanup import (
+    BAKED_EXCLUDE_FILE,
     DEFAULT_RETENTION_DAYS,
     EXPIRES_TS_FORMAT,
     count_s3_objects_for_item,
@@ -25,6 +26,7 @@ from s3_item_cleanup import (
     format_expires,
     load_exclude_ids,
     parse_stac_timestamp,
+    resolve_exclude_ids,
 )
 
 BUCKET = "esa-zarr-sentinel-explorer-fra"
@@ -234,6 +236,38 @@ class TestLoadExcludeIds:
         f = tmp_path / "exclude.txt"
         f.write_text("item-a\n# a comment\n\nitem-b\n")
         assert load_exclude_ids(str(f)) == {"item-a", "item-b"}
+
+
+class TestResolveExcludeIds:
+    """resolve_exclude_ids makes demo protection unconditional: with nothing
+    configured it falls back to the baked demo denylist, so a workflow that
+    forgets EXPIRES_EXCLUDE_FILE cannot leave demo scenes unprotected
+    (coordination#183). Precedence: explicit path > env > baked file."""
+
+    def test_baked_file_ships_with_the_image(self) -> None:
+        # The fallback is only real protection if the file is actually present.
+        assert BAKED_EXCLUDE_FILE.exists()
+        assert load_exclude_ids(str(BAKED_EXCLUDE_FILE))  # non-empty
+
+    def test_unset_falls_back_to_baked(self, monkeypatch: object) -> None:
+        monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)  # type: ignore[attr-defined]
+        assert resolve_exclude_ids() == load_exclude_ids(str(BAKED_EXCLUDE_FILE))
+
+    def test_env_overrides_baked(self, monkeypatch: object, tmp_path: Path) -> None:
+        f = tmp_path / "env.txt"
+        f.write_text("env-a\nenv-b\n")
+        monkeypatch.setenv("EXPIRES_EXCLUDE_FILE", str(f))  # type: ignore[attr-defined]
+        assert resolve_exclude_ids() == {"env-a", "env-b"}
+
+    def test_explicit_path_overrides_env_and_baked(
+        self, monkeypatch: object, tmp_path: Path
+    ) -> None:
+        env_f = tmp_path / "env.txt"
+        env_f.write_text("env-a\n")
+        monkeypatch.setenv("EXPIRES_EXCLUDE_FILE", str(env_f))  # type: ignore[attr-defined]
+        explicit = tmp_path / "explicit.txt"
+        explicit.write_text("explicit-a\nexplicit-b\n")
+        assert resolve_exclude_ids(str(explicit)) == {"explicit-a", "explicit-b"}
 
 
 def test_consumers_share_one_format_helper() -> None:


### PR DESCRIPTION
## Summary

Demo protection was **opt-in**: `register_v1` / `cleanup` / `stamp_expires` read the denylist only from `$EXPIRES_EXCLUDE_FILE` and returned an empty set when unset — so any reconversion that forgot the env var stamped `expires` on demo scenes (seen live: 6/7 demos in staging got stamped).

Make it unconditional: one shared `resolve_exclude_ids()` resolves the denylist by **explicit path → `$EXPIRES_EXCLUDE_FILE` → baked `demo_exclude_ids.txt`**. A forgotten env var can no longer unprotect a demo; the env still overrides.

## For reviewers

- Behaviour change (the point): **env unset now returns the baked demo ids, not `set()`.** Two old-contract tests updated; precedence + fail-loud-if-baked-missing covered by new tests.
- Harmless to the regular pipeline — only the 12 demo ids, which it never ingests.
- Backstop to the cleanup-time skip wired in EOPF-Explorer/platform-deploy#314 (EOPF-Explorer/coordination#183): demos now never stamped *and* never deleted.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted (Claude Code); reviewed against the full unit suite.
