### PR TITLE
feat(operator): bounded repair tool for /stac/raster corrupted item links

### DIFF
--- a/operator-tools/repair_stac_raster_links.py
+++ b/operator-tools/repair_stac_raster_links.py
@@ -26,7 +26,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 import requests
 
@@ -136,14 +136,14 @@ class RepairRun:
         self.truncated = False
         self._backup_path: Path | None = None
         self._results_path: Path | None = None
-        self._backup_fh = None
+        self._backup_fh: TextIO | None = None
 
     def item_url(self, item_id: str) -> str:
         return f"{self.api_url}/collections/{self.collection}/items/{item_id}"
 
-    def _open_backup(self) -> None:
+    def _open_backup(self) -> TextIO:
         if self._backup_fh is not None:
-            return
+            return self._backup_fh
         self.backup_dir.mkdir(parents=True, exist_ok=True)
         stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
         self._backup_path = self.backup_dir / f"raster-link-repair-{self.collection}-{stamp}.jsonl"
@@ -152,16 +152,19 @@ class RepairRun:
             self._backup_path, "a", encoding="utf-8"
         )
         logger.info("Backups: %s", self._backup_path.resolve())
+        return self._backup_fh
 
     def _backup(self, item: dict[str, Any]) -> None:
         """Append the pre-write doc and fsync BEFORE any write goes out."""
-        self._open_backup()
+        backup_fh = self._open_backup()
         line = json.dumps({"collection": self.collection, "id": item["id"], "item": item})
-        self._backup_fh.write(line + "\n")
-        self._backup_fh.flush()
-        os.fsync(self._backup_fh.fileno())
+        backup_fh.write(line + "\n")
+        backup_fh.flush()
+        os.fsync(backup_fh.fileno())
 
     def _record_result(self, item_id: str, updated_after: str | None) -> None:
+        if self._results_path is None:
+            raise RuntimeError("_record_result called before any backup was written")
         with open(self._results_path, "a", encoding="utf-8") as fh:
             fh.write(json.dumps({"id": item_id, "updated_after": updated_after}) + "\n")
             fh.flush()

--- a/operator-tools/repair_stac_raster_links.py
+++ b/operator-tools/repair_stac_raster_links.py
@@ -30,7 +30,11 @@ from typing import Any
 
 import requests
 
-sys.path.insert(0, str(Path(__file__).parent))
+# Add scripts directory to path for the shared OIDC write auth
+scripts_dir = Path(__file__).parent.parent / "scripts"
+if str(scripts_dir) not in sys.path:
+    sys.path.insert(0, str(scripts_dir))
+
 import stac_auth  # noqa: E402
 
 logger = logging.getLogger(__name__)

--- a/scripts/repair_stac_raster_links.py
+++ b/scripts/repair_stac_raster_links.py
@@ -1,0 +1,364 @@
+"""Repair STAC items whose links were persisted with the corrupted /stac/raster prefix.
+
+During the stac-auth-proxy link-rewrite incident (2026-07-21T11:15Z -> 2026-07-22T~14:30Z,
+platform-deploy#343), read-modify-write pipeline jobs persisted proxy-corrupted hrefs
+(``https://<host>/stac/raster/...``) into item ``links`` arrays (rels viewer/xyz/tilejson).
+This operator tool rewrites the corrupted prefix back to ``/raster/`` — and nothing else.
+Tracked in #371; recovery plan + gates live out-of-repo (session project dir).
+
+Safety properties (per the reviewed recovery plan):
+- dry-run by default; ``--apply`` required for any write
+- ``--max-items`` is a hard bound on WRITES, enforced in code before each PUT
+- every touched item is backed up (JSONL, fsync'd) BEFORE its PUT; ``--restore`` replays
+  a backup verbatim (loudly — a restore re-installs the corrupted links by design) with a
+  staleness guard against clobbering items re-registered since the repair
+- 404 on PUT is logged and skipped, never downgraded to a POST (no resurrection)
+- per-item verify (re-GET) after each PUT; 3 consecutive or 10 total failures abort
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent))
+import stac_auth  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+CORRUPT_PREFIX = "https://api.explorer.eopf.copernicus.eu/stac/raster/"
+CLEAN_PREFIX = "https://api.explorer.eopf.copernicus.eu/raster/"
+
+# Default backup location: durable (survives worktree/session cleanup), never a repo path.
+DEFAULT_BACKUP_DIR = (
+    Path.home() / ".claude/projects/-Users-lhoupert-DevDS-EOPF-data-pipeline/backups"
+)
+
+MAX_CONSECUTIVE_FAILURES = 3
+MAX_TOTAL_FAILURES = 10
+
+
+def repair_links(item: dict[str, Any]) -> tuple[dict[str, Any], int]:
+    """Return (repaired copy, number of hrefs changed). Idempotent; touches only links[].href.
+
+    Only an href that starts with the exact corrupted prefix is rewritten; assets and all
+    other link fields are untouched. 0 changes means the item is clean (no-op guarantee).
+    """
+    repaired = copy.deepcopy(item)
+    changed = 0
+    for link in repaired.get("links", []):
+        href = link.get("href")
+        if isinstance(href, str) and href.startswith(CORRUPT_PREFIX):
+            link["href"] = CLEAN_PREFIX + href[len(CORRUPT_PREFIX) :]
+            changed += 1
+    return repaired, changed
+
+
+def is_corrupted(item: dict[str, Any]) -> bool:
+    """True when any link href carries the corrupted prefix."""
+    return any(
+        isinstance(link.get("href"), str) and link["href"].startswith(CORRUPT_PREFIX)
+        for link in item.get("links", [])
+    )
+
+
+def discover_corrupted_ids(
+    session: requests.Session, api_url: str, collection: str, updated_since: str
+) -> list[str]:
+    """Search the collection for corrupted items (string comparison on `updated` —
+    pgstac's `updated` is text; TIMESTAMP() comparison errors)."""
+    body: dict[str, Any] = {
+        "collections": [collection],
+        "limit": 500,
+        "fields": {
+            "include": ["id", "links", "properties.updated"],
+            "exclude": ["assets", "geometry", "bbox"],
+        },
+        "filter-lang": "cql2-json",
+        "filter": {"op": ">=", "args": [{"property": "updated"}, updated_since]},
+    }
+    ids: list[str] = []
+    url = f"{api_url}/search"
+    while True:
+        resp = session.post(url, json=body, timeout=60)
+        resp.raise_for_status()
+        page = resp.json()
+        for feature in page.get("features", []):
+            if is_corrupted(feature):
+                ids.append(feature["id"])
+        next_link = next(
+            (link for link in page.get("links", []) if link.get("rel") == "next"),
+            None,
+        )
+        if next_link is None:
+            return ids
+        body = next_link.get("body", body)
+        url = next_link.get("href", url)
+
+
+class RepairRun:
+    """One bounded repair (or restore) run against a single collection."""
+
+    def __init__(
+        self,
+        session: requests.Session,
+        api_url: str,
+        collection: str,
+        max_items: int,
+        apply: bool,
+        backup_dir: Path,
+    ) -> None:
+        self.session = session
+        self.api_url = api_url
+        self.collection = collection
+        self.max_items = max_items
+        self.apply = apply
+        self.backup_dir = Path(backup_dir)
+        self.scanned = 0
+        self.skipped_clean = 0
+        self.written = 0
+        self.verified = 0
+        self.failures = 0
+        self.consecutive_failures = 0
+        self.truncated = False
+        self._backup_path: Path | None = None
+        self._results_path: Path | None = None
+        self._backup_fh = None
+
+    def item_url(self, item_id: str) -> str:
+        return f"{self.api_url}/collections/{self.collection}/items/{item_id}"
+
+    def _open_backup(self) -> None:
+        if self._backup_fh is not None:
+            return
+        self.backup_dir.mkdir(parents=True, exist_ok=True)
+        stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        self._backup_path = self.backup_dir / f"raster-link-repair-{self.collection}-{stamp}.jsonl"
+        self._results_path = self._backup_path.with_suffix(".results.jsonl")
+        self._backup_fh = open(  # noqa: SIM115 — held across items, fsync'd per line
+            self._backup_path, "a", encoding="utf-8"
+        )
+        logger.info("Backups: %s", self._backup_path.resolve())
+
+    def _backup(self, item: dict[str, Any]) -> None:
+        """Append the pre-write doc and fsync BEFORE any write goes out."""
+        self._open_backup()
+        line = json.dumps({"collection": self.collection, "id": item["id"], "item": item})
+        self._backup_fh.write(line + "\n")
+        self._backup_fh.flush()
+        os.fsync(self._backup_fh.fileno())
+
+    def _record_result(self, item_id: str, updated_after: str | None) -> None:
+        with open(self._results_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"id": item_id, "updated_after": updated_after}) + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+
+    def _fail(self, item_id: str, why: str) -> bool:
+        """Record a failure; return True when the run must abort."""
+        self.failures += 1
+        self.consecutive_failures += 1
+        logger.error("FAILED %s: %s", item_id, why)
+        if self.consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+            logger.error("Aborting: %d consecutive failures", self.consecutive_failures)
+            return True
+        if self.failures >= MAX_TOTAL_FAILURES:
+            logger.error("Aborting: %d total failures", self.failures)
+            return True
+        return False
+
+    def _put_and_verify(self, item_id: str, doc: dict[str, Any]) -> bool:
+        """PUT one doc and re-GET verify. Returns True when the run must abort."""
+        self.written += 1
+        resp = self.session.put(self.item_url(item_id), json=doc, timeout=30)
+        if resp.status_code == 404:
+            # Item deleted between discovery and write: skip. NEVER fall back to a
+            # POST — resurrecting a deleted item is worse than leaving it missing.
+            logger.warning("PUT 404 for %s — deleted mid-run, skipping (no POST)", item_id)
+            return self._fail(item_id, "PUT returned 404")
+        resp.raise_for_status()
+
+        check = self.session.get(self.item_url(item_id), timeout=30)
+        check.raise_for_status()
+        after = check.json()
+        if is_corrupted(after):
+            return self._fail(item_id, "still corrupted after PUT")
+        self.verified += 1
+        self.consecutive_failures = 0
+        self._record_result(item_id, after.get("properties", {}).get("updated"))
+        logger.info("repaired %s", item_id)
+        return False
+
+    def repair(self, item_ids: list[str]) -> None:
+        """Repair the given items, honoring the write bound and dry-run default."""
+        for item_id in item_ids:
+            self.scanned += 1
+            resp = self.session.get(self.item_url(item_id), timeout=30)
+            resp.raise_for_status()
+            original = resp.json()
+
+            repaired, changed = repair_links(original)
+            if changed == 0:
+                self.skipped_clean += 1
+                logger.info("clean, skipping %s", item_id)
+                continue
+
+            if not self.apply:
+                logger.info("DRY-RUN would repair %s (%d links)", item_id, changed)
+                continue
+
+            # Hard write bound, checked BEFORE each PUT.
+            if self.written >= self.max_items:
+                self.truncated = True
+                logger.warning(
+                    "--max-items %d reached; stopping with items remaining", self.max_items
+                )
+                return
+
+            self._backup(original)
+            if self._put_and_verify(item_id, repaired):
+                return
+
+    def restore(self, backup_file: Path, force: bool) -> None:
+        """PUT each backed-up doc verbatim (returns items to their pre-repair state).
+
+        Loud by design: the backup contains the CORRUPTED links. A staleness guard
+        refuses to clobber an item whose current `updated` differs from the value
+        recorded after our repair PUT (i.e. something else wrote it since) unless
+        --force is given.
+        """
+        entries = [json.loads(line) for line in backup_file.read_text().splitlines() if line]
+        n_corrupt = sum(1 for e in entries if is_corrupted(e["item"]))
+        logger.warning(
+            "RESTORE MODE: %d items from %s — %d contain corrupted /stac/raster links "
+            "which will be re-installed verbatim",
+            len(entries),
+            backup_file,
+            n_corrupt,
+        )
+        results_path = backup_file.with_suffix(".results.jsonl")
+        expected: dict[str, str | None] = {}
+        if results_path.exists():
+            for line in results_path.read_text().splitlines():
+                if line:
+                    rec = json.loads(line)
+                    expected[rec["id"]] = rec.get("updated_after")
+
+        for entry in entries:
+            item_id = entry["id"]
+            self.scanned += 1
+            if not self.apply:
+                logger.info("DRY-RUN would restore %s", item_id)
+                continue
+            if self.written >= self.max_items:
+                self.truncated = True
+                logger.warning("--max-items %d reached; stopping", self.max_items)
+                return
+
+            if not force:
+                current = self.session.get(self.item_url(item_id), timeout=30)
+                current.raise_for_status()
+                current_updated = current.json().get("properties", {}).get("updated")
+                if item_id not in expected or expected[item_id] != current_updated:
+                    logger.error(
+                        "STALE %s: current updated=%r != recorded %r — item changed "
+                        "since the repair; refusing without --force",
+                        item_id,
+                        current_updated,
+                        expected.get(item_id),
+                    )
+                    if self._fail(item_id, "stale restore refused"):
+                        return
+                    continue
+
+            self.written += 1
+            resp = self.session.put(self.item_url(item_id), json=entry["item"], timeout=30)
+            if resp.status_code == 404:
+                logger.warning("PUT 404 for %s — skipping (no POST)", item_id)
+                if self._fail(item_id, "PUT returned 404"):
+                    return
+                continue
+            resp.raise_for_status()
+            self.verified += 1
+            self.consecutive_failures = 0
+            logger.info("restored %s", item_id)
+
+    def summary(self) -> str:
+        mode = "APPLY" if self.apply else "DRY-RUN"
+        return (
+            f"[{mode}] scanned={self.scanned} clean-skipped={self.skipped_clean} "
+            f"writes={self.written} verified={self.verified} failed={self.failures} "
+            f"truncated={self.truncated}"
+        )
+
+
+def make_session() -> requests.Session:
+    """A session whose every request carries a fresh bearer (no-op without OIDC env)."""
+    session = requests.Session()
+    session.auth = stac_auth.bearer_auth
+    return session
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--collection", required=True, help="single target collection")
+    parser.add_argument(
+        "--max-items",
+        required=True,
+        type=int,
+        help="hard bound on WRITES (enforced before each PUT)",
+    )
+    parser.add_argument("--stac-api-url", default="https://api.explorer.eopf.copernicus.eu/stac")
+    parser.add_argument("--ids", nargs="+", help="explicit item ids (canary path)")
+    parser.add_argument(
+        "--updated-since",
+        default="2026-07-21T11:15:00Z",
+        help="discovery filter lower bound (string comparison)",
+    )
+    parser.add_argument("--apply", action="store_true", help="actually write (default: dry-run)")
+    parser.add_argument("--backup-dir", type=Path, default=DEFAULT_BACKUP_DIR)
+    parser.add_argument("--restore", type=Path, help="rollback mode: replay a backup JSONL")
+    parser.add_argument(
+        "--force", action="store_true", help="restore mode: override the staleness guard"
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    if args.max_items <= 0:
+        parser.error("--max-items must be a positive integer")
+
+    session = make_session()
+    run = RepairRun(
+        session=session,
+        api_url=args.stac_api_url.rstrip("/"),
+        collection=args.collection,
+        max_items=args.max_items,
+        apply=args.apply,
+        backup_dir=args.backup_dir,
+    )
+    logger.info("Backup dir: %s", Path(args.backup_dir).resolve())
+
+    if args.restore:
+        run.restore(args.restore, force=args.force)
+    else:
+        ids = args.ids or discover_corrupted_ids(
+            session, run.api_url, args.collection, args.updated_since
+        )
+        logger.info("%d target item(s)", len(ids))
+        run.repair(ids)
+
+    print(run.summary())
+    return 1 if run.failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repair_stac_raster_links.py
+++ b/scripts/repair_stac_raster_links.py
@@ -301,6 +301,17 @@ class RepairRun:
         )
 
 
+def parse_ids_file(path: Path) -> list[str]:
+    """Read target ids from a file: one per line, or JSONL objects with an 'id' key."""
+    ids: list[str] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        ids.append(json.loads(line)["id"] if line.startswith("{") else line)
+    return ids
+
+
 def make_session() -> requests.Session:
     """A session whose every request carries a fresh bearer (no-op without OIDC env)."""
     session = requests.Session()
@@ -319,6 +330,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--stac-api-url", default="https://api.explorer.eopf.copernicus.eu/stac")
     parser.add_argument("--ids", nargs="+", help="explicit item ids (canary path)")
+    parser.add_argument(
+        "--ids-file",
+        type=Path,
+        help="file of target ids: one per line, or JSONL objects with an 'id' key",
+    )
     parser.add_argument(
         "--updated-since",
         default="2026-07-21T11:15:00Z",
@@ -350,9 +366,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.restore:
         run.restore(args.restore, force=args.force)
     else:
-        ids = args.ids or discover_corrupted_ids(
-            session, run.api_url, args.collection, args.updated_since
-        )
+        ids = list(args.ids or [])
+        if args.ids_file:
+            ids.extend(parse_ids_file(args.ids_file))
+        if not ids:
+            ids = discover_corrupted_ids(session, run.api_url, args.collection, args.updated_since)
         logger.info("%d target item(s)", len(ids))
         run.repair(ids)
 

--- a/tests/unit/test_repair_stac_raster_links.py
+++ b/tests/unit/test_repair_stac_raster_links.py
@@ -1,4 +1,4 @@
-"""Unit tests for scripts/repair_stac_raster_links.py (#371 repair tool)."""
+"""Unit tests for operator-tools/repair_stac_raster_links.py (#371 repair tool)."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parents[2] / "scripts"))
+sys.path.insert(0, str(Path(__file__).parents[2] / "operator-tools"))
 import repair_stac_raster_links as mod  # noqa: E402
 
 API = "https://api.explorer.eopf.copernicus.eu/stac"

--- a/tests/unit/test_repair_stac_raster_links.py
+++ b/tests/unit/test_repair_stac_raster_links.py
@@ -1,0 +1,282 @@
+"""Unit tests for scripts/repair_stac_raster_links.py (#371 repair tool)."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "scripts"))
+import repair_stac_raster_links as mod  # noqa: E402
+
+API = "https://api.explorer.eopf.copernicus.eu/stac"
+CORRUPT = "https://api.explorer.eopf.copernicus.eu/stac/raster"
+CLEAN = "https://api.explorer.eopf.copernicus.eu/raster"
+
+
+def make_item(item_id: str = "item-1", corrupted: bool = True) -> dict:
+    base = CORRUPT if corrupted else CLEAN
+    return {
+        "id": item_id,
+        "properties": {"updated": "2026-07-22T10:00:00Z"},
+        "links": [
+            {"rel": "self", "href": f"{API}/collections/c/items/{item_id}"},
+            {"rel": "viewer", "href": f"{base}/collections/c/items/{item_id}/viewer"},
+            {
+                "rel": "xyz",
+                "href": f"{base}/collections/c/items/{item_id}/tiles/{{z}}/{{x}}/{{y}}.png",
+            },
+            {"rel": "tilejson", "href": f"{base}/collections/c/items/{item_id}/tilejson.json"},
+            {"rel": "via", "href": "https://stac.core.eopf.eodc.eu/collections/x"},
+        ],
+        "assets": {"thumb": {"href": f"{CLEAN}/collections/c/items/{item_id}/preview"}},
+    }
+
+
+def response(json_data=None, status=200):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def make_run(session, tmp_path, max_items=100, apply=True, collection="c"):
+    return mod.RepairRun(
+        session=session,
+        api_url=API,
+        collection=collection,
+        max_items=max_items,
+        apply=apply,
+        backup_dir=tmp_path / "backups",
+    )
+
+
+# ---------- transform ----------
+
+
+def test_repair_links_rewrites_each_corrupted_rel():
+    repaired, changed = mod.repair_links(make_item())
+    assert changed == 3
+    by_rel = {link["rel"]: link["href"] for link in repaired["links"]}
+    for rel in ("viewer", "xyz", "tilejson"):
+        assert by_rel[rel].startswith(CLEAN + "/")
+        assert "/stac/raster/" not in by_rel[rel]
+
+
+def test_repair_links_idempotent():
+    once, _ = mod.repair_links(make_item())
+    twice, changed = mod.repair_links(once)
+    assert changed == 0
+    assert twice == once
+
+
+def test_repair_links_noop_on_clean_item():
+    clean = make_item(corrupted=False)
+    snapshot = copy.deepcopy(clean)
+    repaired, changed = mod.repair_links(clean)
+    assert changed == 0
+    assert repaired == snapshot
+    assert clean == snapshot  # input never mutated
+
+
+def test_repair_links_never_touches_assets_or_foreign_hrefs():
+    item = make_item()
+    item["links"].append({"rel": "odd", "href": "https://other.host/stac/raster/x"})
+    item["links"].append({"rel": "mid", "href": f"{API}/x?next={CORRUPT}/y"})
+    repaired, _ = mod.repair_links(item)
+    assert repaired["assets"] == item["assets"]
+    by_rel = {link["rel"]: link["href"] for link in repaired["links"]}
+    assert by_rel["odd"] == "https://other.host/stac/raster/x"  # other host untouched
+    assert by_rel["mid"] == f"{API}/x?next={CORRUPT}/y"  # mid-string untouched
+    assert by_rel["self"] == f"{API}/collections/c/items/item-1"
+    assert by_rel["via"] == "https://stac.core.eopf.eodc.eu/collections/x"
+
+
+# ---------- bound / dry-run / backup ----------
+
+
+def test_max_items_bounds_writes_exactly(tmp_path):
+    ids = [f"i{n}" for n in range(5)]
+    session = MagicMock()
+    puts: list[str] = []
+
+    def get(url, **kw):
+        item_id = url.rsplit("/", 1)[-1]
+        # corrupted until PUT, clean afterwards (so verify-GETs pass)
+        done = any(p.endswith(f"/{item_id}") for p in puts)
+        return response(make_item(item_id, corrupted=not done))
+
+    def put(url, **kw):
+        puts.append(url)
+        return response(status=200)
+
+    session.get.side_effect = get
+    session.put.side_effect = put
+    run = make_run(session, tmp_path, max_items=2)
+    run.repair(ids)
+    assert len(puts) == 2
+    assert run.truncated is True
+    assert "truncated=True" in run.summary()
+
+
+def test_dry_run_is_default_and_writes_nothing(tmp_path):
+    session = MagicMock()
+    session.get.return_value = response(make_item())
+    run = make_run(session, tmp_path, apply=False)
+    run.repair(["item-1"])
+    session.put.assert_not_called()
+    assert not (tmp_path / "backups").exists()  # no backup file in dry-run
+    assert "DRY-RUN" in run.summary()
+
+
+def test_backup_written_and_fsynced_before_put(tmp_path):
+    session = MagicMock()
+    original = make_item("item-1")
+    session.get.return_value = response(original)
+    session.put.side_effect = RuntimeError("boom mid-write")
+    run = make_run(session, tmp_path)
+    with pytest.raises(RuntimeError):
+        run.repair(["item-1"])
+    backups = list((tmp_path / "backups").glob("raster-link-repair-c-*.jsonl"))
+    assert len(backups) == 1
+    line = json.loads(backups[0].read_text().splitlines()[0])
+    assert line["id"] == "item-1"
+    assert line["item"] == original  # pre-write doc, corrupted links included
+
+
+def test_put_404_skips_and_never_posts(tmp_path):
+    session = MagicMock()
+    session.get.return_value = response(make_item())
+    session.put.return_value = response(status=404)
+    run = make_run(session, tmp_path)
+    run.repair(["item-1"])
+    session.post.assert_not_called()  # no resurrection
+    assert run.failures == 1
+
+
+def test_verify_mismatch_counts_failures_and_aborts_after_three(tmp_path):
+    session = MagicMock()
+    # GET always returns a corrupted item (both discovery-GET and verify-GET)
+    session.get.side_effect = lambda url, **kw: response(make_item(url.rsplit("/", 1)[-1]))
+    session.put.return_value = response(status=200)
+    run = make_run(session, tmp_path)
+    run.repair([f"i{n}" for n in range(10)])
+    assert run.failures == 3  # aborted at 3 consecutive
+    assert run.written == 3
+
+
+# ---------- restore ----------
+
+
+def restore_fixture(tmp_path, updated_after="2026-07-22T15:00:00Z"):
+    backup = tmp_path / "b.jsonl"
+    backup.write_text(json.dumps({"collection": "c", "id": "item-1", "item": make_item()}) + "\n")
+    results = tmp_path / "b.results.jsonl"
+    results.write_text(json.dumps({"id": "item-1", "updated_after": updated_after}) + "\n")
+    return backup
+
+
+def test_restore_puts_doc_verbatim_and_warns(tmp_path, caplog):
+    backup = restore_fixture(tmp_path)
+    session = MagicMock()
+    session.get.return_value = response(
+        {"id": "item-1", "properties": {"updated": "2026-07-22T15:00:00Z"}}
+    )
+    session.put.return_value = response(status=200)
+    run = make_run(session, tmp_path)
+    with caplog.at_level("WARNING"):
+        run.restore(backup, force=False)
+    assert "corrupted /stac/raster links" in caplog.text  # loud by design
+    put_body = session.put.call_args.kwargs["json"]
+    assert put_body == make_item()  # verbatim, corrupted links included
+    assert run.written == 1
+
+
+def test_restore_staleness_guard_refuses_without_force(tmp_path):
+    backup = restore_fixture(tmp_path, updated_after="2026-07-22T15:00:00Z")
+    session = MagicMock()
+    session.get.return_value = response(
+        {"id": "item-1", "properties": {"updated": "2026-07-23T09:00:00Z"}}  # re-registered since
+    )
+    run = make_run(session, tmp_path)
+    run.restore(backup, force=False)
+    session.put.assert_not_called()
+    assert run.failures == 1
+
+
+def test_restore_force_overrides_staleness(tmp_path):
+    backup = restore_fixture(tmp_path)
+    session = MagicMock()
+    session.put.return_value = response(status=200)
+    run = make_run(session, tmp_path)
+    run.restore(backup, force=True)
+    session.get.assert_not_called()  # guard skipped entirely
+    assert run.written == 1
+
+
+def test_restore_honors_dry_run_and_max_items(tmp_path):
+    backup = tmp_path / "b.jsonl"
+    lines = [
+        json.dumps({"collection": "c", "id": f"i{n}", "item": make_item(f"i{n}")}) for n in range(3)
+    ]
+    backup.write_text("\n".join(lines) + "\n")
+    session = MagicMock()
+    dry = make_run(session, tmp_path, apply=False)
+    dry.restore(backup, force=True)
+    session.put.assert_not_called()
+
+    session2 = MagicMock()
+    session2.put.return_value = response(status=200)
+    bounded = make_run(session2, tmp_path, max_items=2)
+    bounded.restore(backup, force=True)
+    assert session2.put.call_count == 2
+    assert bounded.truncated is True
+
+
+# ---------- discovery ----------
+
+
+def test_discovery_request_shape_and_client_side_predicate():
+    session = MagicMock()
+    page = {
+        "features": [make_item("bad-1"), make_item("clean-1", corrupted=False)],
+        "links": [],
+    }
+    session.post.return_value = response(page)
+    ids = mod.discover_corrupted_ids(session, API, "c", "2026-07-21T11:15:00Z")
+    assert ids == ["bad-1"]
+    body = session.post.call_args.kwargs["json"]
+    assert body["filter-lang"] == "cql2-json"
+    # string comparison (pgstac `updated` is text — TIMESTAMP() errors)
+    assert body["filter"] == {
+        "op": ">=",
+        "args": [{"property": "updated"}, "2026-07-21T11:15:00Z"],
+    }
+    assert body["collections"] == ["c"]
+    assert "links" in body["fields"]["include"]
+
+
+def test_discovery_follows_next_pagination():
+    session = MagicMock()
+    page1 = {
+        "features": [make_item("bad-1")],
+        "links": [{"rel": "next", "href": f"{API}/search", "body": {"token": "next:x"}}],
+    }
+    page2 = {"features": [make_item("bad-2")], "links": []}
+    session.post.side_effect = [response(page1), response(page2)]
+    ids = mod.discover_corrupted_ids(session, API, "c", "2026-07-21T11:15:00Z")
+    assert ids == ["bad-1", "bad-2"]
+    assert session.post.call_count == 2
+
+
+# ---------- session auth ----------
+
+
+def test_session_wires_bearer_auth_hook():
+    session = mod.make_session()
+    assert session.auth is mod.stac_auth.bearer_auth

--- a/tests/unit/test_repair_stac_raster_links.py
+++ b/tests/unit/test_repair_stac_raster_links.py
@@ -280,3 +280,9 @@ def test_discovery_follows_next_pagination():
 def test_session_wires_bearer_auth_hook():
     session = mod.make_session()
     assert session.auth is mod.stac_auth.bearer_auth
+
+
+def test_parse_ids_file_plain_and_jsonl(tmp_path):
+    f = tmp_path / "ids.jsonl"
+    f.write_text('{"id": "a", "updated": "x"}\n\nplain-id-b\n{"id": "c"}\n')
+    assert mod.parse_ids_file(f) == ["a", "plain-id-b", "c"]


### PR DESCRIPTION
Adds the bounded operator tool that repaired the 2,965 items whose links were persisted with the proxy-corrupted `/stac/raster` prefix (closes #371; incident: EOPF-Explorer/platform-deploy#343). Pure prefix transform on `links[].href` only — idempotent, no-op on clean items; dry-run default, `--max-items` = hard write bound enforced in code, fsync'd pre-write backups with `--restore` + staleness guard, 404 = skip (never POST), per-item re-GET verify, failure aborts. `--ids-file` feeds a scan manifest directly — needed because a second cohort (1,823 items) was corrupted via a timestamp-preserving PUT path and was invisible to any `updated`-filter discovery.

For reviewers: already executed in production 2026-07-22 after a staged rollout (staging corrupt→repair→restore drill, 1-item canary, bounded batches) — 2,965/2,965 repaired, 0 failures, and a closing catalog-wide scan of 213,201 items across all 6 collections found zero remaining corruption. PUT preserves `created`/`updated` verbatim (verified in the drill), so the repair had no timestamp side effects.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted: tool + tests authored with Claude from an adversarially-reviewed recovery plan; 17 unit tests + full suite green; production run supervised gate-by-gate.
