### PR TITLE
fix(storage-tier): never select demo scenes for tier migration

### DIFF
--- a/scripts/query_storage_tier_items.py
+++ b/scripts/query_storage_tier_items.py
@@ -5,6 +5,11 @@ Searches for items in a 36h time window around age_days, filters out items
 already at the target storage tier (via storage:refs metadata), and caps
 output at max_batch_size. Outputs JSON array of item IDs to stdout for
 Argo withParam.
+
+Demo scenes are never selected: the same denylist that protects them from
+expiry cleanup (``--exclude-file`` → ``$EXPIRES_EXCLUDE_FILE`` → the baked
+``demo_exclude_ids.txt``) is applied here so the tier-down cron cannot move
+a demo scene off the performance tier when it crosses the age threshold.
 """
 
 from __future__ import annotations
@@ -18,6 +23,7 @@ from datetime import UTC, datetime, timedelta
 
 from pystac import Item
 from pystac_client import Client
+from s3_item_cleanup import resolve_exclude_ids
 from update_stac_storage_tier import TIER_TO_SCHEME
 
 # Configure logging
@@ -87,11 +93,13 @@ def query_items(
     age_days: int,
     target_storage_ref: str,
     max_batch_size: int,
+    exclude_ids: set[str] | frozenset[str] = frozenset(),
 ) -> list[str]:
     """Query STAC and return item IDs needing storage tier change.
 
     Queries a 36h time window (age_days-0.5 to age_days+1 days old),
-    filters out already-migrated items, and caps at max_batch_size.
+    filters out already-migrated and excluded items, and caps at
+    max_batch_size.
 
     Args:
         stac_api_url: STAC API base URL.
@@ -99,6 +107,7 @@ def query_items(
         age_days: Target age in days for storage tier transition.
         target_storage_ref: The storage:refs value indicating target tier.
         max_batch_size: Maximum number of items to return.
+        exclude_ids: Item IDs that must never be selected (demo denylist).
 
     Returns:
         List of item IDs needing storage tier change.
@@ -120,12 +129,15 @@ def query_items(
 
     total_found = 0
     already_migrated = 0
+    excluded = 0
     need_work: list[str] = []
 
     for page in search.pages():
         for item in page.items:
             total_found += 1
-            if is_already_migrated(item, target_storage_ref):
+            if item.id in exclude_ids:
+                excluded += 1
+            elif is_already_migrated(item, target_storage_ref):
                 already_migrated += 1
             else:
                 need_work.append(item.id)
@@ -133,6 +145,7 @@ def query_items(
     capped = need_work[:max_batch_size]
     logger.info(f"Total found: {total_found}")
     logger.info(f"Already migrated: {already_migrated}")
+    logger.info(f"Excluded (demo denylist): {excluded}")
     logger.info(f"Need work: {len(need_work)}")
     logger.info(f"Processing (capped at {max_batch_size}): {len(capped)}")
 
@@ -159,6 +172,14 @@ def main(argv: list[str] | None = None) -> int:
         default=100,
         help="Maximum number of items to return (default: 100)",
     )
+    parser.add_argument(
+        "--exclude-file",
+        default=None,
+        help=(
+            "Path to a denylist of item IDs that must never be selected. "
+            "Falls back to $EXPIRES_EXCLUDE_FILE, then the baked demo_exclude_ids.txt."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -170,6 +191,7 @@ def main(argv: list[str] | None = None) -> int:
             age_days=args.age_days,
             target_storage_ref=target_storage_ref,
             max_batch_size=args.max_batch_size,
+            exclude_ids=resolve_exclude_ids(args.exclude_file),
         )
         sys.stdout.write(json.dumps(items))
         sys.stdout.flush()

--- a/scripts/submit_storage_tier_workflows.py
+++ b/scripts/submit_storage_tier_workflows.py
@@ -24,6 +24,7 @@ from pystac_client import Client
 # The tier-aware selection reuses the proven client-side predicate and tier map
 # from the same scripts/ package (both are on the path in-image and under pytest).
 from query_storage_tier_items import is_already_migrated
+from s3_item_cleanup import resolve_exclude_ids
 from update_stac_storage_tier import TIER_TO_SCHEME
 
 logging.basicConfig(
@@ -139,6 +140,7 @@ def query_stac_items(
     window_end: str,
     date_field: str = "datetime",
     target_storage_ref: str | None = None,
+    exclude_ids: set[str] | frozenset[str] = frozenset(),
 ) -> list[str]:
     """Query STAC for items whose ``date_field`` falls in the window. Returns item IDs.
 
@@ -155,6 +157,10 @@ def query_stac_items(
     target tier, using the same asset-level ``storage:refs`` check as the optimizer
     (``is_already_migrated``). This keeps a recurring run cheap and makes a re-run a
     zero-item no-op. When ``None`` no tier filter is applied.
+
+    ``exclude_ids`` are never selected regardless of window or tier — the demo
+    denylist, so the recurring tier-down cannot move a protected scene off the
+    performance tier (a reconversion re-arms the ``created`` age band 90 days out).
     """
     catalog = Client.open(stac_api_url)
     if window_start is None:
@@ -181,11 +187,18 @@ def query_stac_items(
             filter_lang="cql2-json",
             limit=100,
         )
-    if target_storage_ref is not None:
-        return [
-            item.id for item in search.items() if not is_already_migrated(item, target_storage_ref)
-        ]
-    return [item.id for item in search.items()]
+    selected: list[str] = []
+    excluded = 0
+    for item in search.items():
+        if item.id in exclude_ids:
+            excluded += 1
+            continue
+        if target_storage_ref is not None and is_already_migrated(item, target_storage_ref):
+            continue
+        selected.append(item.id)
+    if excluded:
+        logger.info(f"  Excluded {excluded} denylisted item(s) (demo protection)")
+    return selected
 
 
 def submit_batch(webhook_url: str, payload: dict[str, object], dry_run: bool) -> bool:
@@ -269,8 +282,18 @@ def main() -> None:
     parser.add_argument(
         "--delay", type=float, default=1.0, help="Delay between window submissions in seconds"
     )
+    parser.add_argument(
+        "--exclude-file",
+        default=None,
+        help=(
+            "Path to a denylist of item IDs that must never be selected. "
+            "Falls back to $EXPIRES_EXCLUDE_FILE, then the baked demo_exclude_ids.txt."
+        ),
+    )
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
+
+    exclude_ids = resolve_exclude_ids(args.exclude_file)
 
     try:
         start_date, end_date = resolve_window_bounds(
@@ -325,6 +348,7 @@ def main() -> None:
             window_end,
             date_field,
             target_storage_ref,
+            exclude_ids=exclude_ids,
         )
         if not item_ids:
             logger.info("  Found 0 items — skipping")

--- a/tests/unit/test_query_storage_tier_items.py
+++ b/tests/unit/test_query_storage_tier_items.py
@@ -186,6 +186,33 @@ class TestQueryItems:
 
         assert result == []
 
+    def test_excluded_ids_never_selected(self):
+        """Items on the demo denylist are skipped even when they need work."""
+        items = [
+            create_stac_item("demo-1", storage_refs=["standard"]),  # needs work but excluded
+            create_stac_item("item-2", storage_refs=["standard"]),  # needs work
+        ]
+        client = FakeStacClient(items)
+
+        with patch("scripts.query_storage_tier_items.Client.open", return_value=client):
+            result = query_items(
+                STAC_API_URL, COLLECTION, 7, "glacier", 100, exclude_ids={"demo-1"}
+            )
+
+        assert result == ["item-2"]
+
+    def test_exclusion_does_not_consume_batch_capacity(self):
+        """Excluded items must not eat into max_batch_size."""
+        items = [create_stac_item("demo-1", storage_refs=["standard"])] + [
+            create_stac_item(f"item-{i}", storage_refs=["standard"]) for i in range(3)
+        ]
+        client = FakeStacClient(items)
+
+        with patch("scripts.query_storage_tier_items.Client.open", return_value=client):
+            result = query_items(STAC_API_URL, COLLECTION, 7, "glacier", 3, exclude_ids={"demo-1"})
+
+        assert result == ["item-0", "item-1", "item-2"]
+
 
 # --- Tests for main ---
 
@@ -270,6 +297,68 @@ class TestMain:
         assert exit_code == 0
         output = json.loads(stdout.getvalue())
         assert len(output) == 100
+
+    def test_baked_demo_denylist_applied_by_default(self, monkeypatch):
+        """Without --exclude-file or env var, the baked demo list still protects."""
+        monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
+        demo_id = "S2C_MSIL2A_20250512T100611_N0511_R022_T32TQR_20250512T173114"
+        items = [
+            create_stac_item(demo_id, storage_refs=["performance"]),  # baked demo id
+            create_stac_item("item-2", storage_refs=["performance"]),
+        ]
+        client = FakeStacClient(items)
+
+        with (
+            patch("scripts.query_storage_tier_items.Client.open", return_value=client),
+            patch("sys.stdout", new_callable=StringIO) as stdout,
+        ):
+            exit_code = main(
+                [
+                    "--stac-api-url",
+                    STAC_API_URL,
+                    "--collection",
+                    COLLECTION,
+                    "--age-days",
+                    "180",
+                    "--to-storage-class",
+                    "STANDARD",
+                ]
+            )
+
+        assert exit_code == 0
+        assert json.loads(stdout.getvalue()) == ["item-2"]
+
+    def test_explicit_exclude_file(self, tmp_path):
+        """--exclude-file takes precedence and is honored."""
+        exclude_file = tmp_path / "exclude.txt"
+        exclude_file.write_text("# comment\nitem-1\n")
+        items = [
+            create_stac_item("item-1", storage_refs=["standard"]),
+            create_stac_item("item-2", storage_refs=["standard"]),
+        ]
+        client = FakeStacClient(items)
+
+        with (
+            patch("scripts.query_storage_tier_items.Client.open", return_value=client),
+            patch("sys.stdout", new_callable=StringIO) as stdout,
+        ):
+            exit_code = main(
+                [
+                    "--stac-api-url",
+                    STAC_API_URL,
+                    "--collection",
+                    COLLECTION,
+                    "--age-days",
+                    "7",
+                    "--to-storage-class",
+                    "STANDARD_IA",
+                    "--exclude-file",
+                    str(exclude_file),
+                ]
+            )
+
+        assert exit_code == 0
+        assert json.loads(stdout.getvalue()) == ["item-2"]
 
     def test_error_returns_nonzero(self):
         with patch(

--- a/tests/unit/test_query_storage_tier_items.py
+++ b/tests/unit/test_query_storage_tier_items.py
@@ -301,7 +301,9 @@ class TestMain:
     def test_baked_demo_denylist_applied_by_default(self, monkeypatch):
         """Without --exclude-file or env var, the baked demo list still protects."""
         monkeypatch.delenv("EXPIRES_EXCLUDE_FILE", raising=False)
-        demo_id = "S2C_MSIL2A_20250512T100611_N0511_R022_T32TQR_20250512T173114"
+        from scripts.s3_item_cleanup import BAKED_EXCLUDE_FILE, load_exclude_ids
+
+        demo_id = sorted(load_exclude_ids(str(BAKED_EXCLUDE_FILE)))[0]
         items = [
             create_stac_item(demo_id, storage_refs=["performance"]),  # baked demo id
             create_stac_item("item-2", storage_refs=["performance"]),

--- a/tests/unit/test_submit_storage_tier_workflows.py
+++ b/tests/unit/test_submit_storage_tier_workflows.py
@@ -342,6 +342,51 @@ class TestQueryStacItemsTierFilter:
 
         assert result == []
 
+    def test_excluded_ids_never_selected(self) -> None:
+        """Denylisted items are dropped even when they need the tier move."""
+        demo = _FakeItem("demo-scene", "performance")
+        regular = _FakeItem("regular-scene", "performance")
+        mock_search = MagicMock()
+        mock_search.items.return_value = [demo, regular]
+        mock_catalog = MagicMock()
+        mock_catalog.search.return_value = mock_search
+
+        with patch("submit_storage_tier_workflows.Client") as mock_client:
+            mock_client.open.return_value = mock_catalog
+            result = query_stac_items(
+                "https://stac.example.com",
+                "sentinel-2",
+                "2026-01-01T00:00:00Z",
+                "2026-04-14T00:00:00Z",
+                date_field="created",
+                target_storage_ref="standard",
+                exclude_ids={"demo-scene"},
+            )
+
+        assert result == ["regular-scene"]
+
+    def test_excluded_ids_apply_without_tier_filter(self) -> None:
+        """The denylist also applies when the already-at-target filter is disabled."""
+        mock_search = MagicMock()
+        mock_search.items.return_value = [
+            _FakeItem("demo-scene", None),
+            _FakeItem("regular-scene", None),
+        ]
+        mock_catalog = MagicMock()
+        mock_catalog.search.return_value = mock_search
+
+        with patch("submit_storage_tier_workflows.Client") as mock_client:
+            mock_client.open.return_value = mock_catalog
+            result = query_stac_items(
+                "https://stac.example.com",
+                "sentinel-2",
+                "2026-01-01T00:00:00Z",
+                "2026-04-14T00:00:00Z",
+                exclude_ids={"demo-scene"},
+            )
+
+        assert result == ["regular-scene"]
+
     def test_open_lower_bound_uses_less_than_filter(self) -> None:
         """window_start=None issues a single-sided CQL2 '<' filter on the date field."""
         mock_search = MagicMock()
@@ -518,6 +563,7 @@ class TestMainDateFieldForwarding:
             window_end: str,
             date_field: str,
             target_storage_ref: str | None,
+            exclude_ids: set[str] | frozenset[str] = frozenset(),
         ) -> list[str]:
             captured.append(date_field)
             return []
@@ -560,6 +606,7 @@ class TestMainDateFieldForwarding:
             window_end: str,
             date_field: str,
             target_storage_ref: str | None,
+            exclude_ids: set[str] | frozenset[str] = frozenset(),
         ) -> list[str]:
             captured.append(date_field)
             return []
@@ -636,6 +683,7 @@ class TestMainMinAgeMode:
             window_end: str,
             date_field: str,
             target_storage_ref: str | None,
+            exclude_ids: set[str] | frozenset[str] = frozenset(),
         ) -> list[str]:
             captured.append(
                 {
@@ -693,6 +741,7 @@ class TestMainMinAgeMode:
             window_end: str,
             date_field: str,
             target_storage_ref: str | None,
+            exclude_ids: set[str] | frozenset[str] = frozenset(),
         ) -> list[str]:
             captured.append(date_field)
             return []
@@ -777,6 +826,7 @@ class TestMainMinAgeMode:
             window_end: str,
             date_field: str,
             target_storage_ref: str | None,
+            exclude_ids: set[str] | frozenset[str] = frozenset(),
         ) -> list[str]:
             captured.append(
                 {


### PR DESCRIPTION
The tier-down selection had no demo protection, so protected demo scenes were migrated off the performance tier (found via the EOX blackbox alerts). Both selection paths now apply the same denylist as expiry cleanup (`--exclude-file` → `$EXPIRES_EXCLUDE_FILE` → baked `demo_exclude_ids.txt`): `submit_storage_tier_workflows.py` (the live daily tier-down cron) and `query_storage_tier_items.py` (chunked-drain optimizer). The 12 demo scenes were manually re-tiered to EXPRESS_ONEZONE and their STAC metadata re-synced on 2026-07-18. Related: EOPF-Explorer/coordination#183.

**For reviewers:** takes effect in prod only after a release is built and platform-deploy bumps `pipeline_image_version` on `cronwf/eopf-explorer-cronwf-tier-down.yaml` (currently `v1.11.0-tierdown-rc1`) — needed before ~2026-10-11, when the Fontainebleau demo scenes' `created` age crosses the cron's 90–93 d band.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted (Claude Code): implementation, tests, and five-axis review that caught the live-path gap; full unit suite green (919 passed), reviewed by author.
