### PR TITLE
fix(convert): concurrent-safe source opening — pin data-model v0.10.2 and wire open_source_datatree (#339)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,10 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.3",
-    # Pinned to data-model PR #220 head (concurrent-safe source caching, fixes the fsspec
+    # v0.10.2 ships data-model#220 (concurrent-safe source caching, fixes the fsspec
     # simplecache race behind data-pipeline#339). Chunk-alignment was split out to
     # data-model#221, so quality/atmosphere aot/wvp ship unsharded until that lands.
-    # Re-pin to a release tag once #220 merges + a version is cut.
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@83ab5f2019367aba16162a19c7e9e530997a09cc",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@v0.10.2",
     "requests==2.34.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,10 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.3",
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@v0.10.1",
+    # Pinned to data-model PR #220 head (concurrent-safe source caching + chunk-alignment,
+    # fixes the fsspec simplecache race behind data-pipeline#339). Re-pin to a release tag
+    # once #220 merges + a version is cut.
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@da2f2c1177f9ff4373d0c647e559ae62cc642837",
     "requests==2.34.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,11 @@ dependencies = [
     "tenacity==9.1.4",
     "morecantile==7.0.3",
     "cf-xarray==0.11.3",
-    # Pinned to data-model PR #220 head (concurrent-safe source caching + chunk-alignment,
-    # fixes the fsspec simplecache race behind data-pipeline#339). Re-pin to a release tag
-    # once #220 merges + a version is cut.
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@fbb104b9d681433b7fe5d98edfaf656793d50b25",
+    # Pinned to data-model PR #220 head (concurrent-safe source caching, fixes the fsspec
+    # simplecache race behind data-pipeline#339). Chunk-alignment was split out to
+    # data-model#221, so quality/atmosphere aot/wvp ship unsharded until that lands.
+    # Re-pin to a release tag once #220 merges + a version is cut.
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@83ab5f2019367aba16162a19c7e9e530997a09cc",
     "requests==2.34.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     # Pinned to data-model PR #220 head (concurrent-safe source caching + chunk-alignment,
     # fixes the fsspec simplecache race behind data-pipeline#339). Re-pin to a release tag
     # once #220 merges + a version is cut.
-    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@da2f2c1177f9ff4373d0c647e559ae62cc642837",
+    "eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model.git@fbb104b9d681433b7fe5d98edfaf656793d50b25",
     "requests==2.34.2",
 ]
 

--- a/scripts/convert_v1_s2.py
+++ b/scripts/convert_v1_s2.py
@@ -14,11 +14,11 @@ from urllib.parse import urlparse
 import aiohttp
 import fsspec
 import httpx
-import xarray as xr
 import zarr
 from eopf_geozarr.conversion.fs_utils import (
     get_storage_options,
 )
+from eopf_geozarr.conversion.open_source import open_source_datatree
 from eopf_geozarr.s2_optimization.s2_converter import convert_s2_optimized
 
 # Configure logging (set LOG_LEVEL=DEBUG for verbose output)
@@ -139,18 +139,24 @@ def run_conversion(
     # Load input dataset
     logger.info(f"{'   📥 Loading input dataset '}{zarr_url}")
     storage_options = get_storage_options(str(zarr_url))
+    cache_dir: str | None = None
     if str(zarr_url).startswith("https://"):
-        # fsspec registers `filecache` as WholeFileCacheFileSystem, which is incompatible with
-        # zarr 3's async FsspecStore (no _cat_file on the class). `simplecache` caches each
-        # remote key on local disk once per job; repeated reads (e.g. multiscale) hit the cache.
+        # `open_source_datatree` opens with chunks={} (the store's native chunk
+        # grid), so each on-disk zarr chunk is read by exactly one dask task —
+        # this is what actually closes the concurrent same-key read race
+        # (#339), not the `simplecache` wrapping this used to build by hand.
+        # `cache_dir` gives it an atomic (LocalStore: temp-file + rename)
+        # on-disk cache so repeated reads (e.g. building overview levels)
+        # don't re-fetch from the source; unlike the old `simplecache`, a
+        # concurrent reader can never observe a partially-written entry.
         #
-        # `asynchronous` must be True on both the outer chain and the HTTPS target FS or aiohttp
-        # raises inside the nested cache path.
+        # `asynchronous` must be True on both the outer chain and the HTTPS
+        # target FS or aiohttp raises inside the nested cache path.
         #
         # Do not pass fsspec's `retries`/`backoff_factor` into HTTP storage_options: they end up
         # on aiohttp ClientSession.request() and raise TypeError.
         default_cache = os.path.join(tempfile.gettempdir(), "zarr-source-cache")
-        cache_target = os.environ.get("ZARR_SOURCE_CACHE_DIR", default_cache)
+        cache_dir = os.environ.get("ZARR_SOURCE_CACHE_DIR", default_cache)
         max_conn = int(
             os.environ.get(
                 "ZARR_SOURCE_HTTP_MAX_CONNECTIONS",
@@ -170,20 +176,11 @@ def run_conversion(
             return aiohttp.ClientSession(connector=connector, **{**_extra_client_kwargs, **kwargs})
 
         merged_target["get_client"] = _get_client
-
-        storage_options = {
-            "protocol": "simplecache",
-            "target_protocol": "https",
-            "cache_storage": cache_target,
-            "expiry_time": 3600,
-            "asynchronous": True,
-            "target_options": merged_target,
-        }
-    dt_input = xr.open_datatree(
+        storage_options = merged_target
+    dt_input = open_source_datatree(
         str(zarr_url),
-        engine="zarr",
-        chunks="auto",
         storage_options=storage_options,
+        cache_dir=cache_dir,
     )
 
     try:

--- a/tests/unit/test_convert_v1_s2.py
+++ b/tests/unit/test_convert_v1_s2.py
@@ -90,3 +90,64 @@ def test_no_client_created_when_dask_disabled():
         run_conversion(**args)
 
     mock_setup.assert_called_once()
+
+
+def _open_source_datatree_call_for(zarr_url: str, get_storage_options_return: dict | None = None):
+    """Run a conversion resolving to `zarr_url`; return the open_source_datatree call args.
+
+    Isolates the branch in `run_conversion` that builds `storage_options`/`cache_dir`
+    (HTTPS vs. s3://) from everything else the function does.
+    """
+    mock_open_source_datatree = MagicMock(return_value=MagicMock())
+    mock_fs = MagicMock()
+    mock_fs.rm.side_effect = FileNotFoundError
+
+    with (
+        patch.object(convert_v1_s2, "get_zarr_url", return_value=zarr_url),
+        patch.object(convert_v1_s2, "setup_dask_cluster", return_value=None),
+        patch.object(convert_v1_s2, "get_storage_options", return_value=get_storage_options_return),
+        patch.object(convert_v1_s2, "convert_s2_optimized"),
+        patch("fsspec.filesystem", return_value=mock_fs),
+        patch.object(convert_v1_s2, "open_source_datatree", mock_open_source_datatree),
+    ):
+        run_conversion(**_BASE_ARGS)
+
+    return mock_open_source_datatree.call_args
+
+
+def test_https_source_gets_cache_dir_and_no_simplecache_wrapping():
+    """HTTPS sources must get a cache_dir and plain storage_options.
+
+    `open_source_datatree` owns the atomic on-disk cache now; regressing to the old
+    hand-rolled `simplecache` wrapper here would silently reopen the #339 concurrency
+    race this fix closes (two dask tasks writing the same non-atomic cache file).
+    """
+    call = _open_source_datatree_call_for("https://source.example.com/scene.zarr")
+
+    assert call.kwargs["cache_dir"] is not None
+    storage_options = call.kwargs["storage_options"]
+    assert storage_options["asynchronous"] is True
+    assert callable(storage_options["get_client"])
+    for stale_key in (
+        "protocol",
+        "target_protocol",
+        "cache_storage",
+        "expiry_time",
+        "target_options",
+    ):
+        assert stale_key not in storage_options
+
+
+def test_s3_source_gets_no_cache_dir():
+    """Pre-staged s3:// sources skip open_source_datatree's cache_dir.
+
+    #339 was specifically about the HTTPS simplecache race; s3fs reads don't share a
+    local cache file, so there's nothing for `open_source_datatree`'s CacheStore to
+    protect here (matches the s3:// comment on the CLI entry point below).
+    """
+    call = _open_source_datatree_call_for(
+        "s3://bucket/scene.zarr", get_storage_options_return={"anon": False}
+    )
+
+    assert call.kwargs["cache_dir"] is None
+    assert call.kwargs["storage_options"] == {"anon": False}

--- a/tests/unit/test_convert_v1_s2.py
+++ b/tests/unit/test_convert_v1_s2.py
@@ -37,7 +37,7 @@ def _run_with_mocks(mock_client, convert_side_effect=None):
         patch.object(convert_v1_s2, "get_storage_options", return_value={}),
         patch.object(convert_v1_s2, "convert_s2_optimized", mock_convert),
         patch("fsspec.filesystem", return_value=mock_fs),
-        patch.object(convert_v1_s2.xr, "open_datatree", return_value=MagicMock()),
+        patch.object(convert_v1_s2, "open_source_datatree", return_value=MagicMock()),
         contextlib.suppress(Exception),  # callers that inject side_effect check close() separately
     ):
         run_conversion(**_BASE_ARGS)
@@ -85,7 +85,7 @@ def test_no_client_created_when_dask_disabled():
         patch.object(convert_v1_s2, "get_storage_options", return_value={}),
         patch.object(convert_v1_s2, "convert_s2_optimized"),
         patch("fsspec.filesystem", return_value=mock_fs),
-        patch.object(convert_v1_s2.xr, "open_datatree", return_value=MagicMock()),
+        patch.object(convert_v1_s2, "open_source_datatree", return_value=MagicMock()),
     ):
         run_conversion(**args)
 

--- a/uv.lock
+++ b/uv.lock
@@ -874,7 +874,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.3" },
     { name = "click", specifier = "==8.4.2" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=v0.10.1" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=da2f2c1177f9ff4373d0c647e559ae62cc642837" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "morecantile", specifier = "==7.0.3" },
     { name = "pystac", specifier = "==1.15.1" },
@@ -994,7 +994,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.1"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=v0.10.1#49f18e77f54d2d0dbb89d25f7f5b4b206ede3988" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=da2f2c1177f9ff4373d0c647e559ae62cc642837#da2f2c1177f9ff4373d0c647e559ae62cc642837" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },
@@ -4082,11 +4082,14 @@ cast-value-rs = [
 
 [[package]]
 name = "zarr-cm"
-version = "0.2.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/40/99c941d23a7cd84fb194b3eaa2ca2d0d85f5135aa07e2c4f2c12febfef43/zarr_cm-0.2.0.tar.gz", hash = "sha256:737f5b181e8a2456643c423f49b59d879531498c13c7345860f0e718ef73d8a8", size = 24773, upload-time = "2026-02-06T14:47:57.588Z" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/c6/51d38cafa07bdf725c77a67719647eea43255f925fda062b40799bbb361d/zarr_cm-0.4.1.tar.gz", hash = "sha256:693d24ca2b8e3a7230e1ed448c2c57f98833b81e5899607b6cb4a7ac31f94002", size = 50839, upload-time = "2026-06-21T19:20:36.277Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/60/06c371c10a321db63ec46634c9498a3c491754214c0e3bfc27410c528d99/zarr_cm-0.2.0-py3-none-any.whl", hash = "sha256:7f4c778d70d37ccb6e10e1509f4c0a488689027dcebcd6b64fa89a899f101e11", size = 14222, upload-time = "2026-02-06T14:47:56.465Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/14/3de8976647909b2f6764b8d0c9add0a961667ef4ab46f3f99e12d7a522fa/zarr_cm-0.4.1-py3-none-any.whl", hash = "sha256:2c7f36383af2e6f75eb274a797a13154fd5c5827390de7c79294dfeb9f0543ee", size = 33005, upload-time = "2026-06-21T19:20:35.05Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -874,7 +874,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.3" },
     { name = "click", specifier = "==8.4.2" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=fbb104b9d681433b7fe5d98edfaf656793d50b25" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=83ab5f2019367aba16162a19c7e9e530997a09cc" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "morecantile", specifier = "==7.0.3" },
     { name = "pystac", specifier = "==1.15.1" },
@@ -994,7 +994,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.1"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=fbb104b9d681433b7fe5d98edfaf656793d50b25#fbb104b9d681433b7fe5d98edfaf656793d50b25" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=83ab5f2019367aba16162a19c7e9e530997a09cc#83ab5f2019367aba16162a19c7e9e530997a09cc" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -874,7 +874,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.3" },
     { name = "click", specifier = "==8.4.2" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=83ab5f2019367aba16162a19c7e9e530997a09cc" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=v0.10.2" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "morecantile", specifier = "==7.0.3" },
     { name = "pystac", specifier = "==1.15.1" },
@@ -993,8 +993,8 @@ wheels = [
 
 [[package]]
 name = "eopf-geozarr"
-version = "0.10.1"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=83ab5f2019367aba16162a19c7e9e530997a09cc#83ab5f2019367aba16162a19c7e9e530997a09cc" }
+version = "0.10.2"
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=v0.10.2#cc8766411e681e5513cf7f6b447c29a1a66c6247" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -874,7 +874,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.42.89" },
     { name = "cf-xarray", specifier = "==0.11.3" },
     { name = "click", specifier = "==8.4.2" },
-    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=da2f2c1177f9ff4373d0c647e559ae62cc642837" },
+    { name = "eopf-geozarr", git = "https://github.com/EOPF-Explorer/data-model.git?rev=fbb104b9d681433b7fe5d98edfaf656793d50b25" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "morecantile", specifier = "==7.0.3" },
     { name = "pystac", specifier = "==1.15.1" },
@@ -994,7 +994,7 @@ wheels = [
 [[package]]
 name = "eopf-geozarr"
 version = "0.10.1"
-source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=da2f2c1177f9ff4373d0c647e559ae62cc642837#da2f2c1177f9ff4373d0c647e559ae62cc642837" }
+source = { git = "https://github.com/EOPF-Explorer/data-model.git?rev=fbb104b9d681433b7fe5d98edfaf656793d50b25#fbb104b9d681433b7fe5d98edfaf656793d50b25" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },


### PR DESCRIPTION
Pins `eopf-geozarr` v0.10.1 → **v0.10.2** (released today; ships EOPF-Explorer/data-model#220) — concurrent-safe source caching that fixes the fsspec simplecache race behind #339 (`blosc decompression` errors on cpm_v270 single-chunk sources) — and wires `scripts/convert_v1_s2.py` to actually call the new `open_source_datatree` ([`fd26e95`](https://github.com/EOPF-Explorer/data-pipeline/commit/fd26e9591c4d0c6c5dce56df327bc46ec0d143f6), tests in [`9dde9ca`](https://github.com/EOPF-Explorer/data-pipeline/commit/9dde9ca6a3a504cc61edb5dd1fde17c674813e70)), which the earlier pin updated as a dependency but never invoked — so the race was still live. Also regenerates `uv.lock` (`zarr-cm 0.2.0→0.4.1`). **Validated end-to-end in `devseed-staging` on 6 `cpm_v270` scenes (incl. both that motivated #339): 6/6 converted on the first attempt, zero `blosc` errors.**

## For reviewers

- The E2E ran against #220's branch head (`83ab5f2`); the release pin adds only EOPF-Explorer/data-model#199 (zarr-conventions bump + pyright migration) and CI dep bumps on top. 403 unit tests pass against `v0.10.2`.
- **This ships an aot/wvp layout regression.** The output-chunk clamp was split out to EOPF-Explorer/data-model#221 (draft). Without it, `quality/atmosphere` `aot`/`wvp` at r10m/r20m write **unsharded** whole-array chunks (verified: 36/36 arrays `SHARDED: False`), losing byte-range partial reads for tiled serving until EOPF-Explorer/data-model#221 lands. Accepted deliberately to get the CacheStore fix now.
- **`CacheStore` never expires entries**, unlike the old hand-rolled `simplecache` (1h `expiry_time`). Moot for one-shot Argo pods, but relevant if the cache dir ever becomes a longer-lived or shared volume.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted (bump + lock + text + wiring fix + staging validation); reviewed by me.
