### PR TITLE
fix(cleanup): don't let a STAC DELETE timeout abort the whole run

### DIFF
--- a/scripts/README_cleanup_expired_items.md
+++ b/scripts/README_cleanup_expired_items.md
@@ -91,10 +91,14 @@ s3_objects_deleted, s3_objects_failed, s3_remaining, stac_deleted, status
 stac-auth-proxy enforcement lands; wire the bearer in `_session()`),
 `already_gone` (re-fetch got 404 — already deleted, idempotent success),
 `refetch_failed` (re-fetch errored — the item is skipped rather than acted on
-with stale data), `no_expires`, `not_expired`, `excluded`, `wrong_bucket`.
+with stale data), `stac_delete_failed` (the STAC DELETE hit a transport or auth
+error after the S3 objects were removed — the item is briefly orphaned and a
+later run completes the delete), `no_expires`, `not_expired`, `excluded`,
+`wrong_bucket`.
 
 Exit code is `1` if any item ended in `s3_validation_failed`, `auth_required`,
-`refetch_failed`, or a `stac_delete_http_*` status. `already_gone` is a success.
+`refetch_failed`, `stac_delete_failed`, or a `stac_delete_http_*` status.
+`already_gone` is a success.
 
 ## Notes on the discovery query (verified live 2026-07-10)
 

--- a/scripts/cleanup_expired_items.py
+++ b/scripts/cleanup_expired_items.py
@@ -57,7 +57,9 @@ DEFAULT_MAX_ITEMS = 100
 
 # Per-item statuses that make the run exit non-zero. `already_gone` is NOT here
 # (idempotent success); `stac_delete_http_*` is matched separately by prefix.
-FAILURE_STATUSES = frozenset({"s3_validation_failed", "auth_required", "refetch_failed"})
+FAILURE_STATUSES = frozenset(
+    {"s3_validation_failed", "auth_required", "refetch_failed", "stac_delete_failed"}
+)
 
 
 def _now() -> datetime:
@@ -133,9 +135,19 @@ def _delete_stac_item(
     item_id: str,
 ) -> tuple[bool, str]:
     """DELETE the STAC item. 404 is success (idempotent); 401/403 is a distinct
-    ``auth_required`` signal (expected once stac-auth-proxy enforcement lands)."""
+    ``auth_required`` signal (expected once stac-auth-proxy enforcement lands).
+
+    A transport error is reported as ``stac_delete_failed`` rather than raised:
+    the caller's S3 objects are already gone, so the item is briefly orphaned
+    until a later run re-processes it (that run finds 0 objects remaining and
+    completes the delete). Raising here would abort the whole batch instead.
+    """
     url = f"{stac_base_url.rstrip('/')}/collections/{collection}/items/{item_id}"
-    resp = session.delete(url, timeout=30)
+    try:
+        resp = session.delete(url, timeout=30)
+    except requests.RequestException as exc:
+        logger.warning("STAC delete failed for %s: %s — retrying on a later run", item_id, exc)
+        return False, "stac_delete_failed"
     if resp.status_code in (200, 202, 204, 404):
         return True, "deleted"
     if resp.status_code in (401, 403):

--- a/scripts/cleanup_expired_items.py
+++ b/scripts/cleanup_expired_items.py
@@ -33,7 +33,7 @@ from urllib.parse import urlparse
 import boto3
 import requests
 import stac_auth
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 from pystac_client import Client
 from s3_item_cleanup import (
     count_s3_objects_for_item,
@@ -141,11 +141,15 @@ def _delete_stac_item(
     the caller's S3 objects are already gone, so the item is briefly orphaned
     until a later run re-processes it (that run finds 0 objects remaining and
     completes the delete). Raising here would abort the whole batch instead.
+
+    ``RuntimeError`` is caught alongside the requests errors because the auth
+    hook runs *inside* ``session.delete``: ``stac_auth.get_token`` re-raises a
+    failed token request as ``RuntimeError``, which is not a ``RequestException``.
     """
     url = f"{stac_base_url.rstrip('/')}/collections/{collection}/items/{item_id}"
     try:
         resp = session.delete(url, timeout=30)
-    except requests.RequestException as exc:
+    except (requests.RequestException, RuntimeError) as exc:
         logger.warning("STAC delete failed for %s: %s — retrying on a later run", item_id, exc)
         return False, "stac_delete_failed"
     if resp.status_code in (200, 202, 204, 404):
@@ -214,7 +218,10 @@ def process_item(
             )
 
         remaining = count_s3_objects_for_item(s3_client, s3_urls)
-    except ClientError as exc:
+    # BotoCoreError covers the transport failures ClientError does NOT: a read
+    # timeout or endpoint blip is not a service-returned error, and letting one
+    # escape would abort the batch mid-run with no summary (issue #364).
+    except (ClientError, BotoCoreError) as exc:
         logger.warning("S3 error validating %s: %s — retaining STAC item", item.get("id"), exc)
         return _audit(item, dry_run, "s3_validation_failed")
 
@@ -351,7 +358,8 @@ def _fetch_item(
         if resp.status_code == 404:
             return None, "gone"
         logger.warning("Re-fetch of %s returned HTTP %d", item_id, resp.status_code)
-    except requests.RequestException as exc:
+    # RuntimeError: the auth hook runs inside session.get (see _delete_stac_item).
+    except (requests.RequestException, RuntimeError) as exc:
         logger.warning("Re-fetch failed for %s: %s", item_id, exc)
     return None, "error"
 

--- a/tests/unit/test_cleanup_expired_items.py
+++ b/tests/unit/test_cleanup_expired_items.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, EndpointConnectionError
 from cleanup_expired_items import (
     build_search_kwargs,
     evaluate_guards,
@@ -382,6 +382,55 @@ def test_execute_reports_stac_delete_failed_on_transport_error(expired_item: dic
 
     assert rec["status"] == "stac_delete_failed"
     assert rec["stac_deleted"] is False
+
+
+def test_execute_reports_stac_delete_failed_on_auth_hook_error(expired_item: dict) -> None:
+    """The Bearer auth hook runs *inside* session.delete, and stac_auth re-raises a
+    failed token request as RuntimeError — not a RequestException. It must not
+    escape and abort the batch."""
+    s3 = MagicMock()
+    s3.get_paginator.return_value = _paginator([["a"], []])
+    s3.delete_objects.return_value = {"Deleted": [{"Key": "a"}], "Errors": []}
+    session = MagicMock()
+    session.delete.side_effect = RuntimeError("OIDC token request failed: ReadTimeout")
+
+    rec = process_item(
+        expired_item,
+        now=NOW,
+        exclude_ids=set(),
+        allowed_bucket=BUCKET,
+        s3_client=s3,
+        session=session,
+        stac_base_url="https://stac.example.com",
+        dry_run=False,
+    )
+
+    assert rec["status"] == "stac_delete_failed"
+    assert rec["stac_deleted"] is False
+
+
+def test_execute_retains_stac_item_on_s3_transport_error(expired_item: dict) -> None:
+    """A botocore transport error is NOT a ClientError (it descends from
+    BotoCoreError). It must be caught too, or an S3 blip aborts the whole run."""
+    s3 = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.side_effect = EndpointConnectionError(endpoint_url="https://s3.example.com")
+    s3.get_paginator.return_value = paginator
+    session = MagicMock()
+
+    rec = process_item(
+        expired_item,
+        now=NOW,
+        exclude_ids=set(),
+        allowed_bucket=BUCKET,
+        s3_client=s3,
+        session=session,
+        stac_base_url="https://stac.example.com",
+        dry_run=False,
+    )
+
+    session.delete.assert_not_called()  # STAC item retained
+    assert rec["status"] == "s3_validation_failed"
 
 
 def test_execute_treats_404_stac_delete_as_success(expired_item: dict) -> None:

--- a/tests/unit/test_cleanup_expired_items.py
+++ b/tests/unit/test_cleanup_expired_items.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from botocore.exceptions import ClientError
 from cleanup_expired_items import (
     build_search_kwargs,
@@ -358,6 +359,31 @@ def test_execute_reports_auth_required_on_403(expired_item: dict) -> None:
     assert rec["stac_deleted"] is False
 
 
+def test_execute_reports_stac_delete_failed_on_transport_error(expired_item: dict) -> None:
+    """A transient network error on the STAC DELETE must become a per-item status,
+    not an exception: process_item's contract is that expected per-item failures
+    never raise, so the batch continues and the audit log stays complete."""
+    s3 = MagicMock()
+    s3.get_paginator.return_value = _paginator([["a"], []])
+    s3.delete_objects.return_value = {"Deleted": [{"Key": "a"}], "Errors": []}
+    session = MagicMock()
+    session.delete.side_effect = requests.exceptions.ReadTimeout("read timed out")
+
+    rec = process_item(
+        expired_item,
+        now=NOW,
+        exclude_ids=set(),
+        allowed_bucket=BUCKET,
+        s3_client=s3,
+        session=session,
+        stac_base_url="https://stac.example.com",
+        dry_run=False,
+    )
+
+    assert rec["status"] == "stac_delete_failed"
+    assert rec["stac_deleted"] is False
+
+
 def test_execute_treats_404_stac_delete_as_success(expired_item: dict) -> None:
     s3 = MagicMock()
     s3.get_paginator.return_value = _paginator([["a"], []])
@@ -500,6 +526,51 @@ def test_run_cleanup_refetch_error_skips_and_exits_1(expired_item, capsys) -> No
     assert code == 1
     assert records[0]["status"] == "refetch_failed"
     s3.delete_objects.assert_not_called()  # did NOT fall back to stale + delete
+
+
+def test_run_cleanup_survives_stac_delete_timeout_mid_batch(expired_item, capsys) -> None:
+    """Regression (2026-07-20 06:00Z tick): a ReadTimeout on one item's STAC
+    DELETE aborted the whole run — the rest of the batch was skipped and no
+    cleanup_summary was emitted, which is our only real-vs-cosmetic signal."""
+    items = [dict(expired_item, id="a"), dict(expired_item, id="b")]
+
+    client = MagicMock()
+    client.self_href = "https://stac.example.com"
+    client.search.return_value.items_as_dicts.return_value = iter(items)
+
+    session = MagicMock()
+
+    def _get(url, timeout=30):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = items[0] if url.endswith("a") else items[1]
+        return resp
+
+    session.get.side_effect = _get
+    # First item times out, second deletes cleanly.
+    session.delete.side_effect = [
+        requests.exceptions.ReadTimeout("read timed out"),
+        MagicMock(status_code=204),
+    ]
+
+    s3 = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Contents": []}]
+    s3.get_paginator.return_value = paginator
+
+    with (
+        patch("cleanup_expired_items.Client.open", return_value=client),
+        patch("cleanup_expired_items._session", return_value=session),
+        patch("cleanup_expired_items._s3_client", return_value=s3),
+    ):
+        code = run_cleanup(_args(execute=True))
+
+    records = _capture_lines(capsys)
+    statuses = [r["status"] for r in records if r["event"] == "cleanup_item"]
+    assert statuses == ["stac_delete_failed", "deleted"]  # batch continued
+    assert records[-1]["event"] == "cleanup_summary"  # summary still emitted
+    assert records[-1]["processed"] == 2
+    assert code == 1  # the timeout is still a failure
 
 
 def test_run_cleanup_paginates_fully_before_deleting(expired_item) -> None:


### PR DESCRIPTION
A `requests.ReadTimeout` on one item's STAC DELETE killed the 2026-07-20 06:00Z cleanup tick after ~56 items: the request was issued unguarded, so the exception propagated out of `process_item` and aborted the batch with no `cleanup_summary` — the one signal that tells a real failure apart from the cosmetic "pod deleted" phantom. Transport errors now become a `stac_delete_failed` per-item status, matching how S3 and re-fetch errors are already handled, so the loop continues and the run still exits non-zero. Closes #364.

Review found the same defect class in two sibling paths, fixed here too: `process_item` caught only `ClientError`, but botocore transport failures descend from `BotoCoreError`; and the Bearer auth hook runs *inside* `session.delete`, where `stac_auth` re-raises a failed token request as `RuntimeError`, which is not a `RequestException`.

## For reviewers

The affected item self-heals on a later run (its S3 objects are already gone, so the re-run validates 0 remaining and completes the STAC delete) — verified by simulating the re-run for both asset shapes. Each test was checked to fail against the un-broadened guard with the exact escaping exception. Deliberately not fixed with a workflow `retryStrategy` — that was reverted in EOPF-Explorer/platform-deploy#328 because a retry re-runs the batch and can exceed the 100-item bound on an unversioned bucket.

Known remaining gap, deferred: `list(search.items_as_dicts())` in `run_cleanup` is still unguarded, so a discovery-time timeout aborts before any summary. Fixing that properly means wrapping the run body to always emit an `aborted: true` summary — a design change worth its own PR.

## Author attestation

- [ ] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted: root-caused from Loki logs and implemented test-first with Claude Code, then independently reviewed by a second agent; I reviewed the diff.
