### PR TITLE
build(docker): base the pipeline image on Chainguard Wolfi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,11 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
+    - name: Smoke-test the image runtime contract
+      env:
+        IMAGE_REF: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+      run: ./docker/smoke-test.sh "$IMAGE_REF"
+
     - name: Scan image with Trivy (SARIF CRITICAL/HIGH, incl. unfixed)
       id: trivy-sarif-critical-high
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,10 @@ repos:
     rev: v2.12.0
     hooks:
       - id: hadolint-docker
-        args: ["--ignore", "DL3008", "--ignore", "DL3018"]  # Allow unpinned apt/apk (GDAL version tied to OS release)
+        # Allow unpinned apt/apk. Wolfi rolls forward and garbage-collects old package versions, so
+        # pinning `=<version>` breaks builds; the version-scoped package *names* (python-3.14,
+        # geos-3.14) are the guardrail instead, and the base image itself is digest-pinned.
+        args: ["--ignore", "DL3008", "--ignore", "DL3018"]
 
   - repo: local
     hooks:

--- a/README.md
+++ b/README.md
@@ -92,10 +92,25 @@ docker build -f docker/Dockerfile --network host -t w9mllyot.c1.de1.container-re
 
 
 
+- Check the image still satisfies the runtime contract Argo depends on (Python entrypoints, `sh` and
+  `bash` script steps, uid 1000, working GDAL/PROJ). CI runs this on every build:
+```bash
+./docker/smoke-test.sh w9mllyot.c1.de1.container-registry.ovh.net/eopf-sentinel-zarr-explorer/data-pipeline:v1-staging
+```
+
 - Push to container registry:
 ```bash
 docker push w9mllyot.c1.de1.container-registry.ovh.net/eopf-sentinel-zarr-explorer/data-pipeline:v1-staging
 ```
+
+#### Base image
+
+The image is built on [Chainguard's Wolfi](https://github.com/wolfi-dev/os) (`cgr.dev/chainguard/wolfi-base`,
+digest-pinned — `:latest` is the only free tag, so the digest is what makes builds reproducible, and
+Dependabot bumps it). `rasterio` and `pyproj` are compiled against Wolfi's own GDAL and PROJ instead
+of installed as manylinux wheels: a GDAL/PROJ CVE is then fixed by bumping the base image, and both
+libraries stay visible to Trivy and to generated SBOMs rather than being vendored inside a wheel.
+Local development still uses wheels — the source build is a Dockerfile-only flag.
 
 - Once the new image is pushed, run the example [Notebook](operator-tools/submit_stac_items_notebook.ipynb) and verify that workflows are running in [Argo Workflows](https://argo-workflows.hub-eopf-explorer.eox.at/workflows/devseed-staging)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,32 @@
 # Build for linux/amd64: docker buildx build --platform linux/amd64 -t <tag> . --push
+#
+# Base is Chainguard's Wolfi (glibc), not python:alpine (musl). Wolfi's apk repo is public and free
+# (https://packages.wolfi.dev/os, definitions in github.com/wolfi-dev/os), so we get continuously
+# rebuilt OS packages without a subscription. rasterio and pyproj are built from source against
+# Wolfi's GDAL/PROJ rather than installed as manylinux wheels, so a GDAL or PROJ CVE is fixed by
+# bumping the base instead of waiting for a rasterio release to re-vendor its bundled copy — and both
+# libraries stay visible to Trivy and to any SBOM we generate (EU CRA).
+#
+# `:latest` is the only free Chainguard tag, so the digest pin below IS the reproducibility
+# mechanism; Dependabot bumps it (docker ecosystem, /docker).
+#
+# docker/smoke-test.sh asserts the runtime contract this image owes Argo — run it after any change.
 
 # --- Builder stage: installs build tools and Python dependencies ---
-FROM python:3.14.6-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92 AS builder
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:003627df3c1e1bba0c4116afcddb314aca9594ee2328c7e876a8081a6c988b2e AS builder
 
+# git: eopf-geozarr is a git dependency.
+# proj-util: ships `projinfo`, which pyproj's sdist build requires — proj-dev alone is not enough.
 RUN apk add --no-cache \
+    python-3.14 \
+    python-3.14-dev \
+    py3.14-pip \
     git \
-    curl \
-    ca-certificates \
+    ca-certificates-bundle \
     build-base \
     gdal-dev \
-    crc32c-dev
+    proj-dev \
+    proj-util
 
 WORKDIR /app
 
@@ -19,25 +36,40 @@ RUN pip install --no-cache-dir -r /app/requirements-build.txt
 
 # Copy lockfile before source so this layer is cached independently of code changes
 COPY pyproject.toml uv.lock README.md /app/
-RUN uv sync --frozen --no-dev --no-editable
+# --no-binary-package is a build-time flag rather than a [tool.uv] setting on purpose: local
+# development on macOS has no system GDAL and must keep using wheels.
+RUN uv sync --frozen --no-dev --no-editable --python /usr/bin/python3.14 \
+    --no-binary-package rasterio \
+    --no-binary-package pyproj
 
 # --- Runtime stage: minimal production image without build tools ---
-FROM python:3.14.6-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:003627df3c1e1bba0c4116afcddb314aca9594ee2328c7e876a8081a6c988b2e
 
+# bash: Argo cron and job steps invoke `command: [bash, -c]`; wolfi-base already provides sh.
+# gdal/proj: the shared libraries rasterio and pyproj were linked against (no -dev headers here).
+# geos-3.14 is pinned deliberately. Wolfi's `gdal` declares only the soname `so:libgeos_c.so.1`,
+# which geos-3.12, geos-3.13 and geos-3.14 all provide, and apk resolves it to geos-3.12 — whose ABI
+# lacks GEOSGridIntersectionFractions_r. Without this pin the image builds green, scans clean, then
+# fails at runtime on `import rasterio`. Keep it until wolfi-dev/os tightens that dependency.
 RUN apk add --no-cache \
+    python-3.14 \
     bash \
-    ca-certificates \
+    ca-certificates-bundle \
     gdal \
-    gdal-dev \
-    gdal-tools \
-    crc32c
+    proj \
+    geos-3.14
 
 # Copy the virtualenv created by uv sync; activate it via PATH
 COPY --from=builder /app/.venv /app/.venv
 ENV VIRTUAL_ENV=/app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
-RUN adduser -D -h /home/appuser -s /bin/sh appuser
+# A source-built pyproj looks for proj.db under its own package directory, not the system share dir.
+ENV PROJ_DATA=/usr/share/proj
+
+# uid 1000 is explicit: no platform-deploy template sets securityContext.runAsUser, so this uid is
+# what every mounted volume sees.
+RUN adduser -D -u 1000 -h /home/appuser -s /bin/sh appuser
 
 WORKDIR /app
 

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -35,6 +35,23 @@ print("py", __import__("sys").version.split()[0], "| GDAL", rasterio.__gdal_vers
       "| PROJ", pyproj.proj_version_str, "| zarr", zarr.__version__,
       "| crc32c", google_crc32c.implementation)'
 
+# 1b. Exercise GDAL and PROJ for real: an import succeeds even when PROJ's proj.db or a GDAL driver
+#     is missing, which is exactly how a source-built rasterio/pyproj goes wrong.
+check "gdal+proj actually work" 0 python -c '
+import numpy, rasterio, pyproj
+from rasterio.io import MemoryFile
+from rasterio.transform import from_bounds
+t = pyproj.Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True)
+x, y = t.transform(2.35, 48.85)
+assert 260000 < x < 263000 and 6249000 < y < 6252000, (x, y)
+with MemoryFile() as m:
+    with m.open(driver="GTiff", width=8, height=8, count=1, dtype="uint16",
+                crs="EPSG:3857", transform=from_bounds(0, 0, 8, 8, 8, 8)) as dst:
+        dst.write(numpy.arange(64, dtype="uint16").reshape(1, 8, 8))
+    with m.open() as src:
+        assert src.crs.to_epsg() == 3857 and int(src.read(1).max()) == 63
+print("proj transform + GTiff roundtrip ok")'
+
 # 2. GDAL Python bindings are deliberately absent: nothing in the closure imports osgeo, and no
 #    script shells out to a gdal CLI. This check fails loudly if that assumption ever changes.
 check "osgeo absent (expected failure)" 1 python -c 'import osgeo'

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Runtime contract for the pipeline image.
+#
+# Argo (EOPF-Explorer/platform-deploy) invokes this image three ways — `command: [python, ...]`,
+# `command: [sh]` script templates, and `command: [bash, -c]` cron steps — and no template sets
+# securityContext.runAsUser, so the image's own USER decides the runtime uid. Each check below is
+# one of those assumptions; `--entrypoint` mirrors how Argo overrides the entrypoint.
+#
+# Usage: docker/smoke-test.sh <image>
+set -uo pipefail
+
+IMAGE="${1:?usage: docker/smoke-test.sh <image>}"
+FAILED=0
+
+check() { # check <name> <expected-exit> <entrypoint> <args...>
+    local name="$1" want="$2" entry="$3"
+    shift 3
+    local out rc
+    out="$(docker run --rm --entrypoint "$entry" "$IMAGE" "$@" 2>&1)"
+    rc=$?
+    if [ "$rc" -eq "$want" ]; then
+        printf 'PASS  %-38s %s\n' "$name" "$(printf '%s' "$out" | tr '\n' ' ' | cut -c1-90)"
+    else
+        FAILED=$((FAILED + 1))
+        printf 'FAIL  %-38s (exit %s, wanted %s)\n%s\n' "$name" "$rc" "$want" "$out"
+    fi
+}
+
+echo "== smoke test: $IMAGE =="
+
+# 1. The full runtime import closure must load — this is what `command: [python, ...]` steps need.
+check "python imports runtime closure" 0 python -c '
+import rasterio, pyproj, zarr, numcodecs, google_crc32c, eopf_geozarr, s3fs, pystac_client, xarray
+print("py", __import__("sys").version.split()[0], "| GDAL", rasterio.__gdal_version__,
+      "| PROJ", pyproj.proj_version_str, "| zarr", zarr.__version__,
+      "| crc32c", google_crc32c.implementation)'
+
+# 2. GDAL Python bindings are deliberately absent: nothing in the closure imports osgeo, and no
+#    script shells out to a gdal CLI. This check fails loudly if that assumption ever changes.
+check "osgeo absent (expected failure)" 1 python -c 'import osgeo'
+
+# 3. Both shells, because prod uses both.
+check "bash present" 0 bash -c 'echo bash ok'
+check "sh present" 0 sh -c 'echo sh ok'
+
+# 4. Non-root at uid 1000 — changing this changes ownership expectations on every mounted volume.
+check "runs as appuser uid 1000" 0 sh -c \
+    'set -e; [ "$(id -u)" = 1000 ] || { echo "uid=$(id -u)"; exit 9; }; id -un'
+
+# 5. Writable paths the scripts rely on (query_stac.py writes /tmp/items.json).
+check "/tmp and \$HOME writable" 0 sh -c \
+    'set -e; touch /tmp/.smoke; touch "${HOME:-/home/appuser}/.smoke"; echo "HOME=${HOME:-unset}"'
+
+# 6. `python` must resolve to the venv interpreter via PATH, not the system one.
+check "python resolves to venv" 0 sh -c \
+    'set -e; p="$(command -v python)"; [ "$p" = /app/.venv/bin/python ] || { echo "got $p"; exit 9; }; echo "$p"'
+
+# 7. Entrypoints Argo actually calls.
+for s in convert_v1_s2.py register_v1.py query_stac.py change_storage_tier.py cleanup_expired_items.py; do
+    check "scripts/$s --help" 0 python "/app/scripts/$s" --help
+done
+
+# 8. Test helpers must not ship in the runtime image.
+check "no test_*.py under /app/scripts" 0 sh -c \
+    'n="$(find /app/scripts -name "test_*.py" | wc -l)"; [ "$n" -eq 0 ] || { find /app/scripts -name "test_*.py"; exit 9; }; echo "none"'
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+    echo "SMOKE TEST PASSED: $IMAGE"
+else
+    echo "SMOKE TEST FAILED: $FAILED check(s) — $IMAGE"
+fi
+exit $((FAILED > 0))


### PR DESCRIPTION
Moves `docker/Dockerfile` from `python:3.14.6-alpine` to a digest-pinned `cgr.dev/chainguard/wolfi-base`, compiling `rasterio` and `pyproj` against Wolfi's GDAL 3.13.2 / PROJ 9.8.1 instead of taking manylinux wheels, so both libraries stay `apk`-patchable and visible to Trivy and SBOMs rather than vendored inside a wheel. Runtime OS packages drop 117 → 99, PROJ moves 9.5.1 → 9.8.1, Trivy still reports no fixable CRITICAL/HIGH, and a new `docker/smoke-test.sh` (14 checks: `python` entrypoints, `sh` and `bash` script steps, uid 1000, a real 4326→3857 transform plus GTiff roundtrip) now runs in CI. Groundwork for the CRA vulnerability-reporting duties tracked in https://github.com/developmentseed/ds-devops/issues/116

**For reviewers:** the `geos-3.14` pin cannot be dropped. Wolfi's `gdal` declares only the soname `so:libgeos_c.so.1`, which `geos-3.12`/`3.13`/`3.14` all provide, and apk resolves it to `geos-3.12` — whose ABI lacks `GEOSGridIntersectionFractions_r`, so the image builds green, scans clean, and fails at runtime on `import rasterio`. Not yet exercised on a real workload: staging validation (convert + register, the `sh`/`bash` cron steps, memory behaviour under glibc) comes before any prod pin bump.

## Author attestation

- [ ] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI-assisted: Claude Code measured the alpine/Wolfi variants, wrote the Dockerfile and the smoke test, and found the GEOS ABI trap; I reviewed the diff and the measurements.
