### PR TITLE
fix(cleanup): authenticate STAC DELETE in cleanup_expired_items

### DIFF
--- a/scripts/cleanup_expired_items.py
+++ b/scripts/cleanup_expired_items.py
@@ -32,6 +32,7 @@ from urllib.parse import urlparse
 
 import boto3
 import requests
+import stac_auth
 from botocore.exceptions import ClientError
 from pystac_client import Client
 from s3_item_cleanup import (
@@ -228,14 +229,15 @@ def process_item(
 
 
 def _session(stac_api_url: str) -> requests.Session:
-    """Build the STAC HTTP session.
+    """Build the STAC HTTP session with a fresh Bearer per request.
 
-    Auth seam: when the stac-auth-proxy branch lands, wire the bearer token
-    here (2-line change) — e.g. ``import stac_auth; stac_auth.apply(session)``.
-    Today it is an unauthenticated session, matching main.
+    ``bearer_auth`` re-reads the cached token on every request (refreshed near
+    expiry), so a long cleanup batch can't send a stale one. A no-op when the
+    OIDC env is unset — pre-enforcement runs are unchanged.
     """
     session = requests.Session()
     session.headers.update({"Content-Type": "application/json"})
+    session.auth = stac_auth.bearer_auth
     return session
 
 

--- a/tests/unit/test_write_sites_authenticated.py
+++ b/tests/unit/test_write_sites_authenticated.py
@@ -131,6 +131,21 @@ def test_manage_item_session_unauthenticated_without_env():
     assert _auth_header_on_write(mgr.session) is None
 
 
+def test_cleanup_expired_items_session_authenticated(oidc_env, token_response):
+    import cleanup_expired_items
+
+    session = cleanup_expired_items._session("https://api.test/stac")
+    with patch("stac_auth.httpx.post", return_value=token_response()):
+        assert _auth_header_on_write(session) == "Bearer test-token"
+
+
+def test_cleanup_expired_items_session_unauthenticated_without_env():
+    import cleanup_expired_items
+
+    session = cleanup_expired_items._session("https://api.test/stac")
+    assert _auth_header_on_write(session) is None
+
+
 # --- Delegation: pystac write sites open via the helper ----------------------
 
 


### PR DESCRIPTION
Wires `session.auth = stac_auth.bearer_auth` into `cleanup_expired_items.py`'s STAC session — a full audit of every outbound STAC write in the shipped `scripts/` found this was the **only** site left unauthenticated (all register_*, update_stac_storage_tier, wipe_s1rtc_tiles go through `stac_auth.open_client`; aggregate_items uses `auth_headers()`). Without it, the historical-cleanup cron would delete S3 objects then 401 on the STAC DELETE once the stac-auth-proxy enforcement flips (EOPF-Explorer/platform-deploy#299). No-op when the OIDC env is unset, so pre-enforcement runs are unchanged.

Adds the two auth-coverage tests that were missing for this write site.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted: gap found by an audit of all STAC write sites with Claude Code, fix + tests reviewed via `git diff`; full unit suite (913 passed) and pre-commit green.
