### PR TITLE
feat(image): bake operator-tools/ into the runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 .github
 tests/
 notebooks/
-operator-tools/
 tasks/
 *.ipynb
 *.md

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,6 +42,7 @@ RUN adduser -D -h /home/appuser -s /bin/sh appuser
 WORKDIR /app
 
 COPY scripts/ /app/scripts/
+COPY operator-tools/ /app/operator-tools/
 # Remove test helpers (no purpose in production) and set ownership in one layer
 RUN find /app/scripts -name 'test_*.py' -delete \
     && chown -R appuser:appuser /app

--- a/scripts/s3_item_cleanup.py
+++ b/scripts/s3_item_cleanup.py
@@ -3,9 +3,9 @@
 
 Extracted from ``operator-tools/manage_item.py`` (coordination#183) so both the
 operator CLIs and the ``scripts/``-hosted cleanup cron can share one
-recursive-delete implementation. ``scripts/`` is baked into the pipeline image
-(``docker/Dockerfile``) whereas ``operator-tools/`` is not, so this module must
-not depend on ``click`` — batch progress is emitted through ``logging``.
+recursive-delete implementation. This module must not depend on ``click``
+(unlike the operator CLIs) so the cleanup cron's minimal env stays lean —
+batch progress is emitted through ``logging`` instead.
 
 Behaviour preserved from the original:
 - assets are resolved to S3 URLs via ``alternate.s3.href`` then main ``href``

--- a/tests/unit/test_docker_image_layout.py
+++ b/tests/unit/test_docker_image_layout.py
@@ -1,0 +1,45 @@
+"""Static checks that `operator-tools/` is baked into the runtime image.
+
+coordination#183: the in-cluster `stamp_expires` backfill needs
+`operator-tools/migrate_catalog.py` inside the image, as a sibling of the
+already-baked `scripts/` directory. These tests pin the two file edits that
+make that true; the actual build is verified separately with `docker build`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _dockerignore_lines() -> list[str]:
+    return (REPO_ROOT / ".dockerignore").read_text().splitlines()
+
+
+def _dockerfile_lines() -> list[str]:
+    return (REPO_ROOT / "docker" / "Dockerfile").read_text().splitlines()
+
+
+def test_dockerignore_does_not_exclude_operator_tools():
+    lines = {line.strip() for line in _dockerignore_lines()}
+    assert "operator-tools/" not in lines
+
+
+def test_dockerfile_copies_operator_tools_as_sibling_of_scripts():
+    lines = [line.strip() for line in _dockerfile_lines()]
+    assert "COPY scripts/ /app/scripts/" in lines
+    assert "COPY operator-tools/ /app/operator-tools/" in lines
+
+    scripts_idx = lines.index("COPY scripts/ /app/scripts/")
+    operator_tools_idx = lines.index("COPY operator-tools/ /app/operator-tools/")
+    assert operator_tools_idx > scripts_idx
+
+
+def test_dockerfile_chown_runs_after_both_copies():
+    text = "\n".join(_dockerfile_lines())
+    scripts_pos = text.index("COPY scripts/ /app/scripts/")
+    operator_tools_pos = text.index("COPY operator-tools/ /app/operator-tools/")
+    chown_pos = text.index("chown -R appuser:appuser /app")
+    assert scripts_pos < chown_pos
+    assert operator_tools_pos < chown_pos


### PR DESCRIPTION
Bakes operator-tools/ into the pipeline image as a sibling of scripts/ under /app, so the coordination#183 stamp_expires backfill can run in-cluster (near prod STAC, no laptop-sleep interruptions) instead of from a laptop. No dependency or code changes — deps are already in the image venv.

Verified: `docker build` + `migrate_catalog.py --help`/`list` in-image, sys.path import check, non-root ownership, full test suite (479 passed).

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted (Claude Code): implemented Part A of a pre-approved plan (.dockerignore + Dockerfile edit, static layout test, stale-comment fix), reviewed diff and verification output before commit.