### PR TITLE
fix(ci): keep uv.lock in sync across releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
-          version: "0.9.10"
+          version: "0.11.17"
+      # --locked fails on a uv.lock that disagrees with pyproject.toml instead
+      # of silently regenerating it, which previously let version drift reach
+      # main unnoticed and surface as a dirty lock on every local commit.
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --locked --all-groups
       - name: Set up pre-commit cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,12 +21,61 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses:  googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           config-file: "release-please-config.json"
           manifest-file: ".release-please-manifest.json"
+
+  # Release Please bumps $.project.version in pyproject.toml but cannot
+  # regenerate uv.lock, which carries its own copy of that version. Without
+  # this, every release ships a lock whose data-pipeline stamp lags pyproject,
+  # breaking `uv lock --check` and making `uv run` rewrite the lock mid-commit.
+  # Relock on the release branch so the version bump and the lock land together.
+  #
+  # Kept in its own job so a transient `uv lock` failure cannot skip
+  # docker-build, which only needs release-please: an unpublished image is a
+  # worse outcome than a lock that the next run re-syncs anyway.
+  sync-release-lock:
+    name: Sync uv.lock on release PR
+    needs: release-please
+    if: needs.release-please.outputs.pr
+    permissions:
+      contents: write # Push the uv.lock commit to the release PR branch.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release PR branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          version: "0.11.17"
+          enable-cache: false # Job can push to a release branch; avoid cache poisoning.
+
+      - name: Sync uv.lock with the bumped version
+        env:
+          BRANCH: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # --upgrade-package (not a bare `uv lock`) so this can only ever move
+          # our own version stamp: the release is already tested, and a bare
+          # lock would be free to pull in any dependency that drifted.
+          uv lock --upgrade-package data-pipeline
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock already in sync with pyproject.toml"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock with released version"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${BRANCH}"
 
   docker-build:
     name: Docker image after release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,10 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: uv run --group test pytest
+        # --locked: error out on a stale uv.lock rather than rewriting it
+        # mid-commit, which trips pre-commit's "files were modified by this
+        # hook" and pushes everyone to --no-verify.
+        entry: uv run --locked --group test pytest
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ help:  ## Show this help message
 
 setup:  ## Install dependencies and pre-commit hooks
 	@echo "📦 Installing dependencies..."
-	uv sync --all-groups
+	# --locked matches CI: fail on a stale uv.lock instead of silently
+	# regenerating it and leaving a dirty tree. Run `uv lock` to refresh.
+	uv sync --locked --all-groups
 	@echo "🔧 Installing pre-commit hooks..."
 	uv run pre-commit install
 


### PR DESCRIPTION
## Summary

`release-please-config.json` bumps only `pyproject.toml`'s version. Nothing regenerates `uv.lock`, which carries its own copy of it — so every release ships a stale lock:

| tag | pyproject | uv.lock |
|---|---|---|
| v1.10.0 | 1.10.0 | 1.8.1 |
| v1.11.0 | 1.11.0 | 1.10.0 |
| v1.11.1 | 1.11.1 | 1.10.0 |
| v1.12.0 | 1.12.0 | 1.10.0 |

#341 fixed the symptom on main; the generator recreated it on the next release PR (#343). CI missed it because `uv sync` without `--locked` regenerates the lock before pre-commit runs.

**Scope of the harm — no shipped artifact was ever wrong.** `docker/Dockerfile` uses `uv sync --frozen --no-editable`, which builds the wheel from `pyproject.toml`, so released images always carried the correct version (verified: under the exact v1.12.0 drift, the installed package reports 1.12.1). The lock's stamp is metadata only. The real cost is developer-facing: `uv sync --locked` can't be adopted at all while drift exists, and the pytest hook's `uv run` rewrites `uv.lock` mid-commit ("files were modified by this hook") — which is what normalised `--no-verify`, and with it the silent loss of unstaged work to pre-commit's stash. That habit disables gitleaks, mypy and tests on every commit, which is the actual reason to fix this.

This is a known class, not a local quirk: [python-semantic-release documents the same problem and remedy for uv](https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration-guides/uv_integration.html) — relock in the release step and commit the lock — and `uv sync --locked` is [uv's own CI example](https://docs.astral.sh/uv/guides/integration/github/).

Three changes, needed together:

1. **`release-please.yml`** — a `sync-release-lock` job relocks and commits `uv.lock` on the release branch. Stops the recurrence. Separate job on purpose: `docker-build` only needs `release-please`, so a transient `uv lock` failure can't skip publishing the release image.
2. **`ci.yml`** — `uv sync --locked` fails loudly on drift. uv pinned to 0.11.17 to match local.
3. **`.pre-commit-config.yaml`** — `uv run --locked` errors on a stale lock instead of rewriting it.
4. **`Makefile`** — `make setup` gets `--locked` too, so CI, the hook and dev setup agree rather than silently regenerating the lock during onboarding.

## For reviewers

CI/release plumbing only; no runtime behavior change, and `uv.lock`/`pyproject.toml` are untouched by this PR.

Verified against #343's real head: `uv sync --locked` fails there, the release step produces exactly the one-line stamp fix (no dependency churn), and the branch then passes. `--locked` already passes on current main, so it won't fail spuriously. zizmor (pedantic) clean.

Two notes:

- **Don't merge #343 as-is** — once this lands, Release Please force-pushes its branch and the relock step re-adds the lock, so it self-heals.
- CI on release PRs isn't self-verifying: runs are created but park at `action_required` pending manual approval (that's why #343 shows no test result). The lock commit this adds is subject to the same gate, so treat `--locked` on normal PRs as the real backstop.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood
  every change and can explain why each is correct.

AI-assisted root-cause tracing and drafting; each claim was verified by execution against the real #343 branch rather than inference.
