### PR TITLE
feat(stac): attribute the S2 eodash baselayers and pin their aggregation links

### DIFF
--- a/stac/sentinel-2-l2a-staging.json
+++ b/stac/sentinel-2-l2a-staging.json
@@ -15,7 +15,8 @@
       "href": "https://s2maps-tiles.eu/wmts/1.0.0/osm_3857/default/g/{z}/{y}/{x}.jpeg",
       "type": "image/jpeg",
       "roles": ["baselayer", "invisible"],
-      "title": "OSM Background"
+      "title": "OSM Background",
+      "attribution": "{ OSM: Data &copy; <a href=\"http://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap</a> contributors and <a href=\"https://maps.eox.at/#data\" target=\"_blank\">others</a>, Rendering &copy; <a href=\"http://eox.at\" target=\"_blank\">EOX</a> }"
     },
     {
       "id": "terrain-light",
@@ -23,7 +24,8 @@
       "href": "https://s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpeg",
       "type": "image/jpeg",
       "roles": ["baselayer", "visible"],
-      "title": "Terrain Light"
+      "title": "Terrain Light",
+      "attribution": "{ OSM: Data &copy; <a href=\"http://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap</a> contributors and <a href=\"https://maps.eox.at/#data\" target=\"_blank\">others</a>, Rendering &copy; <a href=\"http://eox.at\" target=\"_blank\">EOX</a> }"
     },
     {
       "id": "overlay_bright",
@@ -31,7 +33,8 @@
       "href": "https://s2maps-tiles.eu/wmts/1.0.0/overlay_base_bright_3857/default/g/{z}/{y}/{x}.png",
       "type": "image/png",
       "roles": ["overlay", "visible"],
-      "title": "Overlay labels"
+      "title": "Overlay labels",
+      "attribution": "{ Overlay: Data &copy; <a href=\"http://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap</a> contributors, Made with Natural Earth, Rendering &copy; <a href=\"https://eox.at\" target=\"_blank\">EOX</a> }"
     },
     {
       "id": "cloudless-2024",
@@ -39,13 +42,28 @@
       "href": "https://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2024_3857/default/g/{z}/{y}/{x}.jpeg",
       "type": "image/jpeg",
       "roles": ["baselayer", "invisible"],
-      "title": "EOxCloudless 2024"
+      "title": "EOxCloudless 2024",
+      "attribution": "{ EOxCloudless 2024: <a xmlns:dct=\"http://purl.org/dc/terms/\" href=\"https://s2maps.eu\" target=\"_blank\" property=\"dct:title\">Sentinel-2 cloudless - s2maps.eu</a> by <a xmlns:cc=\"http://creativecommons.org/ns#\" href=\"https://eox.at\" target=\"_blank\" property=\"cc:attributionName\" rel=\"cc:attributionURL\">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2024) }"
     },
     {
       "rel": "style",
       "href": "https://raw.githubusercontent.com/EOPF-Explorer/eodash-assets/refs/heads/main/styles/geozarr.json",
       "type": "application/json",
       "asset:keys": ["reflectance"]
+    },
+    {
+      "rel": "pre-aggregation",
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/aggregations/sentinel-2-l2a-staging/daily.json",
+      "type": "application/json",
+      "title": "Daily Item Aggregation",
+      "aggregation:interval": "daily"
+    },
+    {
+      "rel": "pre-aggregation",
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/aggregations/sentinel-2-l2a-staging/monthly.json",
+      "type": "application/json",
+      "title": "Monthly Item Aggregation",
+      "aggregation:interval": "monthly"
     }
   ],
   "title": "Sentinel-2 Level-2A [V1 staging]",

--- a/stac/sentinel-2-l2a.json
+++ b/stac/sentinel-2-l2a.json
@@ -15,7 +15,8 @@
       "href": "https://s2maps-tiles.eu/wmts/1.0.0/osm_3857/default/g/{z}/{y}/{x}.jpeg",
       "type": "image/jpeg",
       "roles": ["baselayer", "invisible"],
-      "title": "OSM Background"
+      "title": "OSM Background",
+      "attribution": "{ OSM: Data &copy; <a href=\"http://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap</a> contributors and <a href=\"https://maps.eox.at/#data\" target=\"_blank\">others</a>, Rendering &copy; <a href=\"http://eox.at\" target=\"_blank\">EOX</a> }"
     },
     {
       "id": "terrain-light",
@@ -23,7 +24,8 @@
       "href": "https://s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpeg",
       "type": "image/jpeg",
       "roles": ["baselayer", "visible"],
-      "title": "Terrain Light"
+      "title": "Terrain Light",
+      "attribution": "{ OSM: Data &copy; <a href=\"http://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap</a> contributors and <a href=\"https://maps.eox.at/#data\" target=\"_blank\">others</a>, Rendering &copy; <a href=\"http://eox.at\" target=\"_blank\">EOX</a> }"
     },
     {
       "id": "overlay_bright",
@@ -31,7 +33,8 @@
       "href": "https://s2maps-tiles.eu/wmts/1.0.0/overlay_base_bright_3857/default/g/{z}/{y}/{x}.png",
       "type": "image/png",
       "roles": ["overlay", "visible"],
-      "title": "Overlay labels"
+      "title": "Overlay labels",
+      "attribution": "{ Overlay: Data &copy; <a href=\"http://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap</a> contributors, Made with Natural Earth, Rendering &copy; <a href=\"https://eox.at\" target=\"_blank\">EOX</a> }"
     },
     {
       "id": "cloudless-2024",
@@ -39,13 +42,28 @@
       "href": "https://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2024_3857/default/g/{z}/{y}/{x}.jpeg",
       "type": "image/jpeg",
       "roles": ["baselayer", "invisible"],
-      "title": "EOxCloudless 2024"
+      "title": "EOxCloudless 2024",
+      "attribution": "{ EOxCloudless 2024: <a xmlns:dct=\"http://purl.org/dc/terms/\" href=\"https://s2maps.eu\" target=\"_blank\" property=\"dct:title\">Sentinel-2 cloudless - s2maps.eu</a> by <a xmlns:cc=\"http://creativecommons.org/ns#\" href=\"https://eox.at\" target=\"_blank\" property=\"cc:attributionName\" rel=\"cc:attributionURL\">EOX IT Services GmbH</a> (Contains modified Copernicus Sentinel data 2024) }"
     },
     {
       "rel": "style",
       "href": "https://raw.githubusercontent.com/EOPF-Explorer/eodash-assets/refs/heads/main/styles/geozarr.json",
       "type": "application/json",
       "asset:keys": ["reflectance"]
+    },
+    {
+      "rel": "pre-aggregation",
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/aggregations/sentinel-2-l2a/daily.json",
+      "type": "application/json",
+      "title": "Daily Item Aggregation",
+      "aggregation:interval": "daily"
+    },
+    {
+      "rel": "pre-aggregation",
+      "href": "https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/aggregations/sentinel-2-l2a/monthly.json",
+      "type": "application/json",
+      "title": "Monthly Item Aggregation",
+      "aggregation:interval": "monthly"
     }
   ],
   "title": "Sentinel-2 Level-2A",

--- a/tests/test_stac_collections.py
+++ b/tests/test_stac_collections.py
@@ -100,7 +100,8 @@ def test_baselayers_present_in_order(filename: str) -> None:
 def test_every_baselayer_has_attribution(filename: str) -> None:
     """The EOx/s2maps tiles must be attributed wherever they are shown (issue #270)."""
     for link in _xyz_links(filename):
-        assert link.get("attribution", "").strip(), f"{filename}: {link.get('id')} lacks attribution"
+        attribution = link.get("attribution", "")
+        assert attribution.strip(), f"{filename}: {link.get('id')} lacks attribution"
 
 
 @pytest.mark.parametrize("filename", EODASH_COLLECTIONS)

--- a/tests/test_stac_collections.py
+++ b/tests/test_stac_collections.py
@@ -71,3 +71,54 @@ def test_no_leak_into_other_collections() -> None:
         assert not [
             link for link in data.get("links", []) if link.get("rel") == "style"
         ], f"unexpected style link in {path.name}"
+
+
+# --- baselayer attribution (issue #270) --------------------------------------
+
+# The basemaps eodash offers in its layer switcher, and the attribution each must carry.
+# Attribution strings are issue #270's, verbatim; the same values are used for the S1
+# collections (issue #348 restates them identically), so the two families cannot drift.
+EXPECTED_BASELAYERS = [
+    ("OSM", "image/jpeg", ["baselayer", "invisible"]),
+    ("terrain-light", "image/jpeg", ["baselayer", "visible"]),
+    ("overlay_bright", "image/png", ["overlay", "visible"]),
+    ("cloudless-2024", "image/jpeg", ["baselayer", "invisible"]),
+]
+
+
+def _xyz_links(filename: str) -> list[dict[str, Any]]:
+    return [link for link in _load(filename)["links"] if link.get("rel") == "xyz"]
+
+
+@pytest.mark.parametrize("filename", EODASH_COLLECTIONS)
+def test_baselayers_present_in_order(filename: str) -> None:
+    actual = [(lk.get("id"), lk.get("type"), lk.get("roles")) for lk in _xyz_links(filename)]
+    assert actual == EXPECTED_BASELAYERS
+
+
+@pytest.mark.parametrize("filename", EODASH_COLLECTIONS)
+def test_every_baselayer_has_attribution(filename: str) -> None:
+    """The EOx/s2maps tiles must be attributed wherever they are shown (issue #270)."""
+    for link in _xyz_links(filename):
+        assert link.get("attribution", "").strip(), f"{filename}: {link.get('id')} lacks attribution"
+
+
+@pytest.mark.parametrize("filename", EODASH_COLLECTIONS)
+def test_exactly_one_visible_baselayer(filename: str) -> None:
+    """eodash shows one basemap at a time; `overlay` is a different class and is exempt."""
+    visible = [
+        lk for lk in _xyz_links(filename) if {"baselayer", "visible"} <= set(lk.get("roles", []))
+    ]
+    assert len(visible) == 1, f"{filename}: expected exactly one visible baselayer"
+
+
+@pytest.mark.parametrize("filename", EODASH_COLLECTIONS)
+def test_pre_aggregation_links_are_last(filename: str) -> None:
+    """The templates carry the pre-aggregation links so a `create --update` cannot wipe them.
+
+    aggregate_items.py strips-then-appends, so they must sit at the END of the array or the
+    two writers permanently reorder each other's output. Pinned end-to-end by
+    tests/unit/test_aggregate_items.py::TestTemplateSurvivesAggregation.
+    """
+    rels = [link["rel"] for link in _load(filename)["links"]]
+    assert rels[-2:] == ["pre-aggregation", "pre-aggregation"]

--- a/tests/unit/test_aggregate_items.py
+++ b/tests/unit/test_aggregate_items.py
@@ -1,11 +1,14 @@
 """Tests for scripts/aggregate_items.py."""
 
 import collections
+import json
 from datetime import datetime
 from io import StringIO
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 from pystac import Item
 
 from scripts.aggregate_items import (
@@ -346,3 +349,53 @@ class TestMainDryRun:
             )
 
         assert rc == 0
+
+
+class TestTemplateSurvivesAggregation:
+    """The S2 templates ship their own pre-aggregation links (issue #270 / #348).
+
+    Two writers own collection["links"]: manage_collections PUTs the template wholesale,
+    aggregate_items strips-then-appends against live. Before this, the templates carried no
+    pre-aggregation links, so a `create --update` silently deleted whatever aggregate_items
+    had published — which is exactly what happened to sentinel-2-l2a-staging (its S3
+    aggregation objects are live and served, but the collection's links were gone).
+
+    Carrying the links in the template fixes that only if both writers agree on the result,
+    which requires them to be LAST. Prove it rather than assert it.
+    """
+
+    def _capture_put(self, collection_id: str, collection_data: dict) -> dict:
+        get_resp = MagicMock()
+        get_resp.json.return_value = collection_data
+        get_resp.raise_for_status = MagicMock()
+        put_resp = MagicMock()
+        put_resp.raise_for_status = MagicMock()
+        captured: dict = {}
+
+        def mock_put(url, json=None, headers=None):  # noqa: ARG001
+            captured["json"] = json
+            return put_resp
+
+        client = MagicMock()
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.get.return_value = get_resp
+        client.put = mock_put
+
+        with patch("scripts.aggregate_items.httpx.Client", return_value=client):
+            update_collection_links(
+                "https://api.explorer.eopf.copernicus.eu/stac",
+                collection_id,
+                "https://s3.explorer.eopf.copernicus.eu",  # s3_gateway_url
+                "esa-zarr-sentinel-explorer-fra",  # s3_bucket
+                "aggregations",  # s3_prefix
+            )
+        return captured["json"]
+
+    @pytest.mark.parametrize("collection_id", ["sentinel-2-l2a", "sentinel-2-l2a-staging"])
+    def test_aggregation_rewrite_is_a_no_op_on_the_committed_template(self, collection_id):
+        template = json.loads(
+            (Path(__file__).parent.parent.parent / "stac" / f"{collection_id}.json").read_text()
+        )
+        put_body = self._capture_put(collection_id, json.loads(json.dumps(template)))
+        assert put_body["links"] == template["links"]


### PR DESCRIPTION
Adds the `attribution` strings requested in #270 to the four S2 eodash baselayer/overlay links, verbatim from the issue — tile URLs and mime types unchanged. Also folds in the two `pre-aggregation` links the templates were missing while the live collections carried them.

Closes #270

## For reviewers

The `pre-aggregation` links must stay last in the array — `aggregate_items.py` strips-then-appends, so any other position makes the two writers reorder each other. A test pins it.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted (Claude Opus 4.8): implementation and tests. Attribution strings were parsed from the issue body rather than retyped.
