### PR TITLE
perf(cleanup): cache the denylist file read (once per path, not per item)

### DIFF
--- a/scripts/s3_item_cleanup.py
+++ b/scripts/s3_item_cleanup.py
@@ -18,6 +18,7 @@ import logging
 import os
 from collections import defaultdict
 from datetime import UTC, datetime
+from functools import cache
 from typing import Any
 from urllib.parse import urlparse
 
@@ -63,19 +64,31 @@ def env_int(name: str, default: int) -> int:
     return int(value) if value else default
 
 
-def load_exclude_ids(path: str | None) -> set[str]:
-    """Read a newline-delimited item-ID denylist. Blank lines and ``#`` comments
-    are ignored. Shared by the cleanup script (``--exclude-file``) and the
-    backfill migration (``EXPIRES_EXCLUDE_FILE``) so the format cannot drift."""
-    if not path:
-        return set()
+@cache
+def _read_denylist(path: str) -> frozenset[str]:
+    """Parse a newline-delimited denylist file into an immutable set. Cached by
+    path: the file is static for a process's lifetime, but the backfill
+    migration resolves the denylist once *per item* over 100k+ items, so caching
+    the file I/O turns 100k+ reads of a tiny file into one."""
     ids: set[str] = set()
     with open(path, encoding="utf-8") as fh:
         for line in fh:
             stripped = line.strip()
             if stripped and not stripped.startswith("#"):
                 ids.add(stripped)
-    return ids
+    return frozenset(ids)
+
+
+def load_exclude_ids(path: str | None) -> set[str]:
+    """Read a newline-delimited item-ID denylist. Blank lines and ``#`` comments
+    are ignored. Shared by the cleanup script (``--exclude-file``) and the
+    backfill migration (``EXPIRES_EXCLUDE_FILE``) so the format cannot drift.
+
+    Returns a fresh mutable set each call; the underlying file read is cached
+    (see ``_read_denylist``)."""
+    if not path:
+        return set()
+    return set(_read_denylist(path))
 
 
 def extract_s3_urls_from_item(item_dict: dict) -> set[str]:

--- a/tests/unit/test_s3_item_cleanup.py
+++ b/tests/unit/test_s3_item_cleanup.py
@@ -235,6 +235,27 @@ class TestLoadExcludeIds:
         f.write_text("item-a\n# a comment\n\nitem-b\n")
         assert load_exclude_ids(str(f)) == {"item-a", "item-b"}
 
+    def test_file_read_is_cached_per_path(self, tmp_path: Path) -> None:
+        # The backfill resolves the denylist once per item over 100k+ items; the
+        # tiny file must not be re-read every time.
+        from s3_item_cleanup import _read_denylist
+
+        _read_denylist.cache_clear()
+        f = tmp_path / "exclude.txt"
+        f.write_text("item-a\nitem-b\n")
+        assert load_exclude_ids(str(f)) == {"item-a", "item-b"}
+        hits_before = _read_denylist.cache_info().hits
+        assert load_exclude_ids(str(f)) == {"item-a", "item-b"}  # second call
+        assert _read_denylist.cache_info().hits == hits_before + 1  # served from cache
+
+    def test_returned_set_is_an_independent_copy(self, tmp_path: Path) -> None:
+        # A caller mutating the result must never corrupt the shared cache.
+        f = tmp_path / "exclude.txt"
+        f.write_text("item-a\n")
+        first = load_exclude_ids(str(f))
+        first.add("mutated")
+        assert load_exclude_ids(str(f)) == {"item-a"}
+
 
 def test_consumers_share_one_format_helper() -> None:
     """Regression guard for the load-bearing format: register and cleanup must


### PR DESCRIPTION
## Summary

Follow-up to the #342 review (performance suggestion). The `stamp_expires` backfill resolves the demo denylist inside `stamp_expires()`, which the migration runner calls **once per item** — so `load_exclude_ids` re-opens and re-parses the same tiny file for every one of the 100k+ catalog items. Register and cleanup call it once per run, but the migration turns it into a hot path.

Move the file read behind a `@cache`'d `_read_denylist(path)` that returns a `frozenset`; `load_exclude_ids` wraps it in a fresh `set` per call so a caller mutating the result can't corrupt the cache. 100k+ reads → one.

## For reviewers

- **Behaviour unchanged:** same ids, still returns a mutable `set`. The file is static for a process's lifetime (single-shot migration / per-item register pods), so caching by path is safe; the wrapper returns an independent copy each call.
- Two regression tests: the file read is served from cache on the second call, and the returned set is an independent copy (caller mutation doesn't leak into the cache).
- Honest scope: the migration is network-bound (DELETE-then-POST per item), so the wall-clock win is small — this is I/O hygiene (don't re-read a constant file in a 100k-iteration loop), not a hot-path rescue.
- Independent of #342; composes with it (its `resolve_exclude_ids` calls `load_exclude_ids`). Whichever merges second may need a trivial rebase in `s3_item_cleanup.py`'s import block.
- Full `s3_item_cleanup` / `migrate` / `cleanup` / `register` suites green; ruff + mypy clean.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted (Claude Code): surfaced during the #342 five-axis review (per-item `_resolve_config` → `load_exclude_ids` file read); the fix caches the read with mutation-safety and is covered by two regression tests.
